### PR TITLE
feat(mcp): add MCP server for LLM agents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Binaries
 /loveliness
+/loveliness-mcp
 /benchmark
 /generate
 /bin/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -17,6 +17,22 @@ builds:
     ldflags:
       - -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}}
 
+  # MCP server — pure-Go, no CGO; ships for linux + darwin on both archs
+  # so Claude Desktop / Claude Code / Zed can install it locally.
+  - id: loveliness-mcp
+    main: ./cmd/loveliness-mcp
+    binary: loveliness-mcp
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}}
+
 archives:
   - id: default
     format: tar.gz

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,18 @@
-.PHONY: build test run clean docker
+.PHONY: build test run clean docker mcp
 
 BINARY := loveliness
+MCP_BINARY := loveliness-mcp
 PKG := ./cmd/loveliness
+MCP_PKG := ./cmd/loveliness-mcp
 
 build:
 	CGO_ENABLED=1 go build -o $(BINARY) $(PKG)
+	CGO_ENABLED=0 go build -o $(MCP_BINARY) $(MCP_PKG)
+
+# mcp builds just the MCP server binary. Useful for quick iteration
+# when working on pkg/mcp without touching the main server.
+mcp:
+	CGO_ENABLED=0 go build -o $(MCP_BINARY) $(MCP_PKG)
 
 test:
 	go test ./pkg/... -v -count=1
@@ -16,7 +24,7 @@ race:
 	go test ./pkg/... -v -race -count=1
 
 clean:
-	rm -f $(BINARY)
+	rm -f $(BINARY) $(MCP_BINARY)
 	rm -rf data/
 
 run: build

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test run clean docker mcp
+.PHONY: build test run clean docker mcp install-mcp
 
 BINARY := loveliness
 MCP_BINARY := loveliness-mcp
@@ -13,6 +13,12 @@ build:
 # when working on pkg/mcp without touching the main server.
 mcp:
 	CGO_ENABLED=0 go build -o $(MCP_BINARY) $(MCP_PKG)
+
+# install-mcp builds loveliness-mcp into $GOBIN, registers it with the
+# `claude` CLI if present, and links the SKILL into ~/.claude/skills/.
+# Pass FLAGS=... to forward args to the installer (e.g. --no-skill).
+install-mcp:
+	./scripts/install-mcp.sh $(FLAGS)
 
 test:
 	go test ./pkg/... -v -count=1

--- a/README.md
+++ b/README.md
@@ -201,9 +201,18 @@ client (Claude Code, Claude Desktop, Cursor, Zed) can query and write
 through typed, schema-aware tools.
 
 ```bash
-# install the MCP server for Claude Code
+# one-shot: build the binary, register it with Claude, install the skill
+make install-mcp
+
+# or, manually:
 claude mcp add loveliness -e LOVELINESS_URL=http://localhost:8080 -- loveliness-mcp
 ```
+
+`make install-mcp` runs `scripts/install-mcp.sh`, which builds
+`loveliness-mcp`, runs `claude mcp add` (or prints the manual JSON if
+`claude` isn't on PATH), and links the bundled skill at
+`skills/loveliness/SKILL.md` into `~/.claude/skills/loveliness/` so
+agents get prose guidance on how to use the tools.
 
 Full install snippets for Claude Desktop / Zed, tool reference, readonly
 and auth patterns: [docs/mcp.md](docs/mcp.md).

--- a/README.md
+++ b/README.md
@@ -194,6 +194,20 @@ docker run -p 8080:8080 -p 7687:7687 dreamwarenz/loveliness
 docker compose up
 ```
 
+## MCP (LLM agents)
+
+Loveliness ships a Model Context Protocol server so any MCP-aware LLM
+client (Claude Code, Claude Desktop, Cursor, Zed) can query and write
+through typed, schema-aware tools.
+
+```bash
+# install the MCP server for Claude Code
+claude mcp add loveliness -e LOVELINESS_URL=http://localhost:8080 -- loveliness-mcp
+```
+
+Full install snippets for Claude Desktop / Zed, tool reference, readonly
+and auth patterns: [docs/mcp.md](docs/mcp.md).
+
 ## Kubernetes
 
 ```bash

--- a/cmd/loveliness-mcp/main.go
+++ b/cmd/loveliness-mcp/main.go
@@ -1,0 +1,85 @@
+// Command loveliness-mcp runs a Model Context Protocol server that
+// exposes a Loveliness cluster to LLM agents over stdio.
+//
+// It is equivalent to `loveliness mcp` — the main CLI has a subcommand
+// that calls the same pkg/mcp.Server.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"os/signal"
+	"strconv"
+	"syscall"
+	"time"
+
+	"github.com/johnjansen/loveliness/pkg/mcp"
+)
+
+func main() {
+	os.Exit(run(os.Args[1:]))
+}
+
+func run(args []string) int {
+	fs := flag.NewFlagSet("loveliness-mcp", flag.ContinueOnError)
+
+	url := fs.String("url", envOr("LOVELINESS_URL", "http://localhost:8080"),
+		"Loveliness HTTP endpoint (env: LOVELINESS_URL)")
+	token := fs.String("token", os.Getenv("LOVELINESS_TOKEN"),
+		"Bearer token for authenticated clusters (env: LOVELINESS_TOKEN)")
+	timeout := fs.Duration("timeout", envDuration("LOVELINESS_TIMEOUT", 30*time.Second),
+		"Per-request HTTP timeout (env: LOVELINESS_TIMEOUT)")
+	readonly := fs.Bool("readonly", envBool("LOVELINESS_READONLY", false),
+		"Register read-only tools only (env: LOVELINESS_READONLY)")
+
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	srv := mcp.New(mcp.Options{
+		URL:      *url,
+		Token:    *token,
+		Timeout:  *timeout,
+		Readonly: *readonly,
+	})
+
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer cancel()
+
+	if err := srv.Run(ctx); err != nil {
+		fmt.Fprintf(os.Stderr, "loveliness-mcp: %v\n", err)
+		return 1
+	}
+	return 0
+}
+
+func envOr(k, def string) string {
+	if v := os.Getenv(k); v != "" {
+		return v
+	}
+	return def
+}
+
+func envDuration(k string, def time.Duration) time.Duration {
+	v := os.Getenv(k)
+	if v == "" {
+		return def
+	}
+	if d, err := time.ParseDuration(v); err == nil {
+		return d
+	}
+	return def
+}
+
+func envBool(k string, def bool) bool {
+	v := os.Getenv(k)
+	if v == "" {
+		return def
+	}
+	if b, err := strconv.ParseBool(v); err == nil {
+		return b
+	}
+	return def
+}

--- a/cmd/loveliness/main.go
+++ b/cmd/loveliness/main.go
@@ -42,6 +42,9 @@ func main() {
 		case "query":
 			runQuery(os.Args[2:])
 			return
+		case "mcp":
+			runMCP(os.Args[2:])
+			return
 		case "help", "--help", "-h":
 			printUsage()
 			return

--- a/cmd/loveliness/mcp.go
+++ b/cmd/loveliness/mcp.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"os/signal"
+	"strconv"
+	"syscall"
+	"time"
+
+	"github.com/johnjansen/loveliness/pkg/mcp"
+)
+
+// runMCP is the entrypoint for `loveliness mcp`. It mirrors the
+// standalone loveliness-mcp binary.
+func runMCP(args []string) {
+	fs := flag.NewFlagSet("mcp", flag.ExitOnError)
+	url := fs.String("url", envOr("LOVELINESS_URL", "http://localhost:8080"),
+		"Loveliness HTTP endpoint (env: LOVELINESS_URL)")
+	token := fs.String("token", os.Getenv("LOVELINESS_TOKEN"),
+		"Bearer token (env: LOVELINESS_TOKEN)")
+	timeout := fs.Duration("timeout", envDuration("LOVELINESS_TIMEOUT", 30*time.Second),
+		"Per-request HTTP timeout (env: LOVELINESS_TIMEOUT)")
+	readonly := fs.Bool("readonly", envBool("LOVELINESS_READONLY", false),
+		"Register read-only tools only (env: LOVELINESS_READONLY)")
+	if err := fs.Parse(args); err != nil {
+		os.Exit(2)
+	}
+
+	srv := mcp.New(mcp.Options{
+		URL:      *url,
+		Token:    *token,
+		Timeout:  *timeout,
+		Readonly: *readonly,
+	})
+
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer cancel()
+
+	if err := srv.Run(ctx); err != nil {
+		fmt.Fprintf(os.Stderr, "loveliness mcp: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func envOr(k, def string) string {
+	if v := os.Getenv(k); v != "" {
+		return v
+	}
+	return def
+}
+
+func envDuration(k string, def time.Duration) time.Duration {
+	v := os.Getenv(k)
+	if v == "" {
+		return def
+	}
+	if d, err := time.ParseDuration(v); err == nil {
+		return d
+	}
+	return def
+}
+
+func envBool(k string, def bool) bool {
+	v := os.Getenv(k)
+	if v == "" {
+		return def
+	}
+	if b, err := strconv.ParseBool(v); err == nil {
+		return b
+	}
+	return def
+}

--- a/cmd/loveliness/query.go
+++ b/cmd/loveliness/query.go
@@ -16,6 +16,7 @@ Commands:
   serve          Start the server (default if no command given)
   up <N>         Start N local nodes for development
   query <cypher> Run a Cypher query against a running server
+  mcp            Run the MCP server for LLM agents (stdio)
   help           Show this help
   version        Show version
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -2,6 +2,9 @@
 
 All endpoints are on the HTTP port (default `:8080`).
 
+> For LLM agents, prefer the [MCP server](mcp.md) — it wraps these
+> endpoints in a typed, schema-aware tool surface.
+
 ## Query Endpoint
 
 `POST /cypher` — send raw Cypher as the request body, get JSON results back.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -11,7 +11,27 @@ running cluster via HTTP, and exposes a small opinionated tool surface.
 
 ## Install
 
-Two equivalent ways to run it:
+### One-shot installer
+
+```bash
+make install-mcp
+```
+
+This runs `scripts/install-mcp.sh`, which:
+
+1. Builds `loveliness-mcp` into `$GOBIN` (or `$(go env GOPATH)/bin`).
+2. Registers it with `claude mcp add` if the `claude` CLI is on PATH;
+   otherwise prints the manual `~/.claude.json` snippet.
+3. Symlinks the bundled skill at `skills/loveliness/SKILL.md` into
+   `~/.claude/skills/loveliness/` so Claude Code gets prose guidance
+   on how to use the tools.
+
+Honors `LOVELINESS_URL` and `LOVELINESS_TOKEN` from the environment.
+Pass `FLAGS=--no-skill` or `FLAGS=--no-register` to skip steps.
+
+### Manual install
+
+Two equivalent ways to run the server:
 
 ```bash
 # standalone binary (shipped in releases alongside `loveliness`)

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,0 +1,177 @@
+# MCP (Model Context Protocol) server
+
+Loveliness ships a first-class MCP server so LLM agents (Claude Code,
+Claude Desktop, Cursor, Zed, custom harnesses) can drive the database
+through typed, schema-aware tools instead of string-building raw Cypher.
+
+The [Model Context Protocol](https://modelcontextprotocol.io) is the
+emerging standard for exposing tools to LLM clients over stdio or HTTP.
+The Loveliness MCP server speaks JSON-RPC over stdio, connects to a
+running cluster via HTTP, and exposes a small opinionated tool surface.
+
+## Install
+
+Two equivalent ways to run it:
+
+```bash
+# standalone binary (shipped in releases alongside `loveliness`)
+loveliness-mcp --url http://localhost:8080
+
+# same thing, from the main CLI
+loveliness mcp --url http://localhost:8080
+```
+
+### Claude Code
+
+```bash
+claude mcp add loveliness -- loveliness-mcp
+# or with config:
+claude mcp add loveliness -e LOVELINESS_URL=http://localhost:8080 -- loveliness-mcp
+```
+
+### Claude Desktop
+
+Edit `~/Library/Application Support/Claude/claude_desktop_config.json`:
+
+```jsonc
+{
+  "mcpServers": {
+    "loveliness": {
+      "command": "loveliness-mcp",
+      "env": { "LOVELINESS_URL": "http://localhost:8080" }
+    }
+  }
+}
+```
+
+### Zed
+
+Edit `~/.config/zed/settings.json`:
+
+```jsonc
+{
+  "context_servers": {
+    "loveliness": {
+      "command": "loveliness-mcp",
+      "env": { "LOVELINESS_URL": "http://localhost:8080" }
+    }
+  }
+}
+```
+
+## Configuration
+
+Flag precedence is `flag > env > default`.
+
+| Variable | Flag | Default | Purpose |
+|----------|------|---------|---------|
+| `LOVELINESS_URL` | `--url` | `http://localhost:8080` | HTTP endpoint of a Loveliness node. |
+| `LOVELINESS_TOKEN` | `--token` | *(none)* | Bearer token forwarded as `Authorization: Bearer <token>`. |
+| `LOVELINESS_TIMEOUT` | `--timeout` | `30s` | Per-request HTTP timeout. |
+| `LOVELINESS_READONLY` | `--readonly` | `false` | When true, register read-only tools only. |
+
+## Tools
+
+All tools share the same error envelope: on failure the tool result is
+returned with `isError=true` and a text message like `error -32602: …`.
+Numeric codes follow the JSON-RPC convention:
+
+- `-32602` — invalid params (Cypher parse error, missing shard key, …)
+- `-32000` — server error (shard unavailable, schema propagation, …)
+- `-32001` — timeout
+
+### `cypher_read`
+
+Run a read-only Cypher query. Statically rejects any statement whose
+first non-comment keyword is `CREATE`, `MERGE`, `SET`, `DELETE`, `DROP`,
+`REMOVE`, `LOAD`, `COPY`, `ALTER`, or `DETACH`.
+
+```jsonc
+{
+  "query":  "MATCH (p:Person {name: $name}) RETURN p.age",
+  "params": { "name": "Alice" }
+}
+```
+
+Returns `{columns, rows, stats}`.
+
+### `cypher_write`
+
+Same input shape as `cypher_read`, no keyword gate. Registered only
+when `--readonly=false`. Clients that want per-tool gating (Claude
+Code's `/permissions`) can opt-in this tool specifically.
+
+### `schema`
+
+Return node and edge tables with property names and types. Cached for
+30 seconds in-process to avoid hammering the cluster on every turn.
+
+```jsonc
+{
+  "node_tables": [
+    { "name": "Person", "primary_key": "name",
+      "properties": [{"name":"name","type":"STRING","primary_key":true},
+                     {"name":"age","type":"INT64"}] }
+  ],
+  "edge_tables": [
+    { "name": "KNOWS", "from": "Person", "to": "Person", "properties": [] }
+  ]
+}
+```
+
+### `bulk_nodes` / `bulk_edges`
+
+Synchronous bulk load — wrap `POST /bulk/nodes` and `POST /bulk/edges`.
+Provide either inline `csv_data` or a `csv_path` on the MCP server host.
+
+`bulk_nodes`: `{table, csv_data | csv_path}`
+`bulk_edges`: `{rel_table, from_table, to_table, csv_data | csv_path, skip_refs?}`
+
+Returns `{table, loaded, errors?}`.
+
+### `ingest_nodes` / `ingest_edges`
+
+Async equivalents — return a `job_id` immediately. Poll with
+`ingest_status`.
+
+### `ingest_status`
+
+Input: `{job_id}`. Returns the raw job record (status, loaded count,
+errors).
+
+### `cluster_status`
+
+Return leader, peer list, per-shard assignment, and registered schema
+from `GET /cluster`. Always registered.
+
+## Resources
+
+Two read-only resources, same payload as the equivalent tools:
+
+- `loveliness://schema`
+- `loveliness://cluster`
+
+## Readonly pattern
+
+Run with `--readonly` (or `LOVELINESS_READONLY=true`) to only register
+`cypher_read`, `schema`, and `cluster_status`. Use this for CI
+analysis agents, or when the agent should be allowed to explore the
+graph but not mutate it.
+
+```bash
+loveliness-mcp --readonly --url https://prod-cluster.internal
+```
+
+## Auth
+
+When the cluster has `LOVELINESS_AUTH_TOKEN` set, pass the same token
+to the MCP server via `--token` or `LOVELINESS_TOKEN`. It is forwarded
+as a Bearer token on every HTTP request.
+
+```bash
+LOVELINESS_TOKEN=secret loveliness-mcp --url https://cluster.internal
+```
+
+## Underlying HTTP surface
+
+See [api.md](api.md) for the HTTP endpoints this MCP server wraps.

--- a/docs/superpowers/specs/2026-04-30-mcp-server-design.md
+++ b/docs/superpowers/specs/2026-04-30-mcp-server-design.md
@@ -1,0 +1,194 @@
+# MCP Server Design
+
+**Date**: 2026-04-30
+**Status**: Draft
+**Scope**: new `cmd/loveliness-mcp/` binary and new `pkg/mcp/` package
+
+## Problem
+
+There's no first-class way for LLM agents (Claude Code, Claude Desktop, Cursor, Zed, custom harnesses) to talk to a Loveliness cluster. Today an agent has to shell out to `loveliness query ...` or curl `/cypher` — both work, but the agent has no schema introspection, no typed tool surface, no separation of read vs write, and no async ingest affordance. That pushes Cypher string-building and error handling into every prompt.
+
+The Model Context Protocol (MCP) is the emerging standard for exposing tools to LLM clients over stdio or HTTP. Giving Loveliness a native MCP server lets any MCP-aware client drive the database with schema-aware, permission-gated tools and zero glue code on the caller side.
+
+## Goal
+
+`loveliness mcp` (and a standalone `loveliness-mcp` binary) starts an MCP server that speaks JSON-RPC over stdio, connects to a running Loveliness cluster via HTTP, and exposes a small, opinionated set of tools that cover the 80% use case: querying the graph, writing to it, introspecting schema, bulk/async ingest, and checking cluster health.
+
+Concretely, after this lands:
+
+```jsonc
+// ~/.claude.json (user scope)
+{
+  "mcpServers": {
+    "loveliness": {
+      "command": "loveliness-mcp",
+      "env": { "LOVELINESS_URL": "http://localhost:8080" }
+    }
+  }
+}
+```
+
+…gives Claude Code six tools (`cypher_read`, `cypher_write`, `schema`, `bulk_nodes`, `ingest_nodes`, `cluster_status`) and one readable resource (`loveliness://schema`).
+
+## Design
+
+### New binary
+
+| Path | Role |
+|------|------|
+| `cmd/loveliness-mcp/main.go` | Thin entrypoint. Parses flags + env, constructs `pkg/mcp.Server`, runs it on stdio until EOF. |
+| `cmd/loveliness/main.go` | Existing CLI gets a new `mcp` subcommand that calls into the same `pkg/mcp.Server` — so `loveliness mcp` and `loveliness-mcp` are equivalent. |
+
+Both ship from the existing `.goreleaser.yml` build matrix.
+
+### New package: `pkg/mcp/`
+
+```
+pkg/mcp/
+  server.go            — MCP server setup, tool + resource registration, stdio loop
+  client.go            — HTTP client adapter over /cypher, /bulk/*, /ingest/*, /status
+  tools_cypher.go      — cypher_read, cypher_write
+  tools_schema.go      — schema (CALL SHOW_TABLES + property types)
+  tools_bulk.go        — bulk_nodes, bulk_edges (synchronous)
+  tools_ingest.go      — ingest_nodes, ingest_edges (async, returns job ID)
+  tools_cluster.go     — cluster_status
+  resources.go         — loveliness://schema, loveliness://cluster
+  errors.go            — map Loveliness HTTP errors → MCP error payloads
+  *_test.go            — table-driven tests against a fake HTTP backend (httptest.Server)
+```
+
+SDK: `github.com/modelcontextprotocol/go-sdk` (official Go MCP SDK). Adds one top-level dep to `go.mod`.
+
+### Transport
+
+**stdio only in v1.** This is what Claude Code, Claude Desktop, Cursor, and Zed all use. HTTP/SSE transport is a v2 concern (deploying MCP servers behind a load balancer), not needed for local use.
+
+### Configuration
+
+Env vars (precedence: flag > env > default):
+
+| Variable | Flag | Default | Purpose |
+|----------|------|---------|---------|
+| `LOVELINESS_URL` | `--url` | `http://localhost:8080` | HTTP endpoint of a Loveliness node. |
+| `LOVELINESS_TOKEN` | `--token` | *(none)* | Bearer token, forwarded as `Authorization: Bearer <token>`. Wired through `pkg/auth` if auth is enabled on the cluster. |
+| `LOVELINESS_TIMEOUT` | `--timeout` | `30s` | Per-request HTTP timeout. Cypher queries that exceed this return an MCP timeout error. |
+| `LOVELINESS_READONLY` | `--readonly` | `false` | When true, `cypher_write`, `bulk_*`, and `ingest_*` tools are not registered. Useful for read-only agents. |
+
+No config file in v1 — the server is meant to be ephemeral (client launches it per session).
+
+### Tools
+
+Each tool's name, input schema, and behavior. Schemas are JSON Schema as the SDK expects.
+
+#### `cypher_read`
+
+Run a read-only Cypher query. Statically rejects any statement whose first non-comment keyword is `CREATE`, `MERGE`, `SET`, `DELETE`, `DROP`, `REMOVE`, or `LOAD`. Parameters are bound via the JSON-RPC request, never string-interpolated.
+
+```jsonc
+{
+  "name": "cypher_read",
+  "input": {
+    "query":  "MATCH (p:Person {name: $name}) RETURN p.age",
+    "params": { "name": "Alice" }
+  },
+  "output": {
+    "columns": ["p.age"],
+    "rows":    [[30]],
+    "stats":   { "rows_returned": 1, "ms": 2 }
+  }
+}
+```
+
+#### `cypher_write`
+
+Mirror of `cypher_read` without the statement gate. Registered only when `LOVELINESS_READONLY=false`. Clients that want permission gating (Claude Code's `/permissions`) can opt-in per-tool.
+
+#### `schema`
+
+Returns the node and edge table catalog with property names and types. Internally runs `CALL SHOW_TABLES()` and per-table `CALL TABLE_INFO(name)`, fans out, and structures the result:
+
+```jsonc
+{
+  "node_tables": [
+    { "name": "Person", "primary_key": "name",
+      "properties": [{"name":"name","type":"STRING"},{"name":"age","type":"INT64"}] }
+  ],
+  "edge_tables": [
+    { "name": "KNOWS", "from": "Person", "to": "Person", "properties": [] }
+  ]
+}
+```
+
+Cached in-process for 30s with a sync.Mutex — schema is called on almost every agent turn for context, and hammering the cluster for unchanged data is wasteful.
+
+#### `bulk_nodes` / `bulk_edges`
+
+Wrap `POST /bulk/nodes` and `POST /bulk/edges`. Input is either an inline CSV string (`csv_data`) or a file path (`csv_path`). File path is resolved on the MCP server host, so only files readable by the loveliness-mcp process are accessible. Required header `X-Table` is taken from the tool input `table`.
+
+#### `ingest_nodes` / `ingest_edges`
+
+Same input surface as the bulk tools but hit `POST /ingest/nodes` — returns the 202 job ID as tool output. A separate `ingest_status` tool takes a job ID and returns progress.
+
+#### `cluster_status`
+
+Returns shard count, peer list, leader node, and per-shard health from `GET /status`. Read-only; always registered.
+
+### Resources
+
+MCP resources are read-only, URL-addressed blobs the client can fetch. Two:
+
+- `loveliness://schema` — the same payload as the `schema` tool, for clients that prefer resource polling to tool calls.
+- `loveliness://cluster` — the same as `cluster_status`.
+
+Resources are cheap to add and some clients (e.g. Claude Desktop) surface them in UI.
+
+### Error mapping
+
+Every HTTP error becomes a structured MCP error so the LLM gets actionable feedback:
+
+| Loveliness response | MCP error code | Message |
+|---------------------|----------------|---------|
+| 400 with parser error | `-32602` (invalid params) | Cypher parse error + line/column |
+| 409 `BROADCAST_PARTIAL` | `-32000` (server error) | "Schema propagation in progress, retry" |
+| 503 (shard down) | `-32000` | "Shard N unavailable, check cluster_status" |
+| Timeout | `-32001` | "Query exceeded timeout of Xs" |
+
+### Testing
+
+- **Unit:** `httptest.NewServer` stub returns canned JSON; each tool has a table-driven test covering happy path, validation failures, HTTP error mapping.
+- **Integration:** `test/mcp/e2e_test.go` spins `loveliness up 1` in a subprocess, launches `loveliness-mcp`, drives it with a real MCP Go client, exercises `schema → cypher_write → cypher_read → cluster_status`. Gated behind `-tags=integration` so `make test` stays fast.
+- **Linter:** new package gets added to `.golangci.yml`'s coverage list.
+
+### Documentation
+
+New file `docs/mcp.md`:
+
+1. What MCP is (one paragraph + link to spec).
+2. Install snippet for Claude Code (`claude mcp add loveliness -- loveliness-mcp`), Claude Desktop (`~/Library/Application Support/Claude/claude_desktop_config.json`), and Zed.
+3. Tool reference: name, input schema, example.
+4. Readonly-mode pattern for CI / untrusted agents.
+5. Auth token pattern.
+6. Pointer to `docs/api.md` for the underlying HTTP surface the MCP server wraps.
+
+README gets a new section "MCP (LLM agents)" above the Kubernetes section, with the 4-line install snippet and a link to `docs/mcp.md`.
+
+## Files changed
+
+- `cmd/loveliness-mcp/main.go` — new, ~80 LOC.
+- `cmd/loveliness/main.go` — add `mcp` subcommand, ~15 LOC.
+- `pkg/mcp/*.go` — new package, ~800 LOC incl. tests.
+- `go.mod` / `go.sum` — add `github.com/modelcontextprotocol/go-sdk`.
+- `docs/mcp.md` — new.
+- `docs/api.md` — add a one-line pointer back to the MCP doc.
+- `README.md` — new "MCP (LLM agents)" section.
+- `.goreleaser.yml` — add `loveliness-mcp` binary to the build matrix.
+- `Makefile` — `make mcp` target that builds just the MCP binary for iteration.
+
+## Out of scope
+
+- **HTTP/SSE MCP transport.** v1 is stdio. Adding HTTP transport is a natural follow-up once there's a real deployment story (e.g. "MCP gateway for a shared Loveliness cluster").
+- **Bolt-based transport.** The MCP server talks HTTP to Loveliness. Bolt would be faster but forces a Bolt driver dep and doesn't unlock anything the HTTP path can't do today.
+- **Write-path gating beyond read/write split.** Fine-grained per-table ACLs, row-level filters, query budgeting — belongs in `pkg/auth`, not the MCP layer.
+- **LLM prompt engineering / tool descriptions for specific models.** Tool descriptions are written to be model-agnostic. Claude / GPT-specific tuning happens on the client side.
+- **`cypher_read` → structured graph objects.** v1 returns raw columnar rows from `/cypher`. A future `graph_query` tool could return typed `{nodes, edges, paths}` objects after shape detection, but the underlying API needs shape hints first.
+- **Streaming results.** Large result sets are truncated at 10k rows in v1 with a `truncated: true` flag. MCP does support streaming responses; wire it up once a real use case appears.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/johnjansen/loveliness
 
-go 1.25
+go 1.25.0
 
 require (
 	github.com/LadybugDB/go-ladybug v0.13.1
@@ -10,6 +10,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/raft v1.7.3
 	github.com/hashicorp/raft-boltdb/v2 v2.3.1
+	github.com/modelcontextprotocol/go-sdk v1.5.0
 	github.com/vmihailenco/msgpack/v5 v5.4.1
 )
 
@@ -33,6 +34,7 @@ require (
 	github.com/aws/smithy-go v1.24.2 // indirect
 	github.com/boltdb/bolt v1.3.1 // indirect
 	github.com/fatih/color v1.13.0 // indirect
+	github.com/google/jsonschema-go v0.4.2 // indirect
 	github.com/hashicorp/go-hclog v1.6.2 // indirect
 	github.com/hashicorp/go-immutable-radix v1.0.0 // indirect
 	github.com/hashicorp/go-metrics v0.5.4 // indirect
@@ -40,8 +42,12 @@ require (
 	github.com/hashicorp/golang-lru v0.5.0 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
+	github.com/segmentio/asm v1.1.3 // indirect
+	github.com/segmentio/encoding v0.5.4 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
+	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	go.etcd.io/bbolt v1.3.5 // indirect
-	golang.org/x/sys v0.13.0 // indirect
+	golang.org/x/oauth2 v0.35.0 // indirect
+	golang.org/x/sys v0.41.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -68,6 +68,8 @@ github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
+github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
+github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -83,7 +85,11 @@ github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/jsonschema-go v0.4.2 h1:tmrUohrwoLZZS/P3x7ex0WAVknEkBZM46iALbcqoRA8=
+github.com/google/jsonschema-go v0.4.2/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
@@ -128,6 +134,8 @@ github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Ky
 github.com/mattn/go-isatty v0.0.14 h1:yVuAays6BHfxijgZPzw+3Zlu5yQgKGP2/hcQbHb7S9Y=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
+github.com/modelcontextprotocol/go-sdk v1.5.0 h1:CHU0FIX9kpueNkxuYtfYQn1Z0slhFzBZuq+x6IiblIU=
+github.com/modelcontextprotocol/go-sdk v1.5.0/go.mod h1:gggDIhoemhWs3BGkGwd1umzEXCEMMvAnhTrnbXJKKKA=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
@@ -158,6 +166,10 @@ github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsT
 github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
 github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
+github.com/segmentio/asm v1.1.3 h1:WM03sfUOENvvKexOLp+pCqgb/WDjsi7EK8gIsICtzhc=
+github.com/segmentio/asm v1.1.3/go.mod h1:Ld3L4ZXGNcSLRg4JBsZ3//1+f/TjYl0Mzen/DQy1EJg=
+github.com/segmentio/encoding v0.5.4 h1:OW1VRern8Nw6ITAtwSZ7Idrl3MXCFwXHPgqESYfvNt0=
+github.com/segmentio/encoding v0.5.4/go.mod h1:HS1ZKa3kSN32ZHVZ7ZLPLXWvOVIiZtyJnO1gPH1sKt0=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=
 github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
@@ -176,6 +188,8 @@ github.com/vmihailenco/msgpack/v5 v5.4.1 h1:cQriyiUvjTwOHg8QZaPihLWeRAAVoCpE00IU
 github.com/vmihailenco/msgpack/v5 v5.4.1/go.mod h1:GaZTsDaehaPpQVyxrf5mtQlH+pc21PIudVV/E3rRQok=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
 github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
+github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
+github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 go.etcd.io/bbolt v1.3.5 h1:XAzx9gjCb0Rxj7EoqcClPD1d5ZBxZJk0jbuoPHenBt0=
 go.etcd.io/bbolt v1.3.5/go.mod h1:G5EMThwa9y8QZGBClrRx5EY+Yw9kAhnjy3bSjsnlVTQ=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
@@ -188,6 +202,8 @@ golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190613194153-d28f0bde5980/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
+golang.org/x/oauth2 v0.35.0 h1:Mv2mzuHuZuY2+bkyWXIHMfhNdJAdwW3FuWeCPYN5GVQ=
+golang.org/x/oauth2 v0.35.0/go.mod h1:lzm5WQJQwKZ3nwavOZ3IS5Aulzxi68dUSgRHujetwEA=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -210,11 +226,13 @@ golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.13.0 h1:Af8nKPmuFypiUBjVoU9V20FiaFXOcuZI21p0ycVYYGE=
-golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.41.0 h1:Ivj+2Cp/ylzLiEU89QhWblYnOE9zerudt9Ftecq2C6k=
+golang.org/x/sys v0.41.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+golang.org/x/tools v0.42.0 h1:uNgphsn75Tdz5Ji2q36v/nsFSfR/9BRFvqhGBaJGd5k=
+golang.org/x/tools v0.42.0/go.mod h1:Ma6lCIwGZvHK6XtgbswSoWroEkhugApmsXyrUmBhfr0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=

--- a/pkg/mcp/client.go
+++ b/pkg/mcp/client.go
@@ -1,0 +1,301 @@
+// Package mcp implements a Model Context Protocol server that exposes
+// a running Loveliness cluster to LLM agents over stdio JSON-RPC.
+//
+// The server talks to Loveliness over its regular HTTP API (/cypher,
+// /bulk/*, /ingest/*, /cluster). The HTTP adapter lives in client.go.
+package mcp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// Client is a thin HTTP adapter over the Loveliness HTTP API.
+//
+// It is deliberately not reusing the in-process router from pkg/api —
+// the MCP server is a separate process from the cluster, and talks to
+// whichever node it was pointed at via --url / LOVELINESS_URL.
+type Client struct {
+	baseURL string
+	token   string
+	http    *http.Client
+}
+
+// NewClient creates a new HTTP client.
+//
+// baseURL is the cluster HTTP endpoint (e.g. http://localhost:8080).
+// token is an optional bearer token forwarded via Authorization.
+// timeout is the per-request timeout.
+func NewClient(baseURL, token string, timeout time.Duration) *Client {
+	if timeout <= 0 {
+		timeout = 30 * time.Second
+	}
+	return &Client{
+		baseURL: strings.TrimRight(baseURL, "/"),
+		token:   token,
+		http:    &http.Client{Timeout: timeout},
+	}
+}
+
+// CypherResult is the shape returned by POST /cypher.
+type CypherResult struct {
+	Columns []string         `json:"columns"`
+	Rows    []map[string]any `json:"rows"`
+	Stats   map[string]any   `json:"stats,omitempty"`
+}
+
+// Cypher executes a Cypher statement against /cypher.
+//
+// The Loveliness /cypher endpoint takes raw Cypher in the body (text/plain).
+// Parameters are not bound at the HTTP layer today — if the caller provided
+// params, they are inlined into the query via $-substitution. This is good
+// enough for the MCP surface: the LLM sees a typed (query, params) contract,
+// we flatten it at the edge.
+func (c *Client) Cypher(ctx context.Context, query string, params map[string]any) (*CypherResult, error) {
+	expanded, err := inlineParams(query, params)
+	if err != nil {
+		return nil, err
+	}
+	body, err := c.post(ctx, "/cypher", "text/plain", strings.NewReader(expanded), nil)
+	if err != nil {
+		return nil, err
+	}
+	var out CypherResult
+	if err := json.Unmarshal(body, &out); err != nil {
+		return nil, fmt.Errorf("cypher: decode response: %w", err)
+	}
+	return &out, nil
+}
+
+// ClusterStatus is the shape returned by GET /cluster.
+type ClusterStatus struct {
+	Leader       string         `json:"leader"`
+	NodeID       string         `json:"node_id"`
+	IsLeader     bool           `json:"is_leader"`
+	ShardMap     map[string]any `json:"shard_map"`
+	Nodes        any            `json:"nodes"`
+	Schema       map[string]any `json:"schema"`
+	Raw          []byte         `json:"-"`
+}
+
+// Cluster calls GET /cluster.
+func (c *Client) Cluster(ctx context.Context) (*ClusterStatus, error) {
+	body, err := c.get(ctx, "/cluster", nil)
+	if err != nil {
+		return nil, err
+	}
+	var out ClusterStatus
+	if err := json.Unmarshal(body, &out); err != nil {
+		return nil, fmt.Errorf("cluster: decode response: %w", err)
+	}
+	out.Raw = body
+	return &out, nil
+}
+
+// BulkResult is the shape of /bulk/nodes and /bulk/edges responses.
+type BulkResult struct {
+	Table  string   `json:"table"`
+	Loaded int64    `json:"loaded"`
+	Errors []string `json:"errors,omitempty"`
+}
+
+// BulkNodes posts a CSV to /bulk/nodes with the X-Table header set.
+func (c *Client) BulkNodes(ctx context.Context, table, csvData string) (*BulkResult, error) {
+	headers := map[string]string{"X-Table": table}
+	body, err := c.post(ctx, "/bulk/nodes", "text/csv", strings.NewReader(csvData), headers)
+	if err != nil {
+		return nil, err
+	}
+	var out BulkResult
+	if err := json.Unmarshal(body, &out); err != nil {
+		return nil, fmt.Errorf("bulk/nodes: decode response: %w", err)
+	}
+	return &out, nil
+}
+
+// BulkEdges posts a CSV to /bulk/edges with required headers.
+func (c *Client) BulkEdges(ctx context.Context, relTable, fromTable, toTable, csvData string, skipRefs bool) (*BulkResult, error) {
+	headers := map[string]string{
+		"X-Rel-Table":  relTable,
+		"X-From-Table": fromTable,
+		"X-To-Table":   toTable,
+	}
+	if skipRefs {
+		headers["X-Skip-Refs"] = "true"
+	}
+	body, err := c.post(ctx, "/bulk/edges", "text/csv", strings.NewReader(csvData), headers)
+	if err != nil {
+		return nil, err
+	}
+	var out BulkResult
+	if err := json.Unmarshal(body, &out); err != nil {
+		return nil, fmt.Errorf("bulk/edges: decode response: %w", err)
+	}
+	return &out, nil
+}
+
+// IngestResult is the shape of a 202 response from /ingest/nodes or /ingest/edges.
+type IngestResult struct {
+	JobID  string `json:"job_id"`
+	Status string `json:"status"`
+}
+
+// IngestNodes enqueues an async node ingest.
+func (c *Client) IngestNodes(ctx context.Context, table, csvData string) (*IngestResult, error) {
+	headers := map[string]string{"X-Table": table}
+	body, err := c.post(ctx, "/ingest/nodes", "text/csv", strings.NewReader(csvData), headers)
+	if err != nil {
+		return nil, err
+	}
+	var out IngestResult
+	if err := json.Unmarshal(body, &out); err != nil {
+		return nil, fmt.Errorf("ingest/nodes: decode response: %w", err)
+	}
+	return &out, nil
+}
+
+// IngestEdges enqueues an async edge ingest.
+func (c *Client) IngestEdges(ctx context.Context, relTable, fromTable, toTable, csvData string, skipRefs bool) (*IngestResult, error) {
+	headers := map[string]string{
+		"X-Rel-Table":  relTable,
+		"X-From-Table": fromTable,
+		"X-To-Table":   toTable,
+	}
+	if skipRefs {
+		headers["X-Skip-Refs"] = "true"
+	}
+	body, err := c.post(ctx, "/ingest/edges", "text/csv", strings.NewReader(csvData), headers)
+	if err != nil {
+		return nil, err
+	}
+	var out IngestResult
+	if err := json.Unmarshal(body, &out); err != nil {
+		return nil, fmt.Errorf("ingest/edges: decode response: %w", err)
+	}
+	return &out, nil
+}
+
+// IngestJob is the shape of a single job record returned by /ingest/jobs/{id}.
+type IngestJob map[string]any
+
+// IngestStatus fetches the current status of an async ingest job.
+func (c *Client) IngestStatus(ctx context.Context, jobID string) (IngestJob, error) {
+	body, err := c.get(ctx, "/ingest/jobs/"+jobID, nil)
+	if err != nil {
+		return nil, err
+	}
+	var out IngestJob
+	if err := json.Unmarshal(body, &out); err != nil {
+		return nil, fmt.Errorf("ingest/status: decode response: %w", err)
+	}
+	return out, nil
+}
+
+// HTTPError represents a non-2xx HTTP response from Loveliness.
+type HTTPError struct {
+	Status int
+	Code   string
+	Msg    string
+	Body   []byte
+}
+
+func (e *HTTPError) Error() string {
+	if e.Code != "" {
+		return fmt.Sprintf("loveliness %d %s: %s", e.Status, e.Code, e.Msg)
+	}
+	return fmt.Sprintf("loveliness %d: %s", e.Status, truncate(string(e.Body), 256))
+}
+
+// IsTimeout returns true if err was a request timeout (context deadline).
+func IsTimeout(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	// net/http wraps deadline errors as url.Error.
+	var he *HTTPError
+	if errors.As(err, &he) && he.Status == http.StatusGatewayTimeout {
+		return true
+	}
+	return false
+}
+
+func (c *Client) post(ctx context.Context, path, contentType string, body io.Reader, headers map[string]string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+path, body)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", contentType)
+	c.applyHeaders(req, headers)
+	return c.do(req)
+}
+
+func (c *Client) get(ctx context.Context, path string, headers map[string]string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+path, nil)
+	if err != nil {
+		return nil, err
+	}
+	c.applyHeaders(req, headers)
+	return c.do(req)
+}
+
+func (c *Client) applyHeaders(req *http.Request, headers map[string]string) {
+	if c.token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.token)
+	}
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+}
+
+func (c *Client) do(req *http.Request) ([]byte, error) {
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 16<<20)) // 16 MB cap
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode >= 400 {
+		return nil, parseHTTPError(resp.StatusCode, body)
+	}
+	return body, nil
+}
+
+// parseHTTPError turns a non-2xx response into a typed HTTPError.
+// The Loveliness API consistently returns {error:{code, message}} JSON.
+func parseHTTPError(status int, body []byte) *HTTPError {
+	e := &HTTPError{Status: status, Body: body}
+	var wire struct {
+		Error struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(bytes.TrimSpace(body), &wire); err == nil {
+		e.Code = wire.Error.Code
+		e.Msg = wire.Error.Message
+	}
+	if e.Msg == "" {
+		e.Msg = strings.TrimSpace(string(body))
+	}
+	return e
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "..."
+}

--- a/pkg/mcp/client_test.go
+++ b/pkg/mcp/client_test.go
@@ -1,0 +1,152 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fakeBackend lets tests register per-path handlers.
+func fakeBackend(t *testing.T, handlers map[string]http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	for path, h := range handlers {
+		mux.HandleFunc(path, h)
+	}
+	return httptest.NewServer(mux)
+}
+
+func TestClientCypher(t *testing.T) {
+	srv := fakeBackend(t, map[string]http.HandlerFunc{
+		"/cypher": func(w http.ResponseWriter, r *http.Request) {
+			body, _ := io.ReadAll(r.Body)
+			if got := string(body); !strings.Contains(got, "MATCH") {
+				t.Fatalf("unexpected body %q", got)
+			}
+			if got := r.Header.Get("Authorization"); got != "Bearer t1" {
+				t.Fatalf("missing bearer token, got %q", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"columns":["n"],"rows":[{"n":1}],"stats":{"ms":1}}`))
+		},
+	})
+	t.Cleanup(srv.Close)
+
+	c := NewClient(srv.URL, "t1", 2*time.Second)
+	res, err := c.Cypher(context.Background(), "MATCH (n) RETURN n", nil)
+	if err != nil {
+		t.Fatalf("Cypher: %v", err)
+	}
+	if len(res.Columns) != 1 || res.Columns[0] != "n" {
+		t.Fatalf("columns: %v", res.Columns)
+	}
+	if len(res.Rows) != 1 {
+		t.Fatalf("rows: %v", res.Rows)
+	}
+}
+
+func TestClientCypherHTTPError(t *testing.T) {
+	srv := fakeBackend(t, map[string]http.HandlerFunc{
+		"/cypher": func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":{"code":"CYPHER_PARSE_ERROR","message":"syntax error at line 1"}}`))
+		},
+	})
+	t.Cleanup(srv.Close)
+
+	c := NewClient(srv.URL, "", time.Second)
+	_, err := c.Cypher(context.Background(), "bogus query", nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var he *HTTPError
+	if !errors.As(err, &he) {
+		t.Fatalf("expected *HTTPError, got %T", err)
+	}
+	if he.Status != http.StatusBadRequest || he.Code != "CYPHER_PARSE_ERROR" {
+		t.Fatalf("unexpected error: %+v", he)
+	}
+}
+
+func TestClientCluster(t *testing.T) {
+	srv := fakeBackend(t, map[string]http.HandlerFunc{
+		"/cluster": func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"leader":"127.0.0.1:9000","node_id":"n1","is_leader":true,"shard_map":{},"nodes":[],"schema":{}}`))
+		},
+	})
+	t.Cleanup(srv.Close)
+	c := NewClient(srv.URL, "", time.Second)
+	st, err := c.Cluster(context.Background())
+	if err != nil {
+		t.Fatalf("Cluster: %v", err)
+	}
+	if !st.IsLeader || st.NodeID != "n1" {
+		t.Fatalf("bad cluster status: %+v", st)
+	}
+}
+
+func TestClientBulkNodes(t *testing.T) {
+	srv := fakeBackend(t, map[string]http.HandlerFunc{
+		"/bulk/nodes": func(w http.ResponseWriter, r *http.Request) {
+			if r.Header.Get("X-Table") != "Person" {
+				t.Fatalf("missing X-Table header, got %q", r.Header.Get("X-Table"))
+			}
+			body, _ := io.ReadAll(r.Body)
+			if !strings.Contains(string(body), "Alice") {
+				t.Fatalf("missing CSV body, got %q", body)
+			}
+			_, _ = w.Write([]byte(`{"table":"Person","loaded":3}`))
+		},
+	})
+	t.Cleanup(srv.Close)
+	c := NewClient(srv.URL, "", time.Second)
+	res, err := c.BulkNodes(context.Background(), "Person", "name,age\nAlice,30\n")
+	if err != nil {
+		t.Fatalf("BulkNodes: %v", err)
+	}
+	if res.Loaded != 3 || res.Table != "Person" {
+		t.Fatalf("bad result: %+v", res)
+	}
+}
+
+func TestClientIngestNodes(t *testing.T) {
+	srv := fakeBackend(t, map[string]http.HandlerFunc{
+		"/ingest/nodes": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusAccepted)
+			_, _ = w.Write([]byte(`{"job_id":"abc","status":"pending"}`))
+		},
+	})
+	t.Cleanup(srv.Close)
+	c := NewClient(srv.URL, "", time.Second)
+	res, err := c.IngestNodes(context.Background(), "Person", "name\nAlice\n")
+	if err != nil {
+		t.Fatalf("IngestNodes: %v", err)
+	}
+	if res.JobID != "abc" || res.Status != "pending" {
+		t.Fatalf("bad result: %+v", res)
+	}
+}
+
+func TestClientIngestStatus(t *testing.T) {
+	srv := fakeBackend(t, map[string]http.HandlerFunc{
+		"/ingest/jobs/abc": func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(`{"id":"abc","status":"running","loaded":100}`))
+		},
+	})
+	t.Cleanup(srv.Close)
+	c := NewClient(srv.URL, "", time.Second)
+	job, err := c.IngestStatus(context.Background(), "abc")
+	if err != nil {
+		t.Fatalf("IngestStatus: %v", err)
+	}
+	if job["status"] != "running" {
+		t.Fatalf("bad job: %+v", job)
+	}
+}

--- a/pkg/mcp/errors.go
+++ b/pkg/mcp/errors.go
@@ -1,0 +1,63 @@
+package mcp
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// MCP-side error codes used when returning a tool error.
+//
+// The Go SDK renders tool-call failures via CallToolResult.IsError=true
+// with textual content; the numeric codes in the design doc map to the
+// codes the client should see in the error message text.
+const (
+	codeInvalidParams = -32602 // parse / validation
+	codeServerError   = -32000 // generic server error
+	codeTimeout       = -32001 // timeout
+)
+
+// toolError wraps an error into an MCP tool failure result.
+//
+// The Loveliness HTTP error codes are mapped per the spec table:
+//
+//	400 with parser error       -> -32602 "Cypher parse error..."
+//	409 BROADCAST_PARTIAL       -> -32000 "Schema propagation in progress, retry"
+//	503 (shard unavailable)     -> -32000 "Shard unavailable, check cluster_status"
+//	timeout                     -> -32001 "Query exceeded timeout"
+func toolError(err error) *mcp.CallToolResult {
+	code, msg := classify(err)
+	return &mcp.CallToolResult{
+		IsError: true,
+		Content: []mcp.Content{&mcp.TextContent{
+			Text: fmt.Sprintf("error %d: %s", code, msg),
+		}},
+	}
+}
+
+func classify(err error) (int, string) {
+	if err == nil {
+		return 0, ""
+	}
+	if IsTimeout(err) {
+		return codeTimeout, "query exceeded the configured timeout; increase --timeout or narrow the query"
+	}
+	var he *HTTPError
+	if errors.As(err, &he) {
+		switch {
+		case he.Status == 400 && (he.Code == "CYPHER_PARSE_ERROR" || he.Code == "MISSING_SHARD_KEY" || he.Code == "BAD_REQUEST" || he.Code == "BAD_CSV" || he.Code == "UNKNOWN_TABLE" || he.Code == "NO_SCHEMA"):
+			return codeInvalidParams, fmt.Sprintf("cypher parse error: %s", he.Msg)
+		case he.Status == 409 && he.Code == "BROADCAST_PARTIAL":
+			return codeServerError, "schema propagation in progress, retry"
+		case he.Status == 503:
+			return codeServerError, fmt.Sprintf("shard unavailable: %s (check cluster_status)", he.Msg)
+		case he.Status == 504 || he.Code == "QUERY_TIMEOUT":
+			return codeTimeout, fmt.Sprintf("query exceeded timeout: %s", he.Msg)
+		case he.Status == 401 || he.Status == 403:
+			return codeServerError, fmt.Sprintf("authentication failed: %s (check LOVELINESS_TOKEN)", he.Msg)
+		}
+		return codeServerError, he.Error()
+	}
+	return codeServerError, err.Error()
+}

--- a/pkg/mcp/errors_test.go
+++ b/pkg/mcp/errors_test.go
@@ -1,0 +1,81 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestClassify(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		wantCode int
+		wantMsg  string
+	}{
+		{
+			name:     "nil",
+			err:      nil,
+			wantCode: 0,
+		},
+		{
+			name:     "context deadline",
+			err:      context.DeadlineExceeded,
+			wantCode: codeTimeout,
+			wantMsg:  "query exceeded the configured timeout",
+		},
+		{
+			name:     "400 cypher parse",
+			err:      &HTTPError{Status: 400, Code: "CYPHER_PARSE_ERROR", Msg: "syntax"},
+			wantCode: codeInvalidParams,
+			wantMsg:  "cypher parse error",
+		},
+		{
+			name:     "409 broadcast partial",
+			err:      &HTTPError{Status: 409, Code: "BROADCAST_PARTIAL", Msg: "x"},
+			wantCode: codeServerError,
+			wantMsg:  "schema propagation",
+		},
+		{
+			name:     "503 shard unavailable",
+			err:      &HTTPError{Status: 503, Code: "SHARD_UNAVAILABLE", Msg: "shard 2 down"},
+			wantCode: codeServerError,
+			wantMsg:  "shard unavailable",
+		},
+		{
+			name:     "504 gateway timeout",
+			err:      &HTTPError{Status: 504, Code: "QUERY_TIMEOUT", Msg: "deadline"},
+			wantCode: codeTimeout,
+			wantMsg:  "query exceeded",
+		},
+		{
+			name:     "401 unauthorized",
+			err:      &HTTPError{Status: 401, Code: "UNAUTHORIZED", Msg: "bad token"},
+			wantCode: codeServerError,
+			wantMsg:  "authentication failed",
+		},
+		{
+			name:     "generic 500",
+			err:      &HTTPError{Status: 500, Msg: "boom"},
+			wantCode: codeServerError,
+			wantMsg:  "loveliness 500",
+		},
+		{
+			name:     "plain error",
+			err:      errors.New("something broke"),
+			wantCode: codeServerError,
+			wantMsg:  "something broke",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			code, msg := classify(tc.err)
+			if code != tc.wantCode {
+				t.Errorf("code = %d, want %d", code, tc.wantCode)
+			}
+			if tc.wantMsg != "" && !stringContains(msg, tc.wantMsg) {
+				t.Errorf("msg = %q, want to contain %q", msg, tc.wantMsg)
+			}
+		})
+	}
+}

--- a/pkg/mcp/params.go
+++ b/pkg/mcp/params.go
@@ -1,0 +1,184 @@
+package mcp
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"unicode"
+)
+
+// inlineParams substitutes $name placeholders in a Cypher query with
+// escaped literals from the params map. Loveliness's HTTP /cypher
+// endpoint accepts only a raw Cypher body, so MCP-side param binding
+// must flatten to literals.
+//
+// Supported literal types: string, bool, int/float (number), nil, and
+// slices/maps of the above (rendered as JSON-ish Cypher literals). We
+// intentionally keep this conservative — exotic types become an error.
+//
+// Placeholder matching follows openCypher: a '$' followed by one or
+// more identifier characters ([A-Za-z_][A-Za-z0-9_]*). Occurrences
+// inside single/double-quoted strings are left alone.
+func inlineParams(query string, params map[string]any) (string, error) {
+	// We still need to scan even when params is empty, so that unknown
+	// $placeholders surface as errors rather than being silently passed
+	// through to the server.
+	if params == nil {
+		params = map[string]any{}
+	}
+	if len(params) == 0 && !hasPlaceholder(query) {
+		return query, nil
+	}
+
+	var out strings.Builder
+	out.Grow(len(query))
+
+	runes := []rune(query)
+	i := 0
+	inString := rune(0) // 0 = not in a string, else the opening quote
+	for i < len(runes) {
+		r := runes[i]
+		// Track string boundaries (with minimal escape handling).
+		if inString != 0 {
+			out.WriteRune(r)
+			if r == '\\' && i+1 < len(runes) {
+				out.WriteRune(runes[i+1])
+				i += 2
+				continue
+			}
+			if r == inString {
+				inString = 0
+			}
+			i++
+			continue
+		}
+		if r == '\'' || r == '"' {
+			inString = r
+			out.WriteRune(r)
+			i++
+			continue
+		}
+		if r == '$' && i+1 < len(runes) && isIdentStart(runes[i+1]) {
+			j := i + 1
+			for j < len(runes) && isIdentCont(runes[j]) {
+				j++
+			}
+			name := string(runes[i+1 : j])
+			val, ok := params[name]
+			if !ok {
+				return "", fmt.Errorf("cypher param %q referenced but not provided", name)
+			}
+			lit, err := cypherLiteral(val)
+			if err != nil {
+				return "", fmt.Errorf("cypher param %q: %w", name, err)
+			}
+			out.WriteString(lit)
+			i = j
+			continue
+		}
+		out.WriteRune(r)
+		i++
+	}
+	return out.String(), nil
+}
+
+// hasPlaceholder reports whether q contains a $name placeholder outside
+// of string literals. It's a cheap pre-filter — callers that have real
+// params will always fall through to the full scanner anyway.
+func hasPlaceholder(q string) bool {
+	runes := []rune(q)
+	inString := rune(0)
+	for i := 0; i < len(runes); i++ {
+		r := runes[i]
+		if inString != 0 {
+			if r == '\\' && i+1 < len(runes) {
+				i++
+				continue
+			}
+			if r == inString {
+				inString = 0
+			}
+			continue
+		}
+		if r == '\'' || r == '"' {
+			inString = r
+			continue
+		}
+		if r == '$' && i+1 < len(runes) && isIdentStart(runes[i+1]) {
+			return true
+		}
+	}
+	return false
+}
+
+func isIdentStart(r rune) bool {
+	return r == '_' || unicode.IsLetter(r)
+}
+
+func isIdentCont(r rune) bool {
+	return r == '_' || unicode.IsLetter(r) || unicode.IsDigit(r)
+}
+
+// cypherLiteral renders a Go value as a Cypher literal.
+// Strings use single quotes with minimal escaping; numbers/bools/nil
+// render as their Cypher forms. Complex values are JSON-encoded —
+// openCypher accepts JSON-shaped map/list literals for most drivers.
+func cypherLiteral(v any) (string, error) {
+	switch x := v.(type) {
+	case nil:
+		return "NULL", nil
+	case bool:
+		if x {
+			return "true", nil
+		}
+		return "false", nil
+	case string:
+		return quoteCypherString(x), nil
+	case json.Number:
+		return x.String(), nil
+	case int, int8, int16, int32, int64,
+		uint, uint8, uint16, uint32, uint64,
+		float32, float64:
+		return fmt.Sprintf("%v", x), nil
+	case []any, map[string]any:
+		// Fallback: JSON encoding. Cypher map/list syntax is a superset
+		// compatible with JSON for scalar leaves, so this is acceptable
+		// for the "pass a struct as a param" use case.
+		b, err := json.Marshal(x)
+		if err != nil {
+			return "", err
+		}
+		return string(b), nil
+	default:
+		// Best-effort JSON fallback; if it fails, surface a clear error.
+		b, err := json.Marshal(x)
+		if err != nil {
+			return "", fmt.Errorf("unsupported param type %T", v)
+		}
+		return string(b), nil
+	}
+}
+
+func quoteCypherString(s string) string {
+	var b strings.Builder
+	b.Grow(len(s) + 2)
+	b.WriteByte('\'')
+	for _, r := range s {
+		switch r {
+		case '\'':
+			b.WriteString("\\'")
+		case '\\':
+			b.WriteString("\\\\")
+		case '\n':
+			b.WriteString("\\n")
+		case '\r':
+			b.WriteString("\\r")
+		case '\t':
+			b.WriteString("\\t")
+		default:
+			b.WriteRune(r)
+		}
+	}
+	b.WriteByte('\'')
+	return b.String()
+}

--- a/pkg/mcp/params_test.go
+++ b/pkg/mcp/params_test.go
@@ -1,0 +1,79 @@
+package mcp
+
+import "testing"
+
+func TestInlineParams(t *testing.T) {
+	tests := []struct {
+		name    string
+		query   string
+		params  map[string]any
+		want    string
+		wantErr bool
+	}{
+		{
+			name:   "no params",
+			query:  "MATCH (n) RETURN n",
+			params: nil,
+			want:   "MATCH (n) RETURN n",
+		},
+		{
+			name:   "string substitution",
+			query:  "MATCH (p:Person {name: $name}) RETURN p",
+			params: map[string]any{"name": "Alice"},
+			want:   "MATCH (p:Person {name: 'Alice'}) RETURN p",
+		},
+		{
+			name:   "string escapes single quote",
+			query:  "RETURN $s",
+			params: map[string]any{"s": "O'Brien"},
+			want:   "RETURN 'O\\'Brien'",
+		},
+		{
+			name:   "int and bool",
+			query:  "RETURN $n, $b",
+			params: map[string]any{"n": 42, "b": true},
+			want:   "RETURN 42, true",
+		},
+		{
+			name:   "null",
+			query:  "RETURN $x",
+			params: map[string]any{"x": nil},
+			want:   "RETURN NULL",
+		},
+		{
+			name:   "leave placeholders inside strings alone",
+			query:  "RETURN 'this is $not_a_param'",
+			params: map[string]any{"x": "y"},
+			want:   "RETURN 'this is $not_a_param'",
+		},
+		{
+			name:    "missing param errors",
+			query:   "RETURN $missing",
+			params:  map[string]any{},
+			wantErr: true,
+		},
+		{
+			name:   "multi-char identifier",
+			query:  "RETURN $a1_b",
+			params: map[string]any{"a1_b": 3.14},
+			want:   "RETURN 3.14",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := inlineParams(tc.query, tc.params)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("got  %q\nwant %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/mcp/resources.go
+++ b/pkg/mcp/resources.go
@@ -1,0 +1,62 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// registerResources adds two read-only URL-addressed resources.
+//
+//	loveliness://schema   - same payload as the `schema` tool
+//	loveliness://cluster  - same payload as the `cluster_status` tool
+func registerResources(s *mcp.Server, c *Client, cache *schemaCache) {
+	s.AddResource(&mcp.Resource{
+		URI:         "loveliness://schema",
+		Name:        "loveliness-schema",
+		Title:       "Loveliness graph schema",
+		Description: "Node and edge tables with property names and types.",
+		MIMEType:    "application/json",
+	}, func(ctx context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+		out, err := cache.get(ctx, c)
+		if err != nil {
+			return nil, err
+		}
+		b, err := json.MarshalIndent(out, "", "  ")
+		if err != nil {
+			return nil, err
+		}
+		return &mcp.ReadResourceResult{
+			Contents: []*mcp.ResourceContents{{
+				URI:      "loveliness://schema",
+				MIMEType: "application/json",
+				Text:     string(b),
+			}},
+		}, nil
+	})
+
+	s.AddResource(&mcp.Resource{
+		URI:         "loveliness://cluster",
+		Name:        "loveliness-cluster",
+		Title:       "Loveliness cluster status",
+		Description: "Leader, nodes, shard assignment, registered schema.",
+		MIMEType:    "application/json",
+	}, func(ctx context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+		st, err := c.Cluster(ctx)
+		if err != nil {
+			return nil, err
+		}
+		b, err := json.MarshalIndent(st, "", "  ")
+		if err != nil {
+			return nil, err
+		}
+		return &mcp.ReadResourceResult{
+			Contents: []*mcp.ResourceContents{{
+				URI:      "loveliness://cluster",
+				MIMEType: "application/json",
+				Text:     string(b),
+			}},
+		}, nil
+	})
+}

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -1,0 +1,77 @@
+package mcp
+
+import (
+	"context"
+	"time"
+
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// Version is the advertised server version.
+const Version = "0.1.0"
+
+// Options configures the MCP server.
+type Options struct {
+	// URL is the HTTP endpoint of a Loveliness node.
+	URL string
+	// Token is an optional bearer token.
+	Token string
+	// Timeout is the per-request HTTP timeout.
+	Timeout time.Duration
+	// Readonly disables mutating tools (cypher_write, bulk_*, ingest_*).
+	Readonly bool
+}
+
+// Server wraps a configured MCP server with its HTTP client.
+type Server struct {
+	opts   Options
+	client *Client
+	sdk    *mcpsdk.Server
+}
+
+// New builds a fully-configured MCP server with all tools and resources
+// registered, but does not start the transport.
+func New(opts Options) *Server {
+	if opts.Timeout <= 0 {
+		opts.Timeout = 30 * time.Second
+	}
+	if opts.URL == "" {
+		opts.URL = "http://localhost:8080"
+	}
+	client := NewClient(opts.URL, opts.Token, opts.Timeout)
+	sdk := mcpsdk.NewServer(&mcpsdk.Implementation{
+		Name:    "loveliness-mcp",
+		Title:   "Loveliness",
+		Version: Version,
+	}, &mcpsdk.ServerOptions{
+		Instructions: "Query, write, and introspect a Loveliness graph database. Use `schema` first to learn table shapes, then `cypher_read` for queries and `cypher_write` for mutations.",
+	})
+
+	cache := newSchemaCache(30 * time.Second)
+	registerCypherTools(sdk, client, opts.Readonly)
+	registerSchemaTool(sdk, client, cache)
+	registerClusterTool(sdk, client)
+	if !opts.Readonly {
+		registerBulkTools(sdk, client)
+		registerIngestTools(sdk, client)
+	}
+	registerResources(sdk, client, cache)
+
+	return &Server{opts: opts, client: client, sdk: sdk}
+}
+
+// Run starts the MCP server on stdio and blocks until ctx is cancelled
+// or the peer closes the connection.
+func (s *Server) Run(ctx context.Context) error {
+	return s.sdk.Run(ctx, &mcpsdk.StdioTransport{})
+}
+
+// SDK returns the underlying SDK server for advanced use (tests).
+func (s *Server) SDK() *mcpsdk.Server {
+	return s.sdk
+}
+
+// Client returns the underlying HTTP client (tests).
+func (s *Server) Client() *Client {
+	return s.client
+}

--- a/pkg/mcp/server_test.go
+++ b/pkg/mcp/server_test.go
@@ -1,0 +1,149 @@
+package mcp
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// TestServerToolsViaMCP exercises the server end-to-end using the MCP
+// in-memory transports: we stand up a fake Loveliness backend with
+// httptest, point the MCP server at it, connect an MCP client in the
+// same process, and drive a tool call.
+func TestServerToolsViaMCP(t *testing.T) {
+	backend := fakeBackend(t, map[string]http.HandlerFunc{
+		"/cypher": func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"columns":["c"],"rows":[{"c":1}]}`))
+		},
+		"/cluster": func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"leader":"127.0.0.1:9000","node_id":"n1","is_leader":true,"shard_map":{},"nodes":[]}`))
+		},
+	})
+	t.Cleanup(backend.Close)
+
+	srv := New(Options{URL: backend.URL, Timeout: 2 * time.Second})
+	client := mcp.NewClient(&mcp.Implementation{Name: "test", Version: "0.0.1"}, nil)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	t1, t2 := mcp.NewInMemoryTransports()
+	serverSession, err := srv.SDK().Connect(ctx, t1, nil)
+	if err != nil {
+		t.Fatalf("server connect: %v", err)
+	}
+	t.Cleanup(func() { _ = serverSession.Close() })
+
+	cs, err := client.Connect(ctx, t2, nil)
+	if err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	t.Cleanup(func() { _ = cs.Close() })
+
+	// List tools — should include cypher_read and cluster_status.
+	lt, err := cs.ListTools(ctx, &mcp.ListToolsParams{})
+	if err != nil {
+		t.Fatalf("list tools: %v", err)
+	}
+	names := map[string]bool{}
+	for _, tool := range lt.Tools {
+		names[tool.Name] = true
+	}
+	for _, want := range []string{"cypher_read", "cypher_write", "schema", "cluster_status", "bulk_nodes", "bulk_edges", "ingest_nodes", "ingest_edges", "ingest_status"} {
+		if !names[want] {
+			t.Errorf("missing tool %q; have %v", want, names)
+		}
+	}
+
+	// Call cypher_read.
+	res, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "cypher_read",
+		Arguments: map[string]any{"query": "MATCH (n) RETURN count(n)"},
+	})
+	if err != nil {
+		t.Fatalf("call cypher_read: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("cypher_read returned error: %v", res.Content)
+	}
+
+	// cypher_read should reject a write statement.
+	res2, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "cypher_read",
+		Arguments: map[string]any{"query": "CREATE (n:Person)"},
+	})
+	if err != nil {
+		t.Fatalf("call cypher_read(write): %v", err)
+	}
+	if !res2.IsError {
+		t.Fatal("expected cypher_read to reject write")
+	}
+	text := textOf(res2.Content)
+	if !strings.Contains(text, "CREATE") {
+		t.Errorf("error message should mention CREATE; got %q", text)
+	}
+
+	// Call cluster_status.
+	res3, err := cs.CallTool(ctx, &mcp.CallToolParams{Name: "cluster_status"})
+	if err != nil {
+		t.Fatalf("call cluster_status: %v", err)
+	}
+	if res3.IsError {
+		t.Fatalf("cluster_status returned error: %v", textOf(res3.Content))
+	}
+}
+
+func TestServerReadonlyOmitsWriters(t *testing.T) {
+	backend := fakeBackend(t, map[string]http.HandlerFunc{
+		"/cypher": func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(`{"columns":[],"rows":[]}`))
+		},
+	})
+	t.Cleanup(backend.Close)
+
+	srv := New(Options{URL: backend.URL, Readonly: true, Timeout: time.Second})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	t1, t2 := mcp.NewInMemoryTransports()
+	ss, err := srv.SDK().Connect(ctx, t1, nil)
+	if err != nil {
+		t.Fatalf("server connect: %v", err)
+	}
+	t.Cleanup(func() { _ = ss.Close() })
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test", Version: "0.0.1"}, nil)
+	cs, err := client.Connect(ctx, t2, nil)
+	if err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	t.Cleanup(func() { _ = cs.Close() })
+
+	lt, err := cs.ListTools(ctx, &mcp.ListToolsParams{})
+	if err != nil {
+		t.Fatalf("list tools: %v", err)
+	}
+	for _, tool := range lt.Tools {
+		switch tool.Name {
+		case "cypher_write", "bulk_nodes", "bulk_edges", "ingest_nodes", "ingest_edges":
+			t.Errorf("readonly: unexpected write tool %q", tool.Name)
+		}
+	}
+}
+
+func textOf(contents []mcp.Content) string {
+	var out strings.Builder
+	for _, c := range contents {
+		if tc, ok := c.(*mcp.TextContent); ok {
+			out.WriteString(tc.Text)
+		}
+	}
+	return out.String()
+}

--- a/pkg/mcp/tools_bulk.go
+++ b/pkg/mcp/tools_bulk.go
@@ -1,0 +1,94 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// BulkNodesInput is the input schema for bulk_nodes.
+//
+// Exactly one of csv_data / csv_path must be set. When csv_path is given,
+// the file is read from the MCP server's host — only files readable by
+// the loveliness-mcp process are accessible.
+type BulkNodesInput struct {
+	Table    string `json:"table" jsonschema:"Node table name (required)."`
+	CSVData  string `json:"csv_data,omitempty" jsonschema:"CSV body with a header row. Mutually exclusive with csv_path."`
+	CSVPath  string `json:"csv_path,omitempty" jsonschema:"Path to a CSV file on the MCP server host. Mutually exclusive with csv_data."`
+}
+
+// BulkEdgesInput is the input schema for bulk_edges.
+type BulkEdgesInput struct {
+	RelTable  string `json:"rel_table" jsonschema:"Relationship table name (required)."`
+	FromTable string `json:"from_table" jsonschema:"Source node table (required)."`
+	ToTable   string `json:"to_table" jsonschema:"Destination node table (required)."`
+	CSVData   string `json:"csv_data,omitempty"`
+	CSVPath   string `json:"csv_path,omitempty"`
+	SkipRefs  bool   `json:"skip_refs,omitempty" jsonschema:"Skip reference validation for faster loads."`
+}
+
+// BulkOutput mirrors the /bulk/* response shape.
+type BulkOutput struct {
+	Table  string   `json:"table"`
+	Loaded int64    `json:"loaded"`
+	Errors []string `json:"errors,omitempty"`
+}
+
+func loadCSV(data, path string) (string, error) {
+	if data != "" && path != "" {
+		return "", fmt.Errorf("csv_data and csv_path are mutually exclusive")
+	}
+	if data == "" && path == "" {
+		return "", fmt.Errorf("one of csv_data or csv_path is required")
+	}
+	if data != "" {
+		return data, nil
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("read csv_path: %w", err)
+	}
+	return string(b), nil
+}
+
+func registerBulkTools(s *mcp.Server, c *Client) {
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "bulk_nodes",
+		Title:       "Bulk-load nodes from CSV",
+		Description: "Synchronously load a CSV of node rows via POST /bulk/nodes. Provide either inline csv_data or a host csv_path.",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in BulkNodesInput) (*mcp.CallToolResult, BulkOutput, error) {
+		csv, err := loadCSV(in.CSVData, in.CSVPath)
+		if err != nil {
+			return toolError(err), BulkOutput{}, nil
+		}
+		if in.Table == "" {
+			return toolError(fmt.Errorf("table is required")), BulkOutput{}, nil
+		}
+		res, err := c.BulkNodes(ctx, in.Table, csv)
+		if err != nil {
+			return toolError(err), BulkOutput{}, nil
+		}
+		return nil, BulkOutput{Table: res.Table, Loaded: res.Loaded, Errors: res.Errors}, nil
+	})
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "bulk_edges",
+		Title:       "Bulk-load edges from CSV",
+		Description: "Synchronously load a CSV of relationship rows via POST /bulk/edges. Provide either inline csv_data or a host csv_path.",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in BulkEdgesInput) (*mcp.CallToolResult, BulkOutput, error) {
+		csv, err := loadCSV(in.CSVData, in.CSVPath)
+		if err != nil {
+			return toolError(err), BulkOutput{}, nil
+		}
+		if in.RelTable == "" || in.FromTable == "" || in.ToTable == "" {
+			return toolError(fmt.Errorf("rel_table, from_table, and to_table are required")), BulkOutput{}, nil
+		}
+		res, err := c.BulkEdges(ctx, in.RelTable, in.FromTable, in.ToTable, csv, in.SkipRefs)
+		if err != nil {
+			return toolError(err), BulkOutput{}, nil
+		}
+		return nil, BulkOutput{Table: res.Table, Loaded: res.Loaded, Errors: res.Errors}, nil
+	})
+}

--- a/pkg/mcp/tools_bulk_test.go
+++ b/pkg/mcp/tools_bulk_test.go
@@ -1,0 +1,51 @@
+package mcp
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadCSV(t *testing.T) {
+	t.Run("inline", func(t *testing.T) {
+		got, err := loadCSV("a,b\n1,2\n", "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != "a,b\n1,2\n" {
+			t.Errorf("unexpected %q", got)
+		}
+	})
+	t.Run("file", func(t *testing.T) {
+		dir := t.TempDir()
+		p := filepath.Join(dir, "x.csv")
+		if err := os.WriteFile(p, []byte("a\n1\n"), 0600); err != nil {
+			t.Fatal(err)
+		}
+		got, err := loadCSV("", p)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != "a\n1\n" {
+			t.Errorf("unexpected %q", got)
+		}
+	})
+	t.Run("both rejected", func(t *testing.T) {
+		_, err := loadCSV("x", "y")
+		if err == nil {
+			t.Fatal("expected error")
+		}
+	})
+	t.Run("neither rejected", func(t *testing.T) {
+		_, err := loadCSV("", "")
+		if err == nil {
+			t.Fatal("expected error")
+		}
+	})
+	t.Run("missing file", func(t *testing.T) {
+		_, err := loadCSV("", "/nonexistent/xyz.csv")
+		if err == nil {
+			t.Fatal("expected error")
+		}
+	})
+}

--- a/pkg/mcp/tools_cluster.go
+++ b/pkg/mcp/tools_cluster.go
@@ -1,0 +1,38 @@
+package mcp
+
+import (
+	"context"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// ClusterOutput is the structured cluster status.
+type ClusterOutput struct {
+	Leader   string         `json:"leader"`
+	NodeID   string         `json:"node_id"`
+	IsLeader bool           `json:"is_leader"`
+	ShardMap map[string]any `json:"shard_map,omitempty"`
+	Nodes    any            `json:"nodes,omitempty"`
+	Schema   map[string]any `json:"schema,omitempty"`
+}
+
+func registerClusterTool(s *mcp.Server, c *Client) {
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "cluster_status",
+		Title:       "Cluster topology and health",
+		Description: "Return leader, peer list, per-shard assignment, and registered schema from GET /cluster.",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, ClusterOutput, error) {
+		st, err := c.Cluster(ctx)
+		if err != nil {
+			return toolError(err), ClusterOutput{}, nil
+		}
+		return nil, ClusterOutput{
+			Leader:   st.Leader,
+			NodeID:   st.NodeID,
+			IsLeader: st.IsLeader,
+			ShardMap: st.ShardMap,
+			Nodes:    st.Nodes,
+			Schema:   st.Schema,
+		}, nil
+	})
+}

--- a/pkg/mcp/tools_cypher.go
+++ b/pkg/mcp/tools_cypher.go
@@ -1,0 +1,120 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// CypherInput is the input schema for cypher_read / cypher_write.
+type CypherInput struct {
+	Query  string         `json:"query" jsonschema:"Cypher statement to execute."`
+	Params map[string]any `json:"params,omitempty" jsonschema:"Optional parameter bindings (referenced as $name in the query)."`
+}
+
+// CypherOutput is the structured output.
+type CypherOutput struct {
+	Columns []string         `json:"columns"`
+	Rows    []map[string]any `json:"rows"`
+	Stats   map[string]any   `json:"stats,omitempty"`
+}
+
+// writeKeywords are statements rejected by cypher_read.
+//
+// The spec names CREATE, MERGE, SET, DELETE, DROP, REMOVE, LOAD. The
+// task brief extends this with COPY, ALTER, and DETACH to cover the
+// LadybugDB surface (COPY FROM loads bulk data; DETACH DELETE is a
+// common write form that starts with DETACH).
+var writeKeywords = []string{
+	"CREATE", "MERGE", "SET", "DELETE", "DROP", "REMOVE",
+	"LOAD", "COPY", "ALTER", "DETACH",
+}
+
+// firstKeyword returns the first non-comment, non-whitespace token of q,
+// uppercased. It handles /* ... */ block comments and // line comments,
+// plus arbitrary leading whitespace.
+func firstKeyword(q string) string {
+	s := q
+	for {
+		s = strings.TrimLeftFunc(s, func(r rune) bool {
+			return r == ' ' || r == '\t' || r == '\n' || r == '\r'
+		})
+		switch {
+		case strings.HasPrefix(s, "/*"):
+			end := strings.Index(s[2:], "*/")
+			if end < 0 {
+				return ""
+			}
+			s = s[2+end+2:]
+		case strings.HasPrefix(s, "//"):
+			nl := strings.IndexByte(s, '\n')
+			if nl < 0 {
+				return ""
+			}
+			s = s[nl+1:]
+		default:
+			// Extract keyword: run of letters.
+			i := 0
+			for i < len(s) && isLetter(s[i]) {
+				i++
+			}
+			return strings.ToUpper(s[:i])
+		}
+	}
+}
+
+func isLetter(b byte) bool {
+	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z')
+}
+
+// isWrite returns true if q's first keyword is a known write form.
+func isWrite(q string) bool {
+	kw := firstKeyword(q)
+	for _, w := range writeKeywords {
+		if kw == w {
+			return true
+		}
+	}
+	return false
+}
+
+func registerCypherTools(s *mcp.Server, c *Client, readonly bool) {
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "cypher_read",
+		Title:       "Run a read-only Cypher query",
+		Description: "Execute a Cypher read query (MATCH/RETURN/CALL/...). Rejects write keywords (CREATE, MERGE, SET, DELETE, DROP, REMOVE, LOAD, COPY, ALTER, DETACH). Use $name placeholders with params for safe substitution.",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in CypherInput) (*mcp.CallToolResult, CypherOutput, error) {
+		if strings.TrimSpace(in.Query) == "" {
+			return toolError(fmt.Errorf("query is required")), CypherOutput{}, nil
+		}
+		if isWrite(in.Query) {
+			return toolError(fmt.Errorf("cypher_read rejects write statements; use cypher_write for %s", firstKeyword(in.Query))), CypherOutput{}, nil
+		}
+		res, err := c.Cypher(ctx, in.Query, in.Params)
+		if err != nil {
+			return toolError(err), CypherOutput{}, nil
+		}
+		return nil, CypherOutput{Columns: res.Columns, Rows: res.Rows, Stats: res.Stats}, nil
+	})
+
+	if readonly {
+		return
+	}
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "cypher_write",
+		Title:       "Run a Cypher write query",
+		Description: "Execute a Cypher write statement (CREATE/MERGE/SET/DELETE/etc) or DDL. Not registered when --readonly is set.",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in CypherInput) (*mcp.CallToolResult, CypherOutput, error) {
+		if strings.TrimSpace(in.Query) == "" {
+			return toolError(fmt.Errorf("query is required")), CypherOutput{}, nil
+		}
+		res, err := c.Cypher(ctx, in.Query, in.Params)
+		if err != nil {
+			return toolError(err), CypherOutput{}, nil
+		}
+		return nil, CypherOutput{Columns: res.Columns, Rows: res.Rows, Stats: res.Stats}, nil
+	})
+}

--- a/pkg/mcp/tools_cypher.go
+++ b/pkg/mcp/tools_cypher.go
@@ -32,6 +32,33 @@ var writeKeywords = []string{
 	"LOAD", "COPY", "ALTER", "DETACH",
 }
 
+// writeProcedures are LadybugDB CALL procedures that mutate state or
+// touch the host filesystem. cypher_read additionally rejects CALL
+// statements whose target procedure name appears here, so an LLM can't
+// sneak past the keyword gate with `CALL drop_table('Person')`.
+//
+// Names are matched case-insensitively against the identifier that
+// follows the leading CALL token.
+var writeProcedures = map[string]struct{}{
+	"drop_table":              {},
+	"create_node_table":       {},
+	"create_rel_table":        {},
+	"create_node_table_group": {},
+	"create_rel_table_group":  {},
+	"create_project_graph":    {},
+	"drop_project_graph":      {},
+	"alter_table_add_column":  {},
+	"alter_table_drop_column": {},
+	"alter_table_rename":      {},
+	"copy_from":               {},
+	"copy_to":                 {},
+	"copy_npy":                {},
+	"export_database":         {},
+	"import_database":         {},
+	"install":                 {},
+	"load_extension":          {},
+}
+
 // firstKeyword returns the first non-comment, non-whitespace token of q,
 // uppercased. It handles /* ... */ block comments and // line comments,
 // plus arbitrary leading whitespace.
@@ -69,7 +96,8 @@ func isLetter(b byte) bool {
 	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z')
 }
 
-// isWrite returns true if q's first keyword is a known write form.
+// isWrite returns true if q's first keyword is a known write form, or
+// if it is a CALL whose target procedure is a known mutating procedure.
 func isWrite(q string) bool {
 	kw := firstKeyword(q)
 	for _, w := range writeKeywords {
@@ -77,7 +105,58 @@ func isWrite(q string) bool {
 			return true
 		}
 	}
+	if kw == "CALL" {
+		if proc := callTarget(q); proc != "" {
+			if _, mut := writeProcedures[strings.ToLower(proc)]; mut {
+				return true
+			}
+		}
+	}
 	return false
+}
+
+// callTarget returns the procedure identifier that follows a leading
+// CALL keyword in q, or "" if it can't be parsed. Comments and
+// whitespace before/between tokens are skipped using the same logic as
+// firstKeyword.
+func callTarget(q string) string {
+	s := skipLeading(q)
+	if !strings.HasPrefix(strings.ToUpper(s), "CALL") {
+		return ""
+	}
+	s = s[4:]
+	s = skipLeading(s)
+	i := 0
+	for i < len(s) && (isLetter(s[i]) || s[i] == '_' || (i > 0 && s[i] >= '0' && s[i] <= '9')) {
+		i++
+	}
+	return s[:i]
+}
+
+// skipLeading strips whitespace and /* */ // comments from the start
+// of s. Mirrors firstKeyword's loop body.
+func skipLeading(s string) string {
+	for {
+		s = strings.TrimLeftFunc(s, func(r rune) bool {
+			return r == ' ' || r == '\t' || r == '\n' || r == '\r'
+		})
+		switch {
+		case strings.HasPrefix(s, "/*"):
+			end := strings.Index(s[2:], "*/")
+			if end < 0 {
+				return ""
+			}
+			s = s[2+end+2:]
+		case strings.HasPrefix(s, "//"):
+			nl := strings.IndexByte(s, '\n')
+			if nl < 0 {
+				return ""
+			}
+			s = s[nl+1:]
+		default:
+			return s
+		}
+	}
 }
 
 func registerCypherTools(s *mcp.Server, c *Client, readonly bool) {

--- a/pkg/mcp/tools_cypher_test.go
+++ b/pkg/mcp/tools_cypher_test.go
@@ -46,11 +46,41 @@ func TestIsWrite(t *testing.T) {
 		"MATCH (n) RETURN n",
 		"RETURN 1",
 		"CALL show_tables()",
+		"CALL table_info('Person')",
 		"// note\nMATCH (n) RETURN n",
 	}
 	for _, q := range reads {
 		if isWrite(q) {
 			t.Errorf("isWrite(%q) = true, want false", q)
+		}
+	}
+
+	mutatingCalls := []string{
+		"CALL drop_table('Person')",
+		"CALL DROP_TABLE('Person')",
+		"  call  export_database('/tmp/x')",
+		"/* x */ CALL create_node_table('T', 'id INT64, PRIMARY KEY (id)')",
+		"CALL alter_table_rename('A', 'B')",
+	}
+	for _, q := range mutatingCalls {
+		if !isWrite(q) {
+			t.Errorf("isWrite(%q) = false, want true (mutating CALL)", q)
+		}
+	}
+}
+
+func TestCallTarget(t *testing.T) {
+	tests := map[string]string{
+		"CALL show_tables()":             "show_tables",
+		"  call drop_table('x')":         "drop_table",
+		"/* hi */ CALL  table_info ('a')": "table_info",
+		"MATCH (n)":                       "",
+		"":                                "",
+	}
+	for q, want := range tests {
+		got := callTarget(q)
+		if got != want {
+			t.Errorf("callTarget(%q) = %q, want %q", q, got, want)
 		}
 	}
 }

--- a/pkg/mcp/tools_cypher_test.go
+++ b/pkg/mcp/tools_cypher_test.go
@@ -1,0 +1,56 @@
+package mcp
+
+import "testing"
+
+func TestFirstKeyword(t *testing.T) {
+	tests := map[string]string{
+		"MATCH (n) RETURN n":                    "MATCH",
+		"  match (n)":                           "MATCH",
+		"/* comment */ RETURN 1":                "RETURN",
+		"// line comment\nCREATE (n)":           "CREATE",
+		"/* a */ /* b */ \n DELETE n":           "DELETE",
+		"\t\n  DETACH DELETE n":                 "DETACH",
+		"":                                      "",
+		"   ":                                   "",
+	}
+	for q, want := range tests {
+		t.Run(q, func(t *testing.T) {
+			got := firstKeyword(q)
+			if got != want {
+				t.Errorf("firstKeyword(%q) = %q, want %q", q, got, want)
+			}
+		})
+	}
+}
+
+func TestIsWrite(t *testing.T) {
+	writes := []string{
+		"CREATE (n)",
+		"MERGE (n)",
+		"  SET n.x = 1",
+		"DELETE n",
+		"DETACH DELETE n",
+		"REMOVE n.x",
+		"DROP TABLE x",
+		"LOAD CSV",
+		"COPY Person FROM 'x.csv'",
+		"ALTER TABLE Person ADD COLUMN y INT64",
+		"/* writer */ CREATE (n)",
+	}
+	for _, q := range writes {
+		if !isWrite(q) {
+			t.Errorf("isWrite(%q) = false, want true", q)
+		}
+	}
+	reads := []string{
+		"MATCH (n) RETURN n",
+		"RETURN 1",
+		"CALL show_tables()",
+		"// note\nMATCH (n) RETURN n",
+	}
+	for _, q := range reads {
+		if isWrite(q) {
+			t.Errorf("isWrite(%q) = true, want false", q)
+		}
+	}
+}

--- a/pkg/mcp/tools_ingest.go
+++ b/pkg/mcp/tools_ingest.go
@@ -1,0 +1,96 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// IngestNodesInput mirrors BulkNodesInput for the async /ingest path.
+type IngestNodesInput struct {
+	Table   string `json:"table"`
+	CSVData string `json:"csv_data,omitempty"`
+	CSVPath string `json:"csv_path,omitempty"`
+}
+
+// IngestEdgesInput mirrors BulkEdgesInput for the async /ingest path.
+type IngestEdgesInput struct {
+	RelTable  string `json:"rel_table"`
+	FromTable string `json:"from_table"`
+	ToTable   string `json:"to_table"`
+	CSVData   string `json:"csv_data,omitempty"`
+	CSVPath   string `json:"csv_path,omitempty"`
+	SkipRefs  bool   `json:"skip_refs,omitempty"`
+}
+
+// IngestJobRef is the output for the enqueue tools: a job ID plus status.
+type IngestJobRef struct {
+	JobID  string `json:"job_id"`
+	Status string `json:"status"`
+}
+
+// IngestStatusInput takes a single job ID.
+type IngestStatusInput struct {
+	JobID string `json:"job_id" jsonschema:"The async ingest job ID returned by ingest_nodes / ingest_edges."`
+}
+
+// IngestStatusOutput is the raw job record from /ingest/jobs/{id}.
+type IngestStatusOutput struct {
+	Job map[string]any `json:"job"`
+}
+
+func registerIngestTools(s *mcp.Server, c *Client) {
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "ingest_nodes",
+		Title:       "Async bulk-load nodes",
+		Description: "Enqueue an async node load. Returns a job_id; poll with ingest_status.",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in IngestNodesInput) (*mcp.CallToolResult, IngestJobRef, error) {
+		csv, err := loadCSV(in.CSVData, in.CSVPath)
+		if err != nil {
+			return toolError(err), IngestJobRef{}, nil
+		}
+		if in.Table == "" {
+			return toolError(fmt.Errorf("table is required")), IngestJobRef{}, nil
+		}
+		res, err := c.IngestNodes(ctx, in.Table, csv)
+		if err != nil {
+			return toolError(err), IngestJobRef{}, nil
+		}
+		return nil, IngestJobRef{JobID: res.JobID, Status: res.Status}, nil
+	})
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "ingest_edges",
+		Title:       "Async bulk-load edges",
+		Description: "Enqueue an async relationship load. Returns a job_id; poll with ingest_status.",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in IngestEdgesInput) (*mcp.CallToolResult, IngestJobRef, error) {
+		csv, err := loadCSV(in.CSVData, in.CSVPath)
+		if err != nil {
+			return toolError(err), IngestJobRef{}, nil
+		}
+		if in.RelTable == "" || in.FromTable == "" || in.ToTable == "" {
+			return toolError(fmt.Errorf("rel_table, from_table, and to_table are required")), IngestJobRef{}, nil
+		}
+		res, err := c.IngestEdges(ctx, in.RelTable, in.FromTable, in.ToTable, csv, in.SkipRefs)
+		if err != nil {
+			return toolError(err), IngestJobRef{}, nil
+		}
+		return nil, IngestJobRef{JobID: res.JobID, Status: res.Status}, nil
+	})
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "ingest_status",
+		Title:       "Check async ingest job status",
+		Description: "Return the current status / progress record for an async ingest job.",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in IngestStatusInput) (*mcp.CallToolResult, IngestStatusOutput, error) {
+		if in.JobID == "" {
+			return toolError(fmt.Errorf("job_id is required")), IngestStatusOutput{}, nil
+		}
+		job, err := c.IngestStatus(ctx, in.JobID)
+		if err != nil {
+			return toolError(err), IngestStatusOutput{}, nil
+		}
+		return nil, IngestStatusOutput{Job: job}, nil
+	})
+}

--- a/pkg/mcp/tools_schema.go
+++ b/pkg/mcp/tools_schema.go
@@ -39,13 +39,14 @@ type Property struct {
 // schemaCache is an in-process schema cache with a 30s TTL.
 //
 // schema() is called on almost every agent turn, and hammering the
-// cluster for unchanged data is wasteful.
+// cluster for unchanged data is wasteful. Errors are not cached — a
+// transient cluster blip should not lock out schema lookups for the
+// full TTL window.
 type schemaCache struct {
-	mu        sync.Mutex
-	ttl       time.Duration
-	cachedAt  time.Time
-	cached    *SchemaOutput
-	cachedErr error
+	mu       sync.Mutex
+	ttl      time.Duration
+	cachedAt time.Time
+	cached   *SchemaOutput
 }
 
 func newSchemaCache(ttl time.Duration) *schemaCache {
@@ -59,13 +60,15 @@ func (sc *schemaCache) get(ctx context.Context, c *Client) (*SchemaOutput, error
 	sc.mu.Lock()
 	defer sc.mu.Unlock()
 	if sc.cached != nil && time.Since(sc.cachedAt) < sc.ttl {
-		return sc.cached, sc.cachedErr
+		return sc.cached, nil
 	}
 	out, err := fetchSchema(ctx, c)
+	if err != nil {
+		return nil, err
+	}
 	sc.cached = out
-	sc.cachedErr = err
 	sc.cachedAt = time.Now()
-	return out, err
+	return out, nil
 }
 
 // fetchSchema runs CALL show_tables() and CALL table_info(<name>) per

--- a/pkg/mcp/tools_schema.go
+++ b/pkg/mcp/tools_schema.go
@@ -1,0 +1,175 @@
+package mcp
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// SchemaOutput is the structured schema output.
+type SchemaOutput struct {
+	NodeTables []NodeTable `json:"node_tables"`
+	EdgeTables []EdgeTable `json:"edge_tables"`
+}
+
+// NodeTable describes a node table.
+type NodeTable struct {
+	Name       string     `json:"name"`
+	PrimaryKey string     `json:"primary_key,omitempty"`
+	Properties []Property `json:"properties"`
+}
+
+// EdgeTable describes a relationship table.
+type EdgeTable struct {
+	Name       string     `json:"name"`
+	From       string     `json:"from,omitempty"`
+	To         string     `json:"to,omitempty"`
+	Properties []Property `json:"properties"`
+}
+
+// Property is a single column in a node/edge table.
+type Property struct {
+	Name       string `json:"name"`
+	Type       string `json:"type"`
+	PrimaryKey bool   `json:"primary_key,omitempty"`
+}
+
+// schemaCache is an in-process schema cache with a 30s TTL.
+//
+// schema() is called on almost every agent turn, and hammering the
+// cluster for unchanged data is wasteful.
+type schemaCache struct {
+	mu        sync.Mutex
+	ttl       time.Duration
+	cachedAt  time.Time
+	cached    *SchemaOutput
+	cachedErr error
+}
+
+func newSchemaCache(ttl time.Duration) *schemaCache {
+	if ttl <= 0 {
+		ttl = 30 * time.Second
+	}
+	return &schemaCache{ttl: ttl}
+}
+
+func (sc *schemaCache) get(ctx context.Context, c *Client) (*SchemaOutput, error) {
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+	if sc.cached != nil && time.Since(sc.cachedAt) < sc.ttl {
+		return sc.cached, sc.cachedErr
+	}
+	out, err := fetchSchema(ctx, c)
+	sc.cached = out
+	sc.cachedErr = err
+	sc.cachedAt = time.Now()
+	return out, err
+}
+
+// fetchSchema runs CALL show_tables() and CALL table_info(<name>) per
+// table, structuring the result.
+func fetchSchema(ctx context.Context, c *Client) (*SchemaOutput, error) {
+	tablesRes, err := c.Cypher(ctx, "CALL show_tables() RETURN *", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	out := &SchemaOutput{}
+	for _, row := range tablesRes.Rows {
+		name, _ := row["name"].(string)
+		ttype, _ := row["type"].(string)
+		if name == "" {
+			continue
+		}
+		infoRes, err := c.Cypher(ctx, "CALL table_info('"+escapeSingle(name)+"') RETURN *", nil)
+		if err != nil {
+			// Propagate but still include what we have — a half-schema
+			// is worse than none for LLM reasoning.
+			return nil, err
+		}
+		switch ttype {
+		case "NODE":
+			nt := NodeTable{Name: name}
+			for _, p := range infoRes.Rows {
+				prop := Property{
+					Name: strOr(p["name"], ""),
+					Type: strOr(p["type"], ""),
+				}
+				if asBool(p["primary key"]) {
+					prop.PrimaryKey = true
+					nt.PrimaryKey = prop.Name
+				}
+				if prop.Name != "" {
+					nt.Properties = append(nt.Properties, prop)
+				}
+			}
+			out.NodeTables = append(out.NodeTables, nt)
+		case "REL":
+			et := EdgeTable{Name: name}
+			// LadybugDB's show_tables result also carries "source/destination"
+			// for REL tables in some versions. Best-effort extraction.
+			et.From = strOr(row["src table"], strOr(row["source table"], ""))
+			et.To = strOr(row["dst table"], strOr(row["destination table"], ""))
+			for _, p := range infoRes.Rows {
+				prop := Property{
+					Name: strOr(p["name"], ""),
+					Type: strOr(p["type"], ""),
+				}
+				if prop.Name != "" {
+					et.Properties = append(et.Properties, prop)
+				}
+			}
+			out.EdgeTables = append(out.EdgeTables, et)
+		}
+	}
+	return out, nil
+}
+
+func strOr(v any, def string) string {
+	if s, ok := v.(string); ok {
+		return s
+	}
+	return def
+}
+
+func asBool(v any) bool {
+	switch x := v.(type) {
+	case bool:
+		return x
+	case float64:
+		return x != 0
+	case int64:
+		return x != 0
+	case int:
+		return x != 0
+	}
+	return false
+}
+
+func escapeSingle(s string) string {
+	out := make([]byte, 0, len(s))
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\'' {
+			out = append(out, '\\', '\'')
+			continue
+		}
+		out = append(out, s[i])
+	}
+	return string(out)
+}
+
+func registerSchemaTool(s *mcp.Server, c *Client, cache *schemaCache) {
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "schema",
+		Title:       "Introspect the graph schema",
+		Description: "Return node and edge tables with property names and types. Result is cached for 30s on the MCP server.",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, SchemaOutput, error) {
+		out, err := cache.get(ctx, c)
+		if err != nil {
+			return toolError(err), SchemaOutput{}, nil
+		}
+		return nil, *out, nil
+	})
+}

--- a/pkg/mcp/tools_schema_test.go
+++ b/pkg/mcp/tools_schema_test.go
@@ -1,0 +1,109 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestSchemaCache verifies that schema() is cached for 30s.
+func TestSchemaCache(t *testing.T) {
+	var calls atomic.Int32
+	srv := fakeBackend(t, map[string]http.HandlerFunc{
+		"/cypher": func(w http.ResponseWriter, r *http.Request) {
+			calls.Add(1)
+			// Respond to show_tables() first, then table_info calls.
+			// Differentiate by a cheap body-sniff.
+			buf := make([]byte, 256)
+			n, _ := r.Body.Read(buf)
+			body := string(buf[:n])
+			switch {
+			case containsAll(body, "show_tables"):
+				writeJSON(w, map[string]any{
+					"columns": []string{"name", "type"},
+					"rows": []map[string]any{
+						{"name": "Person", "type": "NODE"},
+					},
+				})
+			case containsAll(body, "table_info"):
+				writeJSON(w, map[string]any{
+					"columns": []string{"name", "type", "primary key"},
+					"rows": []map[string]any{
+						{"name": "name", "type": "STRING", "primary key": true},
+						{"name": "age", "type": "INT64", "primary key": false},
+					},
+				})
+			default:
+				http.Error(w, "unexpected body: "+body, 400)
+			}
+		},
+	})
+	t.Cleanup(srv.Close)
+
+	c := NewClient(srv.URL, "", 2*time.Second)
+	cache := newSchemaCache(30 * time.Second)
+
+	for i := 0; i < 3; i++ {
+		out, err := cache.get(context.Background(), c)
+		if err != nil {
+			t.Fatalf("cache.get: %v", err)
+		}
+		if len(out.NodeTables) != 1 || out.NodeTables[0].Name != "Person" {
+			t.Fatalf("bad schema: %+v", out)
+		}
+		if out.NodeTables[0].PrimaryKey != "name" {
+			t.Fatalf("primary key not captured: %+v", out.NodeTables[0])
+		}
+		if len(out.NodeTables[0].Properties) != 2 {
+			t.Fatalf("properties: %+v", out.NodeTables[0].Properties)
+		}
+	}
+
+	// show_tables + one table_info per table = 2 HTTP calls, only on the
+	// first fetch. Subsequent cached fetches should add none.
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("expected 2 backend calls, got %d", got)
+	}
+}
+
+func writeJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	b, _ := json.Marshal(v)
+	_, _ = w.Write(b)
+}
+
+func containsAll(s string, subs ...string) bool {
+	for _, sub := range subs {
+		if !stringContains(s, sub) {
+			return false
+		}
+	}
+	return true
+}
+
+func stringContains(haystack, needle string) bool {
+	return len(needle) == 0 || indexOf(haystack, needle) >= 0
+}
+
+func indexOf(h, n string) int {
+	hb, nb := []byte(h), []byte(n)
+	if len(nb) == 0 {
+		return 0
+	}
+	for i := 0; i+len(nb) <= len(hb); i++ {
+		match := true
+		for j := 0; j < len(nb); j++ {
+			if hb[i+j] != nb[j] {
+				match = false
+				break
+			}
+		}
+		if match {
+			return i
+		}
+	}
+	return -1
+}

--- a/pkg/mcp/tools_schema_test.go
+++ b/pkg/mcp/tools_schema_test.go
@@ -69,6 +69,59 @@ func TestSchemaCache(t *testing.T) {
 	}
 }
 
+// TestSchemaCacheDoesNotCacheErrors verifies that an error response is
+// not cached — a transient cluster failure should not lock out schema
+// lookups for the full TTL window.
+func TestSchemaCacheDoesNotCacheErrors(t *testing.T) {
+	var calls atomic.Int32
+	var fail atomic.Bool
+	fail.Store(true)
+	srv := fakeBackend(t, map[string]http.HandlerFunc{
+		"/cypher": func(w http.ResponseWriter, r *http.Request) {
+			calls.Add(1)
+			if fail.Load() {
+				http.Error(w, `{"error":{"code":"INTERNAL","message":"boom"}}`, 500)
+				return
+			}
+			buf := make([]byte, 256)
+			n, _ := r.Body.Read(buf)
+			body := string(buf[:n])
+			switch {
+			case containsAll(body, "show_tables"):
+				writeJSON(w, map[string]any{
+					"columns": []string{"name", "type"},
+					"rows":    []map[string]any{{"name": "Person", "type": "NODE"}},
+				})
+			case containsAll(body, "table_info"):
+				writeJSON(w, map[string]any{
+					"columns": []string{"name", "type", "primary key"},
+					"rows":    []map[string]any{{"name": "name", "type": "STRING", "primary key": true}},
+				})
+			}
+		},
+	})
+	t.Cleanup(srv.Close)
+
+	c := NewClient(srv.URL, "", 2*time.Second)
+	cache := newSchemaCache(30 * time.Second)
+
+	if _, err := cache.get(context.Background(), c); err == nil {
+		t.Fatal("expected error from failing backend")
+	}
+	before := calls.Load()
+	fail.Store(false)
+	out, err := cache.get(context.Background(), c)
+	if err != nil {
+		t.Fatalf("expected recovery, got error: %v", err)
+	}
+	if len(out.NodeTables) != 1 {
+		t.Fatalf("expected schema after recovery, got %+v", out)
+	}
+	if calls.Load() <= before {
+		t.Fatalf("expected backend re-fetch after error; calls before=%d after=%d", before, calls.Load())
+	}
+}
+
 func writeJSON(w http.ResponseWriter, v any) {
 	w.Header().Set("Content-Type", "application/json")
 	b, _ := json.Marshal(v)

--- a/scripts/install-mcp.sh
+++ b/scripts/install-mcp.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env sh
+# install-mcp.sh — install loveliness-mcp and wire it into Claude.
+#
+# Usage:
+#   ./scripts/install-mcp.sh                # install + register MCP + skill
+#   ./scripts/install-mcp.sh --no-skill     # skip skill install
+#   ./scripts/install-mcp.sh --no-register  # build + install only
+#   LOVELINESS_URL=http://prod:8080 ./scripts/install-mcp.sh
+#
+# Env:
+#   LOVELINESS_URL    HTTP endpoint of a Loveliness node (default http://localhost:8080)
+#   LOVELINESS_TOKEN  Bearer token for an auth-enabled cluster (optional)
+#   PREFIX            Where to install loveliness-mcp (default ${GOBIN:-$(go env GOPATH)/bin})
+#
+# Exit codes: 0 on success, 1 on failure, 2 on bad usage.
+
+set -eu
+
+want_skill=1
+want_register=1
+
+for arg; do
+  case "$arg" in
+    --no-skill)    want_skill=0 ;;
+    --no-register) want_register=0 ;;
+    -h|--help)
+      sed -n '2,12p' "$0"
+      exit 0
+      ;;
+    *)
+      printf 'unknown flag: %s\n' "$arg" >&2
+      exit 2
+      ;;
+  esac
+done
+
+repo_root() {
+  cd "$(dirname "$0")/.." && pwd
+}
+
+REPO="$(repo_root)"
+PREFIX="${PREFIX:-${GOBIN:-$(go env GOPATH 2>/dev/null || printf '')/bin}}"
+LOVELINESS_URL="${LOVELINESS_URL:-http://localhost:8080}"
+
+if ! command -v go >/dev/null 2>&1; then
+  printf 'error: go toolchain not found on PATH\n' >&2
+  exit 1
+fi
+
+if [ -z "${PREFIX:-}" ] || [ "$PREFIX" = "/bin" ]; then
+  printf 'error: could not resolve install prefix; set PREFIX or GOPATH\n' >&2
+  exit 1
+fi
+
+mkdir -p "$PREFIX"
+
+printf '==> building loveliness-mcp\n'
+( cd "$REPO" && CGO_ENABLED=0 go build -o "$PREFIX/loveliness-mcp" ./cmd/loveliness-mcp )
+printf '    installed: %s/loveliness-mcp\n' "$PREFIX"
+
+if [ "$want_register" = 1 ]; then
+  if command -v claude >/dev/null 2>&1; then
+    printf '==> registering MCP server with Claude\n'
+    # `claude mcp add` is idempotent in recent CLI versions; if it isn't,
+    # remove first to avoid a duplicate-name error.
+    claude mcp remove loveliness >/dev/null 2>&1 || true
+    if [ -n "${LOVELINESS_TOKEN:-}" ]; then
+      claude mcp add loveliness \
+        --env "LOVELINESS_URL=$LOVELINESS_URL" \
+        --env "LOVELINESS_TOKEN=$LOVELINESS_TOKEN" \
+        -- "$PREFIX/loveliness-mcp"
+    else
+      claude mcp add loveliness \
+        --env "LOVELINESS_URL=$LOVELINESS_URL" \
+        -- "$PREFIX/loveliness-mcp"
+    fi
+    printf '    registered as `loveliness` (URL=%s)\n' "$LOVELINESS_URL"
+  else
+    cat <<EOF
+==> claude CLI not found; skipping auto-register
+    Add this to your MCP client config manually:
+
+    {
+      "mcpServers": {
+        "loveliness": {
+          "command": "$PREFIX/loveliness-mcp",
+          "env": { "LOVELINESS_URL": "$LOVELINESS_URL" }
+        }
+      }
+    }
+EOF
+  fi
+else
+  printf '==> skipping MCP registration (--no-register)\n'
+fi
+
+if [ "$want_skill" = 1 ]; then
+  SKILL_SRC="$REPO/skills/loveliness"
+  SKILL_DST="${HOME}/.claude/skills/loveliness"
+  if [ ! -d "$SKILL_SRC" ]; then
+    printf '==> skill source missing at %s; skipping\n' "$SKILL_SRC"
+  else
+    printf '==> installing skill to %s\n' "$SKILL_DST"
+    mkdir -p "$(dirname "$SKILL_DST")"
+    rm -rf "$SKILL_DST"
+    # Symlink rather than copy so updates from `git pull` flow through.
+    ln -s "$SKILL_SRC" "$SKILL_DST"
+    printf '    linked: %s -> %s\n' "$SKILL_DST" "$SKILL_SRC"
+  fi
+else
+  printf '==> skipping skill install (--no-skill)\n'
+fi
+
+printf '\nDone. Restart your MCP client (e.g. Claude Code) to pick up the new server.\n'

--- a/skills/loveliness/SKILL.md
+++ b/skills/loveliness/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: loveliness
+description: Query, write, and introspect a Loveliness graph database through its MCP server. Triggers when the user asks to run Cypher against Loveliness, load CSV data into the graph, inspect node/edge tables, check shard or cluster health, or otherwise drive a Loveliness cluster from an LLM. Also triggers on phrases like "loveliness query", "loveliness schema", "load nodes into loveliness", "loveliness cluster status", or any Cypher-shaped task targeted at a graph called Loveliness.
+---
+
+# Loveliness
+
+Loveliness is a clustered graph database with a Cypher query layer. This skill drives it through the `loveliness` MCP server (run by `loveliness-mcp` or `loveliness mcp`).
+
+## Tools
+
+Read-only:
+
+- `schema` — node + edge tables with property names, types, and primary keys. Cached 30s.
+- `cypher_read` — run a Cypher read query. Rejects writes (`CREATE`/`MERGE`/`SET`/`DELETE`/`DROP`/`REMOVE`/`LOAD`/`COPY`/`ALTER`/`DETACH`) and mutating `CALL` procedures.
+- `cluster_status` — leader, peers, per-shard assignment, registered schema.
+
+Write (skipped when the server is launched with `--readonly`):
+
+- `cypher_write` — Cypher writes / DDL.
+- `bulk_nodes`, `bulk_edges` — synchronous CSV load. Provide either inline `csv_data` or a host-readable `csv_path`.
+- `ingest_nodes`, `ingest_edges` — async CSV load. Returns a `job_id` to poll with `ingest_status`.
+
+Resources (read-only blobs the client can fetch directly):
+
+- `loveliness://schema` — same payload as `schema`.
+- `loveliness://cluster` — same payload as `cluster_status`.
+
+## Working pattern
+
+1. **Always run `schema` first.** Tool descriptions don't tell you what tables exist. The schema cache makes this cheap (30s).
+2. **Use `params`, not string interpolation.** The `query` field accepts `$name` placeholders that map to the `params` object. Loveliness inlines parameters as escaped Cypher literals, so user-controlled strings stay safely quoted. Don't build queries with string concatenation.
+3. **Pick the right write tool:**
+   - One-off mutation: `cypher_write`.
+   - Synchronous CSV ≤100K rows: `bulk_nodes` / `bulk_edges`.
+   - Async / large CSV: `ingest_nodes` / `ingest_edges`, then poll `ingest_status` every few seconds until the job is `done`.
+4. **When something fails:** call `cluster_status` first. A `503` or "shard unavailable" error usually means a peer is down or the shard map is mid-rebalance.
+
+## Common shapes
+
+Read by primary key:
+
+```cypher
+MATCH (p:Person {name: $name}) RETURN p
+```
+With `params: {"name": "Alice"}`.
+
+Write a node:
+
+```cypher
+CREATE (p:Person {name: $name, age: $age}) RETURN p
+```
+
+Bulk-load nodes (synchronous):
+
+```
+bulk_nodes(table="Person", csv_data="name,age\nAlice,30\nBob,25\n")
+```
+
+Async edge load:
+
+```
+ingest_edges(rel_table="KNOWS", from_table="Person", to_table="Person", csv_path="/data/knows.csv")
+→ {"job_id": "abc123", "status": "queued"}
+
+ingest_status(job_id="abc123")
+→ {"job": {"status": "running", "loaded": 1200000, ...}}
+```
+
+## Common errors
+
+- `cypher parse error` — Cypher didn't parse. Re-read `schema` to confirm table/column names; LadybugDB is case-sensitive.
+- `cypher_read rejects write statements` — switch to `cypher_write`, or rephrase as a `MATCH ... RETURN` if you really meant a read.
+- `schema propagation in progress, retry` — another node is broadcasting a DDL change. Wait a moment and retry.
+- `shard unavailable` — call `cluster_status`; the peer for that shard is down or replaying.
+- `query exceeded timeout` — narrow the query (add `LIMIT`, tighter `WHERE`) or relaunch the server with a longer `--timeout`.
+
+## Don't
+
+- Don't paste user-controlled input into the `query` string. Use `params`.
+- Don't loop `ingest_status` faster than every 1–2 seconds — async ingest is throughput-oriented, not real-time.
+- Don't call `cypher_write` for bulk data. The bulk endpoints are an order of magnitude faster.
+- Don't call mutating `CALL` procedures (`drop_table`, `export_database`, …) through `cypher_read`; the server rejects them. Use `cypher_write` if you really intend a mutation.
+
+## Configuration
+
+The server is configured by env vars / flags at launch:
+
+- `LOVELINESS_URL` (default `http://localhost:8080`)
+- `LOVELINESS_TOKEN` — bearer token for auth-enabled clusters
+- `LOVELINESS_TIMEOUT` (default `30s`)
+- `LOVELINESS_READONLY=true` — register read-only tools only
+
+These are set in the MCP client config (e.g. `~/.claude.json`), not at tool-call time.

--- a/test/mcp/e2e_test.go
+++ b/test/mcp/e2e_test.go
@@ -1,0 +1,164 @@
+//go:build integration
+// +build integration
+
+// Package mcp_test spins up a real single-node Loveliness cluster and a
+// real loveliness-mcp subprocess wired to it, then drives the MCP server
+// with an in-process MCP Go client via CommandTransport.
+//
+// Run with:
+//
+//	go test -tags=integration ./test/mcp/...
+//
+// Requires LadybugDB to be installed locally (CGO build of `loveliness`).
+package mcp_test
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// buildBinaries compiles loveliness and loveliness-mcp into a tempdir and
+// returns their absolute paths. Skips the test if the build fails.
+func buildBinaries(t *testing.T) (lovelinessBin, mcpBin string) {
+	t.Helper()
+	dir := t.TempDir()
+	lovelinessBin = filepath.Join(dir, "loveliness")
+	mcpBin = filepath.Join(dir, "loveliness-mcp")
+
+	build := func(out, pkg string, cgo string) {
+		cmd := exec.Command("go", "build", "-o", out, pkg)
+		cmd.Env = append(os.Environ(), "CGO_ENABLED="+cgo)
+		cmd.Dir = repoRoot(t)
+		if b, err := cmd.CombinedOutput(); err != nil {
+			t.Skipf("skipping: go build %s failed (LadybugDB likely not installed): %v\n%s", pkg, err, b)
+		}
+	}
+	build(lovelinessBin, "./cmd/loveliness", "1")
+	build(mcpBin, "./cmd/loveliness-mcp", "0")
+	return lovelinessBin, mcpBin
+}
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// test/mcp/ -> repo root is two levels up
+	return filepath.Clean(filepath.Join(wd, "..", ".."))
+}
+
+func TestMCPE2E(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in -short mode")
+	}
+
+	lovelinessBin, mcpBin := buildBinaries(t)
+
+	// Start a single-node Loveliness cluster.
+	dataDir := t.TempDir()
+	srv := exec.Command(lovelinessBin, "serve")
+	srv.Env = append(os.Environ(),
+		"LOVELINESS_NODE_ID=e2e-node",
+		"LOVELINESS_BIND_ADDR=127.0.0.1:18080",
+		"LOVELINESS_RAFT_ADDR=127.0.0.1:19000",
+		"LOVELINESS_GRPC_ADDR=127.0.0.1:19001",
+		"LOVELINESS_BOLT_ADDR=",
+		"LOVELINESS_DATA_DIR="+dataDir,
+		"LOVELINESS_SHARD_COUNT=1",
+		"LOVELINESS_BOOTSTRAP=true",
+	)
+	srv.Stdout = os.Stderr
+	srv.Stderr = os.Stderr
+	if err := srv.Start(); err != nil {
+		t.Fatalf("start loveliness: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = srv.Process.Signal(os.Interrupt)
+		_ = srv.Wait()
+	})
+
+	// Wait for the HTTP endpoint to accept a health probe.
+	waitUp(t, "http://127.0.0.1:18080/health", 30*time.Second)
+
+	// Start the MCP server and wire via CommandTransport.
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, mcpBin, "--url", "http://127.0.0.1:18080", "--timeout", "10s")
+	transport := &mcp.CommandTransport{Command: cmd}
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "e2e", Version: "0.0.1"}, nil)
+	cs, err := client.Connect(ctx, transport, nil)
+	if err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	t.Cleanup(func() { _ = cs.Close() })
+
+	// schema on an empty DB returns zero tables.
+	if _, err := cs.CallTool(ctx, &mcp.CallToolParams{Name: "schema"}); err != nil {
+		t.Fatalf("schema: %v", err)
+	}
+
+	// cypher_write: create a node table and insert a row.
+	if _, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "cypher_write",
+		Arguments: map[string]any{
+			"query": "CREATE NODE TABLE Person(name STRING, age INT64, PRIMARY KEY(name))",
+		},
+	}); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+	if _, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "cypher_write",
+		Arguments: map[string]any{
+			"query": "CREATE (p:Person {name: 'Alice', age: 30})",
+		},
+	}); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	// cypher_read: MATCH the row.
+	res, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "cypher_read",
+		Arguments: map[string]any{
+			"query": "MATCH (p:Person {name: 'Alice'}) RETURN p.age",
+		},
+	})
+	if err != nil {
+		t.Fatalf("match: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("match returned error: %v", res.Content)
+	}
+
+	// cluster_status: smoke.
+	if _, err := cs.CallTool(ctx, &mcp.CallToolParams{Name: "cluster_status"}); err != nil {
+		t.Fatalf("cluster_status: %v", err)
+	}
+}
+
+func waitUp(t *testing.T, url string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		resp, err := http.Get(url)
+		if err == nil {
+			io.Copy(io.Discard, resp.Body)
+			resp.Body.Close()
+			if resp.StatusCode < 500 {
+				return
+			}
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	t.Fatalf("server at %s did not come up in %s", url, timeout)
+}


### PR DESCRIPTION
## Summary
- New `loveliness-mcp` binary + `loveliness mcp` subcommand sharing `pkg/mcp.Server` over stdio JSON-RPC
- Tools: `cypher_read`/`cypher_write`, `schema` (30s cache), `bulk_nodes`/`bulk_edges`, `ingest_nodes`/`ingest_edges`/`ingest_status`, `cluster_status`; resources: `loveliness://schema`, `loveliness://cluster`
- Readonly mode, bearer auth, configurable URL/timeout via flag or env
- Docs (`docs/mcp.md`, README section), design spec, goreleaser + Makefile wiring

## Test plan
- [x] `go build ./cmd/loveliness-mcp ./pkg/mcp/...`
- [x] `go test ./pkg/mcp/...`
- [x] `go vet ./...`
- [ ] Smoke test against a live `loveliness up 1` via `claude mcp add loveliness -- loveliness-mcp`
- [ ] Verify tools list is non-empty in an MCP client

🤖 Generated with [Claude Code](https://claude.com/claude-code)