### PR TITLE
feat: ship Loveliness as a Claude Code plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,19 @@
+{
+  "name": "loveliness",
+  "description": "Loveliness graph database — local plugin marketplace",
+  "owner": {
+    "name": "Dreamware"
+  },
+  "plugins": [
+    {
+      "name": "loveliness",
+      "source": "./",
+      "category": "data",
+      "description": "MCP server + skill for the Loveliness clustered graph database (Cypher, bulk load, schema, cluster status)",
+      "version": "0.1.0",
+      "author": {
+        "name": "Dreamware"
+      }
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "loveliness",
+  "description": "MCP server + skill for the Loveliness clustered graph database",
+  "version": "0.1.0",
+  "author": {
+    "name": "Dreamware"
+  },
+  "skills": "./skills/"
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,7 @@
+{
+  "mcpServers": {
+    "loveliness": {
+      "command": "loveliness-mcp"
+    }
+  }
+}

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test run clean docker mcp install-mcp
+.PHONY: build test run clean docker mcp install-mcp install-plugin
 
 BINARY := loveliness
 MCP_BINARY := loveliness-mcp
@@ -19,6 +19,12 @@ mcp:
 # Pass FLAGS=... to forward args to the installer (e.g. --no-skill).
 install-mcp:
 	./scripts/install-mcp.sh $(FLAGS)
+
+# install-plugin builds loveliness-mcp into $GOBIN and registers this
+# repo as a Claude Code plugin marketplace, then installs the plugin at
+# user scope. Use this instead of install-mcp for plugin-style install.
+install-plugin:
+	./scripts/install-plugin.sh $(FLAGS)
 
 test:
 	go test ./pkg/... -v -count=1

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -11,7 +11,28 @@ running cluster via HTTP, and exposes a small opinionated tool surface.
 
 ## Install
 
-### One-shot installer
+### Claude Code plugin (recommended)
+
+```bash
+make install-plugin
+```
+
+This runs `scripts/install-plugin.sh`, which:
+
+1. Builds `loveliness-mcp` into `$GOBIN` (or `$(go env GOPATH)/bin`).
+2. Registers this repo as a Claude Code plugin marketplace
+   (`claude plugin marketplace add <repo>`).
+3. Installs the plugin at user scope
+   (`claude plugin install loveliness@loveliness --scope user`).
+
+The plugin ships `.claude-plugin/plugin.json`, `.mcp.json`, and the
+`skills/loveliness/` skill, so the MCP server and skill are visible
+from every Claude Code project after a restart.
+
+Pass `FLAGS=--no-build` to skip the Go build, or `FLAGS=--update` to
+refresh an already-registered marketplace.
+
+### One-shot MCP-only installer
 
 ```bash
 make install-mcp
@@ -30,6 +51,9 @@ This runs `scripts/install-mcp.sh`, which:
 Honors `LOVELINESS_URL` and `LOVELINESS_TOKEN` from the environment.
 Pass `FLAGS=--local` to register at project scope instead, or
 `FLAGS=--no-skill` / `FLAGS=--no-register` to skip steps.
+
+Use `install-plugin` if you want the same setup wrapped as a Claude
+Code plugin (single uninstall via `claude plugin uninstall`).
 
 ### Manual install
 

--- a/scripts/install-plugin.sh
+++ b/scripts/install-plugin.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env sh
+# install-plugin.sh — install loveliness as a Claude Code plugin.
+#
+# Builds loveliness-mcp into $GOBIN, registers this repo as a Claude
+# plugin marketplace, and installs the plugin at user scope so the MCP
+# server + skill are visible from every Claude Code project.
+#
+# Usage:
+#   ./scripts/install-plugin.sh              # install marketplace + plugin
+#   ./scripts/install-plugin.sh --no-build   # skip building loveliness-mcp
+#   ./scripts/install-plugin.sh --update     # update an already-installed marketplace
+#
+# Env:
+#   PREFIX  Where to install loveliness-mcp (default ${GOBIN:-$(go env GOPATH)/bin})
+#
+# Exit codes: 0 on success, 1 on failure, 2 on bad usage.
+
+set -eu
+
+want_build=1
+mode=add
+
+for arg; do
+  case "$arg" in
+    --no-build) want_build=0 ;;
+    --update)   mode=update ;;
+    -h|--help)
+      sed -n '2,15p' "$0"
+      exit 0
+      ;;
+    *)
+      printf 'unknown flag: %s\n' "$arg" >&2
+      exit 2
+      ;;
+  esac
+done
+
+repo_root() { cd "$(dirname "$0")/.." && pwd; }
+REPO="$(repo_root)"
+
+if ! command -v claude >/dev/null 2>&1; then
+  printf 'error: claude CLI not found on PATH — install Claude Code first\n' >&2
+  exit 1
+fi
+
+if [ "$want_build" = 1 ]; then
+  command -v go >/dev/null 2>&1 \
+    || { printf 'error: go toolchain not found on PATH\n' >&2; exit 1; }
+
+  PREFIX="${PREFIX:-${GOBIN:-$(go env GOPATH 2>/dev/null || printf '')/bin}}"
+  if [ -z "${PREFIX:-}" ] || [ "$PREFIX" = "/bin" ]; then
+    printf 'error: could not resolve install prefix; set PREFIX or GOPATH\n' >&2
+    exit 1
+  fi
+
+  mkdir -p "$PREFIX"
+  printf '==> building loveliness-mcp\n'
+  ( cd "$REPO" && CGO_ENABLED=0 go build -o "$PREFIX/loveliness-mcp" ./cmd/loveliness-mcp )
+  printf '    installed: %s/loveliness-mcp\n' "$PREFIX"
+
+  case ":$PATH:" in
+    *":$PREFIX:"*) ;;
+    *) printf '\nNOTE: %s is not on PATH. Add to your shell rc:\n  export PATH="%s:$PATH"\n\n' "$PREFIX" "$PREFIX" ;;
+  esac
+fi
+
+# Drop any standalone user-scope MCP registration so the plugin one isn't
+# shadowed or duplicated. Safe to ignore failures.
+claude mcp remove loveliness --scope user  >/dev/null 2>&1 || true
+claude mcp remove loveliness --scope local >/dev/null 2>&1 || true
+
+if [ "$mode" = update ]; then
+  printf '==> updating marketplace `loveliness`\n'
+  claude plugin marketplace update loveliness
+else
+  # `claude plugin marketplace add` errors if the marketplace name is already
+  # registered, so try update first when adding from this repo path.
+  if claude plugin marketplace list 2>/dev/null | grep -q '^[[:space:]]*❯[[:space:]]*loveliness$'; then
+    printf '==> marketplace `loveliness` already registered; updating\n'
+    claude plugin marketplace update loveliness
+  else
+    printf '==> registering marketplace `loveliness` from %s\n' "$REPO"
+    claude plugin marketplace add "$REPO"
+  fi
+fi
+
+printf '==> installing plugin loveliness@loveliness (scope=user)\n'
+claude plugin install loveliness@loveliness --scope user
+
+cat <<EOF
+
+Done. Restart your MCP client (e.g. Claude Code) so it picks up the
+plugin's MCP server. The \`loveliness-mcp\` binary must be on PATH.
+EOF


### PR DESCRIPTION
## Summary
- Add `.claude-plugin/marketplace.json`, `.claude-plugin/plugin.json`, and `.mcp.json` so Loveliness can be installed as a Claude Code plugin (mirroring the layout of dreamware-nz/memex).
- Add `scripts/install-plugin.sh` and a `make install-plugin` target that builds `loveliness-mcp`, registers this repo as a Claude marketplace, and installs the plugin at user scope.
- `make install-mcp` (existing path) stays as the lower-level alternative; docs updated accordingly.

## Test plan
- [x] `claude plugin validate .` → marketplace manifest passes
- [x] `./scripts/install-plugin.sh --no-build` registers marketplace + installs plugin at user scope on a clean machine
- [x] `claude plugin list` shows `loveliness@loveliness` enabled
- [x] `claude plugin marketplace list` shows the `loveliness` directory marketplace
- [ ] After Claude Code restart, plugin's MCP server starts and `tools/list` returns the 9 loveliness tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)