### PR TITLE
feat(annotations): first-class schema annotations with NL→Cypher hints

### DIFF
--- a/cmd/loveliness/main.go
+++ b/cmd/loveliness/main.go
@@ -202,6 +202,7 @@ func main() {
 		BackupMgr:    backupMgr,
 		WAL:          wal,
 		ReplicaState: replication.NewReplicaState(),
+		Snapshotter:  c, // *cluster.Cluster — forces a Raft snapshot before /backup archives
 	}
 
 	if cfg.S3Bucket != "" {
@@ -231,6 +232,7 @@ func main() {
 		sched := backup.NewScheduler(
 			backupMgr, dr.BackupStore, shards,
 			func() uint64 { return wal.LastSequence() },
+			c, // *cluster.Cluster implements backup.Snapshotter
 			time.Duration(cfg.BackupIntervalMin)*time.Minute,
 			cfg.BackupRetention,
 		)

--- a/docs/api.md
+++ b/docs/api.md
@@ -153,3 +153,38 @@ curl -s localhost:8080/join -d '{
   "join_token": "a1b2c3..."
 }'
 ```
+
+## Schema Annotations
+
+Schema annotations attach descriptions, parameterized query examples,
+and tags to schema elements. They are first-class state in the
+cluster — replicated through Raft alongside the shard map and the
+database catalog, and survive restart and snapshot.
+
+Targets follow a path-shaped scheme: `cluster`, `db:<name>`,
+`db:<name>/table:<name>`, `db:<name>/table:<name>/property:<name>`,
+`db:<name>/edge:<name>`, `db:<name>/saved_query:<id>`.
+
+```bash
+# List all annotations (optionally filter by prefix).
+curl -s 'localhost:8080/annotations?prefix=db:default/' | jq
+
+# Read a single annotation.
+curl -s 'localhost:8080/annotations/db:default/table:Person' | jq
+
+# Set an annotation. Latest-wins — the body replaces any existing one.
+# Must hit the leader.
+curl -s -X POST localhost:8080/annotations -H 'Content-Type: application/json' -d '{
+  "target": "db:default/table:Person",
+  "description": "People in the social graph. PII.",
+  "examples": [
+    {"title": "by name",
+     "query": "MATCH (p:Person {name: $name}) RETURN p",
+     "params": {"name": "Alice"}}
+  ],
+  "tags": ["core", "pii"]
+}'
+
+# Delete an annotation.
+curl -s -X DELETE 'localhost:8080/annotations/db:default/table:Person'
+```

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -243,6 +243,58 @@ errors).
 Return leader, peer list, per-shard assignment, and registered schema
 from `GET /cluster`. Always registered.
 
+### `list_annotations` / `get_annotation` / `set_annotation` / `delete_annotation` / `describe_schema`
+
+Schema annotations are first-class state in Loveliness, persisted
+through Raft alongside the shard map and database catalog. They hold
+the natural-language descriptions and parameterized query examples
+that bridge LLM intent to Cypher.
+
+Targets follow a path-shaped scheme:
+
+- `cluster`
+- `db:<name>`
+- `db:<name>/table:<name>` and `db:<name>/edge:<name>`
+- `db:<name>/table:<name>/property:<name>` and edge equivalent
+- `db:<name>/saved_query:<id>`
+
+`describe_schema` is the primary read tool — it joins the schema with
+all annotations for a database in one round trip:
+
+```jsonc
+{
+  "cluster":  { "target": "cluster",         "description": "..." },
+  "database": { "target": "db:default",      "description": "..." },
+  "node_tables": [
+    { "node_table": { "name": "Person", ... },
+      "annotation": { "description": "people", "examples": [...] } }
+  ],
+  "edge_tables": [...]
+}
+```
+
+`set_annotation` is gated by the same write protections as `cypher_write`
+(`--readonly` skips it). Latest-wins semantics: a SET replaces the
+entire body. The cluster auto-initializes the registry on first write.
+
+```jsonc
+// set_annotation
+{
+  "target": "db:default/table:Person",
+  "description": "People in the social graph. PII.",
+  "examples": [
+    { "title": "by name",
+      "query":  "MATCH (p:Person {name: $name}) RETURN p",
+      "params": {"name": "Alice"} }
+  ],
+  "tags": ["core", "pii"]
+}
+```
+
+The HTTP shape is `GET/POST/DELETE /annotations[/{target}]` with the
+target encoded directly into the path (slashes preserved by the
+`{target...}` route).
+
 ## Resources
 
 Two read-only resources, same payload as the equivalent tools:
@@ -254,11 +306,13 @@ Two read-only resources, same payload as the equivalent tools:
 
 Run with `--readonly` (or `LOVELINESS_READONLY=true`) to only register
 the read-only tools (`cypher_read`, `schema`, `cluster_status`,
-`list_databases`) and read-only resources. Mutating tools
+`list_databases`, `describe_schema`, `list_annotations`,
+`get_annotation`) and read-only resources. Mutating tools
 (`cypher_write`, `create_*`, `drop_*`, `start_*`, `stop_*`,
-`bulk_*`, `ingest_*`, `admin_cypher`) are not registered. Use this
-for CI analysis agents, or when the agent should be allowed to
-explore the graph but not mutate it.
+`bulk_*`, `ingest_*`, `admin_cypher`, `set_annotation`,
+`delete_annotation`) are not registered. Use this for CI analysis
+agents, or when the agent should be allowed to explore the graph but
+not mutate it.
 
 ```bash
 loveliness-mcp --readonly --url https://prod-cluster.internal

--- a/pkg/annotations/registry.go
+++ b/pkg/annotations/registry.go
@@ -1,0 +1,223 @@
+// Package annotations stores natural-language annotations attached to
+// schema elements: descriptions, query examples, and freeform tags.
+//
+// Annotations are a first-class part of the cluster's state — they're
+// replicated through the Raft FSM alongside the shard map and database
+// catalog, snapshotted, and restored on restart. They exist so an LLM
+// (or human) can ask "what does this database hold?" or "how do I
+// fetch X?" and get useful answers without the schema alone.
+//
+// Storage model: latest-wins, no version history. A SET on an existing
+// target replaces the entire annotation body.
+package annotations
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+// QueryExample is a parameterized query template attached to a target.
+// Query holds the template (typically Cypher with $param placeholders),
+// Params documents the expected parameters, Explanation describes what
+// the query does in human terms.
+type QueryExample struct {
+	Title       string         `json:"title,omitempty"`
+	Query       string         `json:"query"`
+	Params      map[string]any `json:"params,omitempty"`
+	Explanation string         `json:"explanation,omitempty"`
+}
+
+// Annotation is the body of metadata attached to a single target.
+// Tags are freeform strings (e.g. "pii", "wide", "deprecated"). Extra
+// holds arbitrary string-keyed values for callers that need to stash
+// structured side data without cluttering top-level fields.
+type Annotation struct {
+	Target      string            `json:"target"`
+	Description string            `json:"description,omitempty"`
+	Examples    []QueryExample    `json:"examples,omitempty"`
+	Tags        []string          `json:"tags,omitempty"`
+	Extra       map[string]string `json:"extra,omitempty"`
+	UpdatedAt   time.Time         `json:"updated_at"`
+}
+
+// targetSegment matches a single path segment after a "kind:" prefix.
+// We constrain to identifier-friendly characters so target strings can
+// be passed through URL paths and JSON without escaping concerns.
+var targetSegment = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_-]*$`)
+
+// ValidateTarget accepts these forms:
+//
+//	cluster
+//	db:<name>
+//	db:<name>/table:<name>
+//	db:<name>/table:<name>/property:<name>
+//	db:<name>/edge:<name>
+//	db:<name>/edge:<name>/property:<name>
+//	db:<name>/saved_query:<id>
+//
+// Returns the canonical target string (currently identical to the
+// input) on success, or an error describing the malformed segment.
+func ValidateTarget(target string) (string, error) {
+	if target == "" {
+		return "", fmt.Errorf("target is empty")
+	}
+	if target == "cluster" {
+		return target, nil
+	}
+	parts := strings.Split(target, "/")
+	for i, p := range parts {
+		kv := strings.SplitN(p, ":", 2)
+		if len(kv) != 2 {
+			return "", fmt.Errorf("segment %d %q: expected kind:name", i, p)
+		}
+		kind, name := kv[0], kv[1]
+		switch kind {
+		case "db", "table", "edge", "property", "saved_query":
+		default:
+			return "", fmt.Errorf("segment %d: unknown kind %q (allowed: db, table, edge, property, saved_query)", i, kind)
+		}
+		if !targetSegment.MatchString(name) {
+			return "", fmt.Errorf("segment %d: invalid name %q", i, name)
+		}
+	}
+	// Light structural rule: first segment must be db:* if not "cluster",
+	// property/edge/table/saved_query must come after a db.
+	if parts[0] == "cluster" {
+		// not reachable — already returned above
+	}
+	first := strings.SplitN(parts[0], ":", 2)[0]
+	if first != "db" {
+		return "", fmt.Errorf("first segment must be cluster or db:<name>, got %q", first)
+	}
+	return target, nil
+}
+
+// Registry is the in-memory store of annotations, replicated through
+// the Raft FSM. The Set/Delete methods do not themselves replicate;
+// callers (the FSM Apply path) call them once per Raft log entry.
+type Registry struct {
+	mu    sync.RWMutex
+	store map[string]Annotation
+}
+
+// New returns an empty registry.
+func New() *Registry {
+	return &Registry{store: make(map[string]Annotation)}
+}
+
+// Set replaces any existing annotation at target. UpdatedAt is set to
+// now if the caller left it zero; this lets the FSM Apply path stamp
+// a deterministic time when needed.
+func (r *Registry) Set(a Annotation) error {
+	target, err := ValidateTarget(a.Target)
+	if err != nil {
+		return err
+	}
+	a.Target = target
+	if a.UpdatedAt.IsZero() {
+		a.UpdatedAt = time.Now().UTC()
+	}
+	// Validate examples have non-empty query strings — examples with
+	// no query are useless to an LLM trying to learn from them.
+	for i, ex := range a.Examples {
+		if strings.TrimSpace(ex.Query) == "" {
+			return fmt.Errorf("examples[%d]: query is empty", i)
+		}
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.store[target] = a
+	return nil
+}
+
+// Get returns the annotation for target, or (zero, false) if absent.
+func (r *Registry) Get(target string) (Annotation, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	a, ok := r.store[target]
+	return a, ok
+}
+
+// Delete drops the annotation at target. Returns true if anything was
+// removed.
+func (r *Registry) Delete(target string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, ok := r.store[target]; !ok {
+		return false
+	}
+	delete(r.store, target)
+	return true
+}
+
+// List returns all annotations whose target starts with prefix, sorted
+// by target. An empty prefix returns everything.
+func (r *Registry) List(prefix string) []Annotation {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]Annotation, 0, len(r.store))
+	for k, v := range r.store {
+		if prefix != "" && !strings.HasPrefix(k, prefix) {
+			continue
+		}
+		out = append(out, v)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Target < out[j].Target })
+	return out
+}
+
+// Snapshot returns a deep copy suitable for Raft snapshotting.
+func (r *Registry) Snapshot() map[string]Annotation {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make(map[string]Annotation, len(r.store))
+	for k, v := range r.store {
+		out[k] = cloneAnnotation(v)
+	}
+	return out
+}
+
+// Restore replaces the registry contents from a snapshot.
+func (r *Registry) Restore(snap map[string]Annotation) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if snap == nil {
+		r.store = make(map[string]Annotation)
+		return
+	}
+	r.store = make(map[string]Annotation, len(snap))
+	for k, v := range snap {
+		r.store[k] = cloneAnnotation(v)
+	}
+}
+
+func cloneAnnotation(a Annotation) Annotation {
+	cp := a
+	if len(a.Examples) > 0 {
+		cp.Examples = make([]QueryExample, len(a.Examples))
+		for i, ex := range a.Examples {
+			cp.Examples[i] = ex
+			if len(ex.Params) > 0 {
+				cp.Examples[i].Params = make(map[string]any, len(ex.Params))
+				for k, v := range ex.Params {
+					cp.Examples[i].Params[k] = v
+				}
+			}
+		}
+	}
+	if len(a.Tags) > 0 {
+		cp.Tags = make([]string, len(a.Tags))
+		copy(cp.Tags, a.Tags)
+	}
+	if len(a.Extra) > 0 {
+		cp.Extra = make(map[string]string, len(a.Extra))
+		for k, v := range a.Extra {
+			cp.Extra[k] = v
+		}
+	}
+	return cp
+}

--- a/pkg/annotations/registry.go
+++ b/pkg/annotations/registry.go
@@ -61,6 +61,9 @@ var targetSegment = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_-]*$`)
 //
 // Returns the canonical target string (currently identical to the
 // input) on success, or an error describing the malformed segment.
+// Errors are position-aware: the allowed kinds at each position depend
+// on the preceding segment (e.g. "property" can only follow "table" or
+// "edge"), and the message lists exactly what's allowed there.
 func ValidateTarget(target string) (string, error) {
 	if target == "" {
 		return "", fmt.Errorf("target is empty")
@@ -69,31 +72,66 @@ func ValidateTarget(target string) (string, error) {
 		return target, nil
 	}
 	parts := strings.Split(target, "/")
-	for i, p := range parts {
-		kv := strings.SplitN(p, ":", 2)
-		if len(kv) != 2 {
-			return "", fmt.Errorf("segment %d %q: expected kind:name", i, p)
+
+	// Segment 0: must be db:<name>. ("cluster" alone is handled above.)
+	kind, name, err := splitSegment(parts[0])
+	if err != nil {
+		return "", fmt.Errorf("segment 0: %w", err)
+	}
+	if kind != "db" {
+		return "", fmt.Errorf(`segment 0: first segment must be "cluster" or "db:<name>", got kind %q`, kind)
+	}
+	if !targetSegment.MatchString(name) {
+		return "", fmt.Errorf("segment 0: invalid name %q", name)
+	}
+
+	// Subsequent segments — allowed kinds depend on the previous segment.
+	prev := "db"
+	for i := 1; i < len(parts); i++ {
+		kind, name, err := splitSegment(parts[i])
+		if err != nil {
+			return "", fmt.Errorf("segment %d: %w", i, err)
 		}
-		kind, name := kv[0], kv[1]
-		switch kind {
-		case "db", "table", "edge", "property", "saved_query":
-		default:
-			return "", fmt.Errorf("segment %d: unknown kind %q (allowed: db, table, edge, property, saved_query)", i, kind)
+		allowed, ok := allowedAfter[prev]
+		if !ok {
+			return "", fmt.Errorf("segment %d: nothing can follow kind %q", i, prev)
+		}
+		if !contains(allowed, kind) {
+			return "", fmt.Errorf("segment %d: kind %q not allowed after %q (allowed: %s)",
+				i, kind, prev, strings.Join(allowed, ", "))
 		}
 		if !targetSegment.MatchString(name) {
 			return "", fmt.Errorf("segment %d: invalid name %q", i, name)
 		}
-	}
-	// Light structural rule: first segment must be db:* if not "cluster",
-	// property/edge/table/saved_query must come after a db.
-	if parts[0] == "cluster" {
-		// not reachable — already returned above
-	}
-	first := strings.SplitN(parts[0], ":", 2)[0]
-	if first != "db" {
-		return "", fmt.Errorf("first segment must be cluster or db:<name>, got %q", first)
+		prev = kind
 	}
 	return target, nil
+}
+
+// allowedAfter encodes which kinds can follow each preceding kind.
+// Terminal kinds (saved_query, property) are absent here so any
+// extension produces a clear "nothing can follow kind …" error.
+var allowedAfter = map[string][]string{
+	"db":    {"table", "edge", "saved_query"},
+	"table": {"property"},
+	"edge":  {"property"},
+}
+
+func splitSegment(p string) (kind, name string, err error) {
+	kv := strings.SplitN(p, ":", 2)
+	if len(kv) != 2 {
+		return "", "", fmt.Errorf("expected kind:name, got %q", p)
+	}
+	return kv[0], kv[1], nil
+}
+
+func contains(xs []string, s string) bool {
+	for _, x := range xs {
+		if x == s {
+			return true
+		}
+	}
+	return false
 }
 
 // Registry is the in-memory store of annotations, replicated through

--- a/pkg/annotations/registry_test.go
+++ b/pkg/annotations/registry_test.go
@@ -23,16 +23,38 @@ func TestValidateTarget(t *testing.T) {
 
 	bad := []string{
 		"",
-		"table:Person",                // first segment must be db: or cluster
-		"db:default/Person",           // missing kind:
-		"db:default/widget:Foo",       // unknown kind
-		"db:default/table:Person; --", // injection-shaped name
-		"db:/table:Person",            // empty db name
-		"db:default/table:",           // empty table name
+		"table:Person",                              // first segment must be db: or cluster
+		"db:default/Person",                         // missing kind:
+		"db:default/widget:Foo",                     // unknown kind after db
+		"db:default/table:Person; --",               // injection-shaped name
+		"db:/table:Person",                          // empty db name
+		"db:default/table:",                         // empty table name
+		"db:default/property:age",                   // property must follow table or edge
+		"db:default/saved_query:foo/property:bar",   // nothing follows saved_query
+		"db:default/table:Person/saved_query:foo",   // saved_query only follows db
+		"db:default/table:Person/property:age/x:y",  // nothing follows property
 	}
 	for _, target := range bad {
 		if _, err := ValidateTarget(target); err == nil {
 			t.Errorf("ValidateTarget(%q) accepted, expected error", target)
+		}
+	}
+
+	// Spot-check that the error message points at the right position
+	// and lists what's actually allowed there, instead of the global set.
+	cases := map[string]string{
+		"wrongprefix:foo":            `segment 0: first segment must be "cluster" or "db:<name>", got kind "wrongprefix"`,
+		"db:default/widget:Foo":      `segment 1: kind "widget" not allowed after "db" (allowed: table, edge, saved_query)`,
+		"db:default/property:age":    `segment 1: kind "property" not allowed after "db" (allowed: table, edge, saved_query)`,
+	}
+	for target, want := range cases {
+		_, err := ValidateTarget(target)
+		if err == nil {
+			t.Errorf("ValidateTarget(%q) accepted, expected error", target)
+			continue
+		}
+		if err.Error() != want {
+			t.Errorf("ValidateTarget(%q) error = %q, want %q", target, err.Error(), want)
 		}
 	}
 }

--- a/pkg/annotations/registry_test.go
+++ b/pkg/annotations/registry_test.go
@@ -1,0 +1,150 @@
+package annotations
+
+import (
+	"testing"
+	"time"
+)
+
+func TestValidateTarget(t *testing.T) {
+	ok := []string{
+		"cluster",
+		"db:default",
+		"db:default/table:Person",
+		"db:default/table:Person/property:age",
+		"db:default/edge:KNOWS",
+		"db:default/edge:KNOWS/property:since",
+		"db:my-db_2/saved_query:topFollowers",
+	}
+	for _, target := range ok {
+		if _, err := ValidateTarget(target); err != nil {
+			t.Errorf("ValidateTarget(%q) err: %v", target, err)
+		}
+	}
+
+	bad := []string{
+		"",
+		"table:Person",                // first segment must be db: or cluster
+		"db:default/Person",           // missing kind:
+		"db:default/widget:Foo",       // unknown kind
+		"db:default/table:Person; --", // injection-shaped name
+		"db:/table:Person",            // empty db name
+		"db:default/table:",           // empty table name
+	}
+	for _, target := range bad {
+		if _, err := ValidateTarget(target); err == nil {
+			t.Errorf("ValidateTarget(%q) accepted, expected error", target)
+		}
+	}
+}
+
+func TestRegistrySetGetDelete(t *testing.T) {
+	r := New()
+	a := Annotation{
+		Target:      "db:default/table:Person",
+		Description: "people in the social graph",
+		Examples: []QueryExample{
+			{Title: "by name", Query: "MATCH (p:Person {name: $n}) RETURN p", Params: map[string]any{"n": "Alice"}},
+		},
+		Tags: []string{"core"},
+	}
+	if err := r.Set(a); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	got, ok := r.Get("db:default/table:Person")
+	if !ok {
+		t.Fatal("get: not found")
+	}
+	if got.Description != a.Description || len(got.Examples) != 1 || got.UpdatedAt.IsZero() {
+		t.Fatalf("unexpected annotation: %+v", got)
+	}
+
+	// Latest-wins: a second Set replaces the body entirely.
+	if err := r.Set(Annotation{Target: a.Target, Description: "updated"}); err != nil {
+		t.Fatalf("re-set: %v", err)
+	}
+	got, _ = r.Get(a.Target)
+	if got.Description != "updated" || len(got.Examples) != 0 {
+		t.Fatalf("latest-wins broken: %+v", got)
+	}
+
+	if !r.Delete(a.Target) {
+		t.Fatal("delete returned false on present key")
+	}
+	if _, ok := r.Get(a.Target); ok {
+		t.Fatal("get after delete returned ok")
+	}
+}
+
+func TestRegistryListPrefix(t *testing.T) {
+	r := New()
+	for _, tgt := range []string{
+		"db:default/table:Person",
+		"db:default/table:Movie",
+		"db:default/edge:KNOWS",
+		"db:other/table:Person",
+		"cluster",
+	} {
+		if err := r.Set(Annotation{Target: tgt, Description: tgt}); err != nil {
+			t.Fatalf("set %q: %v", tgt, err)
+		}
+	}
+
+	all := r.List("")
+	if len(all) != 5 {
+		t.Fatalf("expected 5 entries, got %d", len(all))
+	}
+	if all[0].Target != "cluster" {
+		t.Errorf("expected cluster first (sorted): %v", all[0].Target)
+	}
+
+	defaultDB := r.List("db:default/")
+	if len(defaultDB) != 3 {
+		t.Fatalf("expected 3 entries under db:default/, got %d", len(defaultDB))
+	}
+}
+
+func TestRegistryRejectsExampleWithoutQuery(t *testing.T) {
+	r := New()
+	err := r.Set(Annotation{
+		Target:   "db:default/table:Person",
+		Examples: []QueryExample{{Title: "broken"}},
+	})
+	if err == nil {
+		t.Fatal("expected error for example with no query")
+	}
+}
+
+func TestRegistrySnapshotRestore(t *testing.T) {
+	r := New()
+	stamp := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	a := Annotation{
+		Target:    "db:default/table:Person",
+		Tags:      []string{"core", "pii"},
+		Extra:     map[string]string{"owner": "data-team"},
+		Examples:  []QueryExample{{Query: "MATCH (p:Person) RETURN count(p)"}},
+		UpdatedAt: stamp,
+	}
+	if err := r.Set(a); err != nil {
+		t.Fatal(err)
+	}
+
+	snap := r.Snapshot()
+	r2 := New()
+	r2.Restore(snap)
+	got, ok := r2.Get(a.Target)
+	if !ok {
+		t.Fatal("not found in restored registry")
+	}
+	if got.UpdatedAt != stamp {
+		t.Errorf("timestamp lost: %v", got.UpdatedAt)
+	}
+	if got.Tags[1] != "pii" || got.Extra["owner"] != "data-team" {
+		t.Errorf("collections lost: %+v", got)
+	}
+
+	// Mutating the snapshot must not affect the source registry (deep copy).
+	snap[a.Target].Tags[0] = "TAMPERED"
+	if r.List("")[0].Tags[0] == "TAMPERED" {
+		t.Fatal("Snapshot did not deep-copy tags")
+	}
+}

--- a/pkg/api/annotations.go
+++ b/pkg/api/annotations.go
@@ -1,0 +1,102 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/johnjansen/loveliness/pkg/annotations"
+)
+
+// registerAnnotationRoutes attaches the /annotations endpoints to the
+// protected mux. Reads work on any node; writes must hit the leader so
+// they replicate through Raft.
+func (s *Server) registerAnnotationRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("GET /annotations", s.handleAnnotationsList)
+	mux.HandleFunc("GET /annotations/{target...}", s.handleAnnotationGet)
+	mux.HandleFunc("POST /annotations", s.handleAnnotationSet)
+	mux.HandleFunc("DELETE /annotations/{target...}", s.handleAnnotationDelete)
+}
+
+func (s *Server) handleAnnotationsList(w http.ResponseWriter, r *http.Request) {
+	if s.cluster == nil {
+		writeError(w, http.StatusServiceUnavailable, "NO_CLUSTER", "node is not part of a cluster", 0)
+		return
+	}
+	prefix := r.URL.Query().Get("prefix")
+	out := s.cluster.GetAnnotations().List(prefix)
+	writeJSON(w, http.StatusOK, map[string]any{"annotations": out})
+}
+
+func (s *Server) handleAnnotationGet(w http.ResponseWriter, r *http.Request) {
+	if s.cluster == nil {
+		writeError(w, http.StatusServiceUnavailable, "NO_CLUSTER", "node is not part of a cluster", 0)
+		return
+	}
+	target := r.PathValue("target")
+	if target == "" {
+		writeError(w, http.StatusBadRequest, "BAD_REQUEST", "missing target", 0)
+		return
+	}
+	a, ok := s.cluster.GetAnnotations().Get(target)
+	if !ok {
+		writeError(w, http.StatusNotFound, "NOT_FOUND", "no annotation for target "+target, 0)
+		return
+	}
+	writeJSON(w, http.StatusOK, a)
+}
+
+func (s *Server) handleAnnotationSet(w http.ResponseWriter, r *http.Request) {
+	if s.cluster == nil {
+		writeError(w, http.StatusServiceUnavailable, "NO_CLUSTER", "node is not part of a cluster", 0)
+		return
+	}
+	if !s.cluster.IsLeader() {
+		writeError(w, http.StatusBadRequest, "NOT_LEADER",
+			fmt.Sprintf("not the leader; leader is at %s", s.cluster.LeaderAddr()), 0)
+		return
+	}
+	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "BAD_REQUEST", "cannot read body: "+err.Error(), 0)
+		return
+	}
+	var a annotations.Annotation
+	if err := json.Unmarshal(body, &a); err != nil {
+		writeError(w, http.StatusBadRequest, "BAD_REQUEST", "invalid JSON body: "+err.Error(), 0)
+		return
+	}
+	if strings.TrimSpace(a.Target) == "" {
+		writeError(w, http.StatusBadRequest, "BAD_REQUEST", "target is required", 0)
+		return
+	}
+	if err := s.cluster.SetAnnotation(a); err != nil {
+		writeError(w, http.StatusBadRequest, "ANNOTATION_ERROR", err.Error(), 0)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok", "target": a.Target})
+}
+
+func (s *Server) handleAnnotationDelete(w http.ResponseWriter, r *http.Request) {
+	if s.cluster == nil {
+		writeError(w, http.StatusServiceUnavailable, "NO_CLUSTER", "node is not part of a cluster", 0)
+		return
+	}
+	if !s.cluster.IsLeader() {
+		writeError(w, http.StatusBadRequest, "NOT_LEADER",
+			fmt.Sprintf("not the leader; leader is at %s", s.cluster.LeaderAddr()), 0)
+		return
+	}
+	target := r.PathValue("target")
+	if target == "" {
+		writeError(w, http.StatusBadRequest, "BAD_REQUEST", "missing target", 0)
+		return
+	}
+	if err := s.cluster.DeleteAnnotation(target); err != nil {
+		writeError(w, http.StatusInternalServerError, "ANNOTATION_ERROR", err.Error(), 0)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": "deleted", "target": target})
+}

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -94,6 +94,7 @@ func (s *Server) Handler() http.Handler {
 	protected.HandleFunc("POST /join-token", s.handleJoinToken)
 	s.registerDRRoutes(protected)
 	s.registerIngestRoutes(protected)
+	s.registerAnnotationRoutes(protected)
 
 	// Multi-database scoped routes.
 	protected.HandleFunc("POST /db/{name}/cypher", s.handleCypherScoped)

--- a/pkg/api/dr.go
+++ b/pkg/api/dr.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"os"
+	"time"
 
 	"github.com/johnjansen/loveliness/pkg/backup"
 	"github.com/johnjansen/loveliness/pkg/replication"
@@ -14,8 +16,9 @@ type DRExtension struct {
 	BackupMgr    *backup.Manager
 	WAL          *replication.WAL
 	ReplicaState *replication.ReplicaState
-	BackupStore  backup.BackupStore // S3 or local backup storage
-	Scheduler    *backup.Scheduler  // periodic backup scheduler
+	BackupStore  backup.BackupStore  // S3 or local backup storage
+	Scheduler    *backup.Scheduler   // periodic backup scheduler
+	Snapshotter  backup.Snapshotter  // forces a Raft snapshot before backup; optional
 }
 
 // SetDR attaches DR capabilities to the server.
@@ -53,7 +56,7 @@ func (s *Server) handleBackup(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/gzip")
 	w.Header().Set("Content-Disposition", "attachment; filename=loveliness-backup.tar.gz")
 
-	manifest, err := s.dr.BackupMgr.CreateBackup(w, s.shards, walSeq)
+	manifest, err := s.dr.BackupMgr.CreateBackup(w, s.shards, walSeq, s.dr.Snapshotter)
 	if err != nil {
 		slog.Error("backup failed", "err", err)
 		return
@@ -65,10 +68,25 @@ func (s *Server) handleBackup(w http.ResponseWriter, r *http.Request) {
 
 // handleRestore accepts a compressed tar archive and restores shard data.
 // POST /restore (Content-Type: application/gzip)
+//
+// This is a destructive admin operation. Each shard's Kuzu store is
+// closed before extraction so it cannot checkpoint stale in-memory
+// state on top of the restored files; the process then exits, leaving
+// the operator to restart the server, at which point Kuzu re-opens
+// the restored files cleanly.
 func (s *Server) handleRestore(w http.ResponseWriter, r *http.Request) {
 	if s.dr == nil || s.dr.BackupMgr == nil {
 		writeError(w, http.StatusServiceUnavailable, "NO_DR", "backup not configured", 0)
 		return
+	}
+
+	// Close every shard's Kuzu store first. Otherwise Kuzu still owns
+	// the shard files and would overwrite the freshly restored bytes
+	// on shutdown — the schema and data we just unpacked would be lost.
+	for _, sh := range s.shards {
+		if err := sh.Close(); err != nil {
+			slog.Warn("restore: shard close failed", "shard", sh.ID, "err", err)
+		}
 	}
 
 	manifest, err := s.dr.BackupMgr.RestoreBackup(r.Body)
@@ -82,8 +100,19 @@ func (s *Server) handleRestore(w http.ResponseWriter, r *http.Request) {
 		"shards":       manifest.ShardCount,
 		"wal_sequence": manifest.WALSequence,
 		"created_at":   manifest.CreatedAt,
-		"note":         "restart the server to load restored data",
+		"note":         "shards closed; server is exiting — restart to load restored data",
 	})
+
+	// Flush response, then exit — re-using the in-memory FSM/Raft state
+	// alongside freshly-restored on-disk state is unsafe.
+	if f, ok := w.(http.Flusher); ok {
+		f.Flush()
+	}
+	go func() {
+		time.Sleep(200 * time.Millisecond)
+		slog.Info("restore complete; exiting for operator restart")
+		os.Exit(0)
+	}()
 }
 
 // handleBackupToStore creates a backup and stores it in the configured backup store (S3 or local).

--- a/pkg/backup/backup.go
+++ b/pkg/backup/backup.go
@@ -9,19 +9,39 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/johnjansen/loveliness/pkg/shard"
 )
 
 // Manifest describes the contents of a backup archive.
+//
+// Version 1: shard files + Loveliness WAL only.
+// Version 2: also includes Kuzu per-shard WAL files (shard-N.wal) and
+//
+//	the Raft directory (raft/...) — without these, the FSM
+//	state (database catalog, shard map, schema annotations)
+//	and any unflushed Kuzu writes are lost on restore.
 type Manifest struct {
-	Version     int       `json:"version"`
-	CreatedAt   time.Time `json:"created_at"`
-	NodeID      string    `json:"node_id"`
-	ShardCount  int       `json:"shard_count"`
-	WALSequence uint64    `json:"wal_sequence"`
+	Version     int         `json:"version"`
+	CreatedAt   time.Time   `json:"created_at"`
+	NodeID      string      `json:"node_id"`
+	ShardCount  int         `json:"shard_count"`
+	WALSequence uint64      `json:"wal_sequence"`
 	Shards      []ShardInfo `json:"shards"`
+	// IncludesRaft is true when the archive carries the FSM state.
+	// Restored archives without it will come up with an empty FSM —
+	// useful only as a data-only restore.
+	IncludesRaft bool `json:"includes_raft,omitempty"`
+}
+
+// Snapshotter is anything that can flush the Raft FSM to disk before
+// the backup pipeline archives the raft/ directory. The Cluster type
+// implements this; a nil Snapshotter is allowed (skips the explicit
+// snapshot — Raft's own snapshot store is still archived as-is).
+type Snapshotter interface {
+	TakeSnapshot() error
 }
 
 // ShardInfo describes a single shard in a backup.
@@ -41,16 +61,31 @@ func NewManager(dataDir, nodeID string) *Manager {
 	return &Manager{dataDir: dataDir, nodeID: nodeID}
 }
 
-// CreateBackup creates a compressed tar archive of all shard databases and WAL
-// files. Shards are quiesced (exclusive query lock) during the copy to ensure
-// a consistent snapshot. The archive is written to the given writer.
-func (m *Manager) CreateBackup(w io.Writer, shards []*shard.Shard, walSeq uint64) (*Manifest, error) {
+// CreateBackup creates a compressed tar archive of the cluster's
+// durable state: each shard's main database file and its Kuzu WAL,
+// the Loveliness replication WAL, and the Raft directory (FSM
+// snapshot + log). Pass a non-nil snap to force a fresh FSM snapshot
+// before archiving — recommended for any cluster that mutates state
+// faster than the Raft snapshot threshold. The archive is written to
+// the given writer.
+func (m *Manager) CreateBackup(w io.Writer, shards []*shard.Shard, walSeq uint64, snap Snapshotter) (*Manifest, error) {
 	manifest := &Manifest{
-		Version:     1,
+		Version:     2,
 		CreatedAt:   time.Now(),
 		NodeID:      m.nodeID,
 		ShardCount:  len(shards),
 		WALSequence: walSeq,
+	}
+
+	// Force a Raft snapshot first so the snapshot store contains the
+	// latest FSM state — without this, a quiet cluster archives only
+	// the BoltDB log, and Restore has to replay every command.
+	if snap != nil {
+		if err := snap.TakeSnapshot(); err != nil {
+			slog.Warn("backup: raft snapshot failed", "err", err)
+			// Continue — the existing snapshot store + log still get
+			// archived, which is enough for most cases.
+		}
 	}
 
 	gw := gzip.NewWriter(w)
@@ -58,18 +93,22 @@ func (m *Manager) CreateBackup(w io.Writer, shards []*shard.Shard, walSeq uint64
 	tw := tar.NewWriter(gw)
 	defer func() { _ = tw.Close() }()
 
-	// Snapshot each shard database file.
+	// Snapshot each shard database. Kuzu uses two files per shard:
+	// `shard-N` (main DB) and `shard-N.wal` (its own WAL). Both are
+	// required — restoring just the main file silently loses every
+	// write made since the last Kuzu checkpoint, including schema DDL.
 	for _, s := range shards {
-		shardPath := filepath.Join(m.dataDir, fmt.Sprintf("shard-%d", s.ID))
+		shardName := fmt.Sprintf("shard-%d", s.ID)
+		shardPath := filepath.Join(m.dataDir, shardName)
 
-		// Quiesce the shard by running a no-op read query — this ensures any
-		// in-flight writes complete. LadybugDB flushes on transaction commit,
-		// so after this returns, the file on disk is consistent.
+		// Quiesce the shard with a no-op read so any in-flight writes
+		// complete. Kuzu commits flush to the WAL synchronously, so
+		// once this returns, both files on disk are consistent.
 		if _, err := s.Query("RETURN 1"); err != nil {
 			slog.Warn("backup: quiesce query failed", "shard", s.ID, "err", err)
 		}
 
-		info, err := addFileToTar(tw, shardPath, fmt.Sprintf("shard-%d", s.ID))
+		info, err := addFileToTar(tw, shardPath, shardName)
 		if err != nil {
 			return nil, fmt.Errorf("backup shard %d: %w", s.ID, err)
 		}
@@ -77,10 +116,19 @@ func (m *Manager) CreateBackup(w io.Writer, shards []*shard.Shard, walSeq uint64
 			ID:        s.ID,
 			SizeBytes: info,
 		})
+
+		// Kuzu WAL — best-effort, may be absent on a freshly checkpointed shard.
+		walName := shardName + ".wal"
+		walPath := filepath.Join(m.dataDir, walName)
+		if _, err := os.Stat(walPath); err == nil {
+			if _, err := addFileToTar(tw, walPath, walName); err != nil {
+				return nil, fmt.Errorf("backup shard %d wal: %w", s.ID, err)
+			}
+		}
 		slog.Info("backup: shard archived", "shard", s.ID, "size", info)
 	}
 
-	// Include WAL files if they exist.
+	// Loveliness replication WAL.
 	walDir := filepath.Join(m.dataDir, "wal")
 	if entries, err := filepath.Glob(filepath.Join(walDir, "wal-shard-*.log")); err == nil {
 		for _, walPath := range entries {
@@ -89,6 +137,16 @@ func (m *Manager) CreateBackup(w io.Writer, shards []*shard.Shard, walSeq uint64
 				slog.Warn("backup: WAL file failed", "path", walPath, "err", err)
 			}
 		}
+	}
+
+	// Raft directory: snapshot store + bolt log. This carries the FSM
+	// state — shard map, database catalog, schema annotations.
+	raftDir := filepath.Join(m.dataDir, "raft")
+	if _, err := os.Stat(raftDir); err == nil {
+		if err := addDirToTar(tw, raftDir, "raft"); err != nil {
+			return nil, fmt.Errorf("backup raft dir: %w", err)
+		}
+		manifest.IncludesRaft = true
 	}
 
 	// Write manifest as the last entry.
@@ -109,7 +167,11 @@ func (m *Manager) CreateBackup(w io.Writer, shards []*shard.Shard, walSeq uint64
 }
 
 // RestoreBackup extracts a backup archive into the data directory.
-// The server must be stopped before calling this.
+// The server must be stopped before calling this. If the archive
+// includes a raft/ directory (manifest version >= 2), the existing
+// raft/ directory is wiped first to avoid stale FSM log entries
+// mixing with the restored snapshot — Raft cannot reconcile state
+// from two different lineages.
 func (m *Manager) RestoreBackup(r io.Reader) (*Manifest, error) {
 	gr, err := gzip.NewReader(r)
 	if err != nil {
@@ -118,6 +180,7 @@ func (m *Manager) RestoreBackup(r io.Reader) (*Manifest, error) {
 	defer func() { _ = gr.Close() }()
 	tr := tar.NewReader(gr)
 
+	cleanedRaft := false
 	var manifest *Manifest
 	for {
 		header, err := tr.Next()
@@ -128,7 +191,14 @@ func (m *Manager) RestoreBackup(r io.Reader) (*Manifest, error) {
 			return nil, fmt.Errorf("tar read: %w", err)
 		}
 
-		if header.Name == "manifest.json" {
+		// Path-traversal guard: reject absolute paths and anything that
+		// resolves outside the data dir.
+		clean := filepath.Clean(filepath.FromSlash(header.Name))
+		if filepath.IsAbs(clean) || strings.HasPrefix(clean, "..") {
+			return nil, fmt.Errorf("refusing tar entry with unsafe path: %q", header.Name)
+		}
+
+		if clean == "manifest.json" {
 			data, err := io.ReadAll(tr)
 			if err != nil {
 				return nil, fmt.Errorf("read manifest: %w", err)
@@ -140,8 +210,18 @@ func (m *Manager) RestoreBackup(r io.Reader) (*Manifest, error) {
 			continue
 		}
 
+		// First time we see a raft/ entry, wipe the existing dir so the
+		// restored snapshot/log doesn't get tangled with stale state.
+		if !cleanedRaft && strings.HasPrefix(clean, "raft"+string(filepath.Separator)) {
+			raftDir := filepath.Join(m.dataDir, "raft")
+			if err := os.RemoveAll(raftDir); err != nil {
+				return nil, fmt.Errorf("clean raft dir: %w", err)
+			}
+			cleanedRaft = true
+		}
+
 		// Extract file to data directory.
-		destPath := filepath.Join(m.dataDir, header.Name)
+		destPath := filepath.Join(m.dataDir, clean)
 		destDir := filepath.Dir(destPath)
 		if err := os.MkdirAll(destDir, 0750); err != nil {
 			return nil, fmt.Errorf("create dir for %s: %w", header.Name, err)
@@ -156,7 +236,7 @@ func (m *Manager) RestoreBackup(r io.Reader) (*Manifest, error) {
 			return nil, fmt.Errorf("write %s: %w", header.Name, err)
 		}
 		f.Close()
-		slog.Info("restore: extracted", "file", header.Name, "size", header.Size)
+		slog.Info("restore: extracted", "file", clean, "size", header.Size)
 	}
 
 	if manifest == nil {
@@ -191,4 +271,25 @@ func addFileToTar(tw *tar.Writer, srcPath, archiveName string) (int64, error) {
 		return 0, err
 	}
 	return stat.Size(), nil
+}
+
+// addDirToTar walks srcDir recursively, adding every regular file
+// found beneath it to the tar writer with paths rooted at archivePrefix.
+// Symlinks and special files are skipped.
+func addDirToTar(tw *tar.Writer, srcDir, archivePrefix string) error {
+	return filepath.Walk(srcDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.Mode().IsRegular() {
+			return nil
+		}
+		rel, err := filepath.Rel(srcDir, path)
+		if err != nil {
+			return err
+		}
+		archiveName := filepath.ToSlash(filepath.Join(archivePrefix, rel))
+		_, err = addFileToTar(tw, path, archiveName)
+		return err
+	})
 }

--- a/pkg/backup/backup_test.go
+++ b/pkg/backup/backup_test.go
@@ -28,22 +28,37 @@ func TestCreateAndRestoreBackup(t *testing.T) {
 		shard.NewShard(1, &mockStore{}, 1),
 	}
 
+	// Plant Kuzu-style WAL sidecars and a fake raft directory so the
+	// round-trip exercises every kind of file the backup is supposed to
+	// carry. Without this we'd only test the basic path.
+	for i := 0; i < 2; i++ {
+		walPath := filepath.Join(srcDir, "shard-"+string(rune('0'+i))+".wal")
+		os.WriteFile(walPath, []byte("kuzu-wal-"+string(rune('0'+i))), 0640)
+	}
+	raftDir := filepath.Join(srcDir, "raft")
+	os.MkdirAll(filepath.Join(raftDir, "snapshots", "snap1"), 0750)
+	os.WriteFile(filepath.Join(raftDir, "raft-log.bolt"), []byte("bolt-log"), 0640)
+	os.WriteFile(filepath.Join(raftDir, "snapshots", "snap1", "state.bin"), []byte("snap-state"), 0640)
+
 	// Create backup.
 	mgr := NewManager(srcDir, "test-node")
 	var buf bytes.Buffer
-	manifest, err := mgr.CreateBackup(&buf, shards, 42)
+	manifest, err := mgr.CreateBackup(&buf, shards, 42, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if manifest.Version != 1 {
-		t.Fatalf("expected version 1, got %d", manifest.Version)
+	if manifest.Version != 2 {
+		t.Fatalf("expected version 2, got %d", manifest.Version)
 	}
 	if manifest.ShardCount != 2 {
 		t.Fatalf("expected 2 shards, got %d", manifest.ShardCount)
 	}
 	if manifest.WALSequence != 42 {
 		t.Fatalf("expected wal seq 42, got %d", manifest.WALSequence)
+	}
+	if !manifest.IncludesRaft {
+		t.Fatalf("expected IncludesRaft=true, got false")
 	}
 
 	// Restore to destination.
@@ -56,7 +71,7 @@ func TestCreateAndRestoreBackup(t *testing.T) {
 		t.Fatalf("restored shard count: got %d want 2", restored.ShardCount)
 	}
 
-	// Verify files were extracted.
+	// Verify shard main file + Kuzu WAL sidecar were extracted.
 	for i := 0; i < 2; i++ {
 		path := filepath.Join(dstDir, "shard-"+string(rune('0'+i)))
 		data, err := os.ReadFile(path)
@@ -67,6 +82,57 @@ func TestCreateAndRestoreBackup(t *testing.T) {
 		if string(data) != expected {
 			t.Fatalf("shard-%d content mismatch: got %q want %q", i, data, expected)
 		}
+		walPath := path + ".wal"
+		walData, err := os.ReadFile(walPath)
+		if err != nil {
+			t.Fatalf("shard-%d.wal not restored: %v", i, err)
+		}
+		if string(walData) != "kuzu-wal-"+string(rune('0'+i)) {
+			t.Fatalf("shard-%d.wal content mismatch: got %q", i, walData)
+		}
+	}
+
+	// Verify the raft tree restored under the destination.
+	for _, rel := range []string{"raft/raft-log.bolt", "raft/snapshots/snap1/state.bin"} {
+		if _, err := os.Stat(filepath.Join(dstDir, rel)); err != nil {
+			t.Fatalf("%s not restored: %v", rel, err)
+		}
+	}
+}
+
+// TestRestoreWipesStaleRaft asserts the restore step removes any
+// pre-existing raft/ directory before extracting — otherwise stale FSM
+// log entries could mix with the restored snapshot.
+func TestRestoreWipesStaleRaft(t *testing.T) {
+	srcDir, _ := os.MkdirTemp("", "backup-src-*")
+	defer os.RemoveAll(srcDir)
+	dstDir, _ := os.MkdirTemp("", "backup-dst-*")
+	defer os.RemoveAll(dstDir)
+
+	// Source: minimal raft + one file inside it.
+	os.MkdirAll(filepath.Join(srcDir, "raft"), 0750)
+	os.WriteFile(filepath.Join(srcDir, "raft", "fresh.bin"), []byte("fresh"), 0640)
+	os.WriteFile(filepath.Join(srcDir, "shard-0"), []byte("s"), 0640)
+
+	// Destination: stale raft entry that must be removed during restore.
+	os.MkdirAll(filepath.Join(dstDir, "raft"), 0750)
+	os.WriteFile(filepath.Join(dstDir, "raft", "stale.bin"), []byte("stale"), 0640)
+
+	shards := []*shard.Shard{shard.NewShard(0, &mockStore{}, 1)}
+	mgr := NewManager(srcDir, "test-node")
+	var buf bytes.Buffer
+	if _, err := mgr.CreateBackup(&buf, shards, 0, nil); err != nil {
+		t.Fatal(err)
+	}
+	dst := NewManager(dstDir, "test-node")
+	if _, err := dst.RestoreBackup(&buf); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(dstDir, "raft", "stale.bin")); !os.IsNotExist(err) {
+		t.Fatalf("stale raft entry should be wiped during restore: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dstDir, "raft", "fresh.bin")); err != nil {
+		t.Fatalf("fresh raft entry not restored: %v", err)
 	}
 }
 

--- a/pkg/backup/scheduler.go
+++ b/pkg/backup/scheduler.go
@@ -16,6 +16,7 @@ type Scheduler struct {
 	store    BackupStore
 	shards   []*shard.Shard
 	walSeqFn func() uint64 // returns current WAL sequence
+	snap     Snapshotter   // optional — forces a Raft snapshot before each backup
 
 	interval  time.Duration
 	retention int // number of backups to keep
@@ -24,8 +25,10 @@ type Scheduler struct {
 	wg     sync.WaitGroup
 }
 
-// NewScheduler creates a backup scheduler.
-func NewScheduler(mgr *Manager, store BackupStore, shards []*shard.Shard, walSeqFn func() uint64, interval time.Duration, retention int) *Scheduler {
+// NewScheduler creates a backup scheduler. snap may be nil; when set,
+// each backup forces a Raft FSM snapshot before archiving so the
+// archived raft/ directory is current.
+func NewScheduler(mgr *Manager, store BackupStore, shards []*shard.Shard, walSeqFn func() uint64, snap Snapshotter, interval time.Duration, retention int) *Scheduler {
 	if retention < 1 {
 		retention = 3
 	}
@@ -34,6 +37,7 @@ func NewScheduler(mgr *Manager, store BackupStore, shards []*shard.Shard, walSeq
 		store:     store,
 		shards:    shards,
 		walSeqFn:  walSeqFn,
+		snap:      snap,
 		interval:  interval,
 		retention: retention,
 		stopCh:    make(chan struct{}),
@@ -76,7 +80,7 @@ func (s *Scheduler) runBackup() {
 	walSeq := s.walSeqFn()
 
 	var buf bytes.Buffer
-	manifest, err := s.mgr.CreateBackup(&buf, s.shards, walSeq)
+	manifest, err := s.mgr.CreateBackup(&buf, s.shards, walSeq, s.snap)
 	if err != nil {
 		slog.Error("scheduled backup failed", "err", err)
 		return
@@ -126,7 +130,7 @@ func (s *Scheduler) RunNow() (*Manifest, string, error) {
 	walSeq := s.walSeqFn()
 
 	var buf bytes.Buffer
-	manifest, err := s.mgr.CreateBackup(&buf, s.shards, walSeq)
+	manifest, err := s.mgr.CreateBackup(&buf, s.shards, walSeq, s.snap)
 	if err != nil {
 		return nil, "", err
 	}

--- a/pkg/backup/scheduler_test.go
+++ b/pkg/backup/scheduler_test.go
@@ -30,7 +30,7 @@ func TestSchedulerRunNow(t *testing.T) {
 	mgr := NewManager(dataDir, "test-node")
 	shards := setupTestShards(t, dataDir, 1)
 
-	sched := NewScheduler(mgr, store, shards, func() uint64 { return 42 }, time.Hour, 3)
+	sched := NewScheduler(mgr, store, shards, func() uint64 { return 42 }, nil, time.Hour, 3)
 
 	manifest, key, err := sched.RunNow()
 	if err != nil {
@@ -67,7 +67,7 @@ func TestSchedulerRetention(t *testing.T) {
 	mgr := NewManager(dataDir, "test-node")
 	shards := setupTestShards(t, dataDir, 1)
 
-	sched := NewScheduler(mgr, store, shards, func() uint64 { return 1 }, time.Hour, 3)
+	sched := NewScheduler(mgr, store, shards, func() uint64 { return 1 }, nil, time.Hour, 3)
 	_, _, err := sched.RunNow()
 	if err != nil {
 		t.Fatal("RunNow:", err)

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hashicorp/raft"
 	raftboltdb "github.com/hashicorp/raft-boltdb/v2"
+	"github.com/johnjansen/loveliness/pkg/annotations"
 	"github.com/johnjansen/loveliness/pkg/catalog"
 )
 
@@ -185,6 +186,32 @@ func (c *Cluster) RemoveTable(name string) error {
 // GetSchema returns the current schema keys from the FSM.
 func (c *Cluster) GetSchema() map[string]string {
 	return c.fsm.GetShardMap().SchemaKeys
+}
+
+// GetAnnotations returns the annotation registry. Reads go directly;
+// writes must go through SetAnnotation/DeleteAnnotation so they
+// replicate via Raft.
+func (c *Cluster) GetAnnotations() *annotations.Registry {
+	return c.fsm.GetAnnotations()
+}
+
+// SetAnnotation replicates an annotation write via Raft. Must be
+// called on the leader.
+func (c *Cluster) SetAnnotation(a annotations.Annotation) error {
+	if _, err := annotations.ValidateTarget(a.Target); err != nil {
+		return err
+	}
+	payload, err := json.Marshal(SetAnnotationPayload{Annotation: a})
+	if err != nil {
+		return fmt.Errorf("marshal annotation: %w", err)
+	}
+	return c.Apply(Command{Type: CmdSetAnnotation, Payload: payload})
+}
+
+// DeleteAnnotation replicates an annotation delete via Raft.
+func (c *Cluster) DeleteAnnotation(target string) error {
+	payload, _ := json.Marshal(DeleteAnnotationPayload{Target: target})
+	return c.Apply(Command{Type: CmdDeleteAnnotation, Payload: payload})
 }
 
 // SetSchemaCallback sets a callback that fires whenever schema state changes in the FSM.

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -266,3 +266,14 @@ func (c *Cluster) Shutdown() error {
 	f := c.raft.Shutdown()
 	return f.Error()
 }
+
+// TakeSnapshot forces Raft to write a fresh FSM snapshot to disk. The
+// backup pipeline calls this before archiving so that the snapshot
+// store under data/raft/ contains the latest FSM state — otherwise a
+// long-running cluster that hasn't tripped the snapshot threshold
+// would back up only the log, and Raft would have to replay it on
+// restore. Returns nil if the snapshot succeeds, an error otherwise.
+func (c *Cluster) TakeSnapshot() error {
+	f := c.raft.Snapshot()
+	return f.Error()
+}

--- a/pkg/cluster/fsm.go
+++ b/pkg/cluster/fsm.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"github.com/hashicorp/raft"
+	"github.com/johnjansen/loveliness/pkg/annotations"
 	"github.com/johnjansen/loveliness/pkg/catalog"
 )
 
@@ -49,6 +50,8 @@ const (
 	CmdStopDatabase
 	CmdStartDatabase
 	CmdDeleteDatabase
+	CmdSetAnnotation
+	CmdDeleteAnnotation
 )
 
 // Command is a Raft log entry.
@@ -102,6 +105,16 @@ type DatabaseNamePayload struct {
 	Name string `json:"name"`
 }
 
+// SetAnnotationPayload is the data for CmdSetAnnotation.
+type SetAnnotationPayload struct {
+	Annotation annotations.Annotation `json:"annotation"`
+}
+
+// DeleteAnnotationPayload is the data for CmdDeleteAnnotation.
+type DeleteAnnotationPayload struct {
+	Target string `json:"target"`
+}
+
 // ShardsForNode returns the shard IDs assigned to a node (as primary or replica).
 func (sm ShardMap) ShardsForNode(nodeID string) []int {
 	var ids []int
@@ -144,6 +157,7 @@ type FSM struct {
 	mu             sync.RWMutex
 	shardMap       ShardMap
 	catalog        *catalog.Catalog
+	annotations    *annotations.Registry
 	schemaCallback SchemaCallback
 }
 
@@ -155,13 +169,20 @@ func NewFSM() *FSM {
 			Nodes:       make(map[string]NodeInfo),
 			SchemaKeys:  make(map[string]string),
 		},
-		catalog: catalog.NewCatalog(),
+		catalog:     catalog.NewCatalog(),
+		annotations: annotations.New(),
 	}
 }
 
 // GetCatalog returns the catalog for reading database metadata.
 func (f *FSM) GetCatalog() *catalog.Catalog {
 	return f.catalog
+}
+
+// GetAnnotations returns the annotation registry for reading.
+// Writes go through the FSM via Apply.
+func (f *FSM) GetAnnotations() *annotations.Registry {
+	return f.annotations
 }
 
 // SetSchemaCallback sets a callback that fires whenever schema state changes.
@@ -307,6 +328,21 @@ func (f *FSM) Apply(log *raft.Log) interface{} {
 		}
 		return f.catalog.DeleteDatabase(p.Name)
 
+	case CmdSetAnnotation:
+		var p SetAnnotationPayload
+		if err := json.Unmarshal(cmd.Payload, &p); err != nil {
+			return fmt.Errorf("unmarshal set annotation: %w", err)
+		}
+		return f.annotations.Set(p.Annotation)
+
+	case CmdDeleteAnnotation:
+		var p DeleteAnnotationPayload
+		if err := json.Unmarshal(cmd.Payload, &p); err != nil {
+			return fmt.Errorf("unmarshal delete annotation: %w", err)
+		}
+		f.annotations.Delete(p.Target)
+		return nil
+
 	default:
 		return fmt.Errorf("unknown command type: %d", cmd.Type)
 	}
@@ -314,8 +350,9 @@ func (f *FSM) Apply(log *raft.Log) interface{} {
 
 // fsmState is the combined state serialized in Raft snapshots.
 type fsmState struct {
-	ShardMap ShardMap                `json:"shard_map"`
-	Catalog  catalog.CatalogSnapshot `json:"catalog"`
+	ShardMap    ShardMap                          `json:"shard_map"`
+	Catalog     catalog.CatalogSnapshot           `json:"catalog"`
+	Annotations map[string]annotations.Annotation `json:"annotations,omitempty"`
 }
 
 // Snapshot returns a snapshot of the FSM state for Raft snapshotting.
@@ -323,8 +360,9 @@ func (f *FSM) Snapshot() (raft.FSMSnapshot, error) {
 	f.mu.RLock()
 	defer f.mu.RUnlock()
 	state := fsmState{
-		ShardMap: f.shardMap,
-		Catalog:  f.catalog.Snapshot(),
+		ShardMap:    f.shardMap,
+		Catalog:     f.catalog.Snapshot(),
+		Annotations: f.annotations.Snapshot(),
 	}
 	data, err := json.Marshal(state)
 	if err != nil {
@@ -371,6 +409,9 @@ func (f *FSM) Restore(rc io.ReadCloser) error {
 	if state.Catalog.Databases != nil {
 		f.catalog.Restore(state.Catalog)
 	}
+
+	// Annotations are optional in older snapshots — Restore handles nil.
+	f.annotations.Restore(state.Annotations)
 
 	f.notifySchemaChange()
 	return nil

--- a/pkg/cluster/fsm_test.go
+++ b/pkg/cluster/fsm_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/raft"
+	"github.com/johnjansen/loveliness/pkg/annotations"
 )
 
 func applyCommand(fsm *FSM, cmd Command) interface{} {
@@ -410,6 +411,68 @@ func TestShardMap_PrimaryForShard(t *testing.T) {
 	}
 	if p := sm.PrimaryForShard(99); p != "" {
 		t.Errorf("expected empty for unknown shard, got %s", p)
+	}
+}
+
+func TestFSM_SetAndDeleteAnnotation(t *testing.T) {
+	fsm := NewFSM()
+
+	a := annotations.Annotation{
+		Target:      "db:default/table:Person",
+		Description: "people",
+		Examples: []annotations.QueryExample{
+			{Title: "by name", Query: "MATCH (p:Person {name: $n}) RETURN p"},
+		},
+	}
+	payload, _ := json.Marshal(SetAnnotationPayload{Annotation: a})
+	if result := applyCommand(fsm, Command{Type: CmdSetAnnotation, Payload: payload}); result != nil {
+		t.Fatalf("set: %v", result)
+	}
+
+	got, ok := fsm.GetAnnotations().Get(a.Target)
+	if !ok || got.Description != "people" {
+		t.Fatalf("annotation not stored: %+v ok=%v", got, ok)
+	}
+
+	payload, _ = json.Marshal(DeleteAnnotationPayload{Target: a.Target})
+	if result := applyCommand(fsm, Command{Type: CmdDeleteAnnotation, Payload: payload}); result != nil {
+		t.Fatalf("delete: %v", result)
+	}
+	if _, ok := fsm.GetAnnotations().Get(a.Target); ok {
+		t.Fatal("annotation still present after delete")
+	}
+}
+
+func TestFSM_AnnotationsSnapshotRestore(t *testing.T) {
+	fsm := NewFSM()
+
+	for _, target := range []string{"cluster", "db:default", "db:default/table:Person"} {
+		payload, _ := json.Marshal(SetAnnotationPayload{
+			Annotation: annotations.Annotation{Target: target, Description: target},
+		})
+		if r := applyCommand(fsm, Command{Type: CmdSetAnnotation, Payload: payload}); r != nil {
+			t.Fatalf("seed %s: %v", target, r)
+		}
+	}
+
+	snap, err := fsm.Snapshot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	sink := &mockSnapshotSink{}
+	if err := snap.Persist(sink); err != nil {
+		t.Fatal(err)
+	}
+
+	fsm2 := NewFSM()
+	if err := fsm2.Restore(sink.Reader()); err != nil {
+		t.Fatal(err)
+	}
+	if got := len(fsm2.GetAnnotations().List("")); got != 3 {
+		t.Fatalf("expected 3 annotations restored, got %d", got)
+	}
+	if a, ok := fsm2.GetAnnotations().Get("db:default/table:Person"); !ok || a.Description != "db:default/table:Person" {
+		t.Fatalf("annotation body lost: %+v ok=%v", a, ok)
 	}
 }
 

--- a/pkg/mcp/client.go
+++ b/pkg/mcp/client.go
@@ -215,6 +215,107 @@ func (c *Client) AdminCypher(ctx context.Context, query string) (map[string]any,
 	return out, nil
 }
 
+// AnnotationExample mirrors the server-side QueryExample without
+// taking a hard dependency on the cluster package. It is the shape
+// the MCP wire types use.
+type AnnotationExample struct {
+	Title       string         `json:"title,omitempty"`
+	Query       string         `json:"query"`
+	Params      map[string]any `json:"params,omitempty"`
+	Explanation string         `json:"explanation,omitempty"`
+}
+
+// Annotation is the MCP-side mirror of annotations.Annotation.
+type Annotation struct {
+	Target      string              `json:"target"`
+	Description string              `json:"description,omitempty"`
+	Examples    []AnnotationExample `json:"examples,omitempty"`
+	Tags        []string            `json:"tags,omitempty"`
+	Extra       map[string]string   `json:"extra,omitempty"`
+	UpdatedAt   string              `json:"updated_at,omitempty"`
+}
+
+// ListAnnotations calls GET /annotations[?prefix=...].
+func (c *Client) ListAnnotations(ctx context.Context, prefix string) ([]Annotation, error) {
+	path := "/annotations"
+	if prefix != "" {
+		// Light query-string escape: URL-encode the prefix value.
+		path += "?prefix=" + queryEscape(prefix)
+	}
+	body, err := c.get(ctx, path, nil)
+	if err != nil {
+		return nil, err
+	}
+	var out struct {
+		Annotations []Annotation `json:"annotations"`
+	}
+	if err := json.Unmarshal(body, &out); err != nil {
+		return nil, fmt.Errorf("annotations: decode response: %w", err)
+	}
+	return out.Annotations, nil
+}
+
+// GetAnnotation calls GET /annotations/{target}. Returns (nil, nil) if
+// the server responded 404 — callers can treat absence as a normal
+// state rather than an error.
+func (c *Client) GetAnnotation(ctx context.Context, target string) (*Annotation, error) {
+	body, err := c.get(ctx, "/annotations/"+target, nil)
+	if err != nil {
+		var he *HTTPError
+		if errors.As(err, &he) && he.Status == http.StatusNotFound {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var out Annotation
+	if err := json.Unmarshal(body, &out); err != nil {
+		return nil, fmt.Errorf("annotation: decode response: %w", err)
+	}
+	return &out, nil
+}
+
+// SetAnnotation calls POST /annotations.
+func (c *Client) SetAnnotation(ctx context.Context, a Annotation) error {
+	buf, err := json.Marshal(a)
+	if err != nil {
+		return fmt.Errorf("annotation: encode: %w", err)
+	}
+	_, err = c.post(ctx, "/annotations", "application/json", bytes.NewReader(buf), nil)
+	return err
+}
+
+// DeleteAnnotation calls DELETE /annotations/{target}.
+func (c *Client) DeleteAnnotation(ctx context.Context, target string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, c.baseURL+"/annotations/"+target, nil)
+	if err != nil {
+		return err
+	}
+	c.applyHeaders(req, nil)
+	_, err = c.do(req)
+	return err
+}
+
+// queryEscape is a minimal escape sufficient for annotation prefixes,
+// which are restricted to identifier-safe characters plus '/' and ':'.
+// Using net/url here would also work but pulls in another import.
+func queryEscape(s string) string {
+	var b strings.Builder
+	for i := 0; i < len(s); i++ {
+		ch := s[i]
+		switch {
+		case ch >= 'A' && ch <= 'Z',
+			ch >= 'a' && ch <= 'z',
+			ch >= '0' && ch <= '9',
+			ch == '-', ch == '_', ch == '.', ch == '~',
+			ch == ':', ch == '/':
+			b.WriteByte(ch)
+		default:
+			fmt.Fprintf(&b, "%%%02X", ch)
+		}
+	}
+	return b.String()
+}
+
 // HTTPError represents a non-2xx HTTP response from Loveliness.
 type HTTPError struct {
 	Status int

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -52,6 +52,7 @@ func New(opts Options) *Server {
 	registerSchemaTool(sdk, client, cache)
 	registerClusterTool(sdk, client)
 	registerAdminTools(sdk, client, opts.Readonly)
+	registerAnnotationTools(sdk, client, cache, opts.Readonly)
 	if !opts.Readonly {
 		registerDDLTools(sdk, client, cache)
 		registerBulkTools(sdk, client)

--- a/pkg/mcp/tools_annotations.go
+++ b/pkg/mcp/tools_annotations.go
@@ -1,0 +1,210 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// AnnotationExampleInput is the input shape for examples on
+// set_annotation. Mirrors AnnotationExample.
+type AnnotationExampleInput struct {
+	Title       string         `json:"title,omitempty" jsonschema:"Optional short label, e.g. 'find by name'."`
+	Query       string         `json:"query" jsonschema:"Cypher template, typically using $name parameter placeholders."`
+	Params      map[string]any `json:"params,omitempty" jsonschema:"Example parameter bindings the LLM can copy."`
+	Explanation string         `json:"explanation,omitempty" jsonschema:"What the query does, in human terms."`
+}
+
+// SetAnnotationInput is the input for set_annotation.
+type SetAnnotationInput struct {
+	Target      string                   `json:"target" jsonschema:"Schema target. One of: 'cluster', 'db:<name>', 'db:<name>/table:<name>', 'db:<name>/table:<name>/property:<name>', 'db:<name>/edge:<name>', 'db:<name>/edge:<name>/property:<name>', 'db:<name>/saved_query:<id>'."`
+	Description string                   `json:"description,omitempty" jsonschema:"Free-form description of this element. The most important field — this is what an LLM reads to understand the schema."`
+	Examples    []AnnotationExampleInput `json:"examples,omitempty" jsonschema:"Parameterized query templates that demonstrate how to use this element."`
+	Tags        []string                 `json:"tags,omitempty" jsonschema:"Freeform tags (e.g. 'pii', 'core', 'deprecated')."`
+	Extra       map[string]string        `json:"extra,omitempty" jsonschema:"Arbitrary string key/value pairs."`
+}
+
+// GetAnnotationInput is the input for get_annotation.
+type GetAnnotationInput struct {
+	Target string `json:"target" jsonschema:"Schema target to look up. See set_annotation for the format."`
+}
+
+// DeleteAnnotationInput is the input for delete_annotation.
+type DeleteAnnotationInput struct {
+	Target string `json:"target" jsonschema:"Schema target to delete."`
+}
+
+// ListAnnotationsInput is the input for list_annotations.
+type ListAnnotationsInput struct {
+	Prefix string `json:"prefix,omitempty" jsonschema:"Optional target prefix to filter by, e.g. 'db:default/' to list everything in that database."`
+}
+
+// AnnotationOutput is the response for get_annotation / set_annotation.
+type AnnotationOutput struct {
+	Annotation Annotation `json:"annotation"`
+}
+
+// ListAnnotationsOutput is the response for list_annotations.
+type ListAnnotationsOutput struct {
+	Annotations []Annotation `json:"annotations"`
+}
+
+// AnnotatedTable is a schema table joined with its annotation (if any).
+type AnnotatedTable struct {
+	NodeTable  *NodeTable  `json:"node_table,omitempty"`
+	EdgeTable  *EdgeTable  `json:"edge_table,omitempty"`
+	Annotation *Annotation `json:"annotation,omitempty"`
+}
+
+// DescribeSchemaInput is the input for describe_schema.
+type DescribeSchemaInput struct {
+	Database string `json:"database,omitempty" jsonschema:"Database name (default 'default'). Used to construct annotation targets like 'db:<database>/table:<name>'."`
+}
+
+// DescribeSchemaOutput joins the schema with annotations in a single
+// payload. The cluster annotation (target='cluster') and database
+// annotation (target='db:<database>') are surfaced separately so the
+// LLM can read top-level descriptions in one turn.
+type DescribeSchemaOutput struct {
+	Cluster    *Annotation      `json:"cluster,omitempty"`
+	Database   *Annotation      `json:"database,omitempty"`
+	NodeTables []AnnotatedTable `json:"node_tables"`
+	EdgeTables []AnnotatedTable `json:"edge_tables"`
+}
+
+// DeleteAnnotationOutput is the response for delete_annotation.
+type DeleteAnnotationOutput struct {
+	Status string `json:"status"`
+	Target string `json:"target"`
+}
+
+func registerAnnotationTools(s *mcp.Server, c *Client, cache *schemaCache, readonly bool) {
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "list_annotations",
+		Title:       "List schema annotations",
+		Description: "Return all annotations attached to schema elements (descriptions, query examples, tags). Pass `prefix` to filter, e.g. 'db:default/' for everything in that database. Annotations are the LLM's primary source for what tables and edges mean — read them before writing queries.",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in ListAnnotationsInput) (*mcp.CallToolResult, ListAnnotationsOutput, error) {
+		out, err := c.ListAnnotations(ctx, in.Prefix)
+		if err != nil {
+			return toolError(err), ListAnnotationsOutput{}, nil
+		}
+		return nil, ListAnnotationsOutput{Annotations: out}, nil
+	})
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "get_annotation",
+		Title:       "Read a schema annotation",
+		Description: "Return the annotation attached to a specific schema target (description, query examples, tags). Returns an empty annotation if none is set.",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in GetAnnotationInput) (*mcp.CallToolResult, AnnotationOutput, error) {
+		if strings.TrimSpace(in.Target) == "" {
+			return toolError(fmt.Errorf("target is required")), AnnotationOutput{}, nil
+		}
+		got, err := c.GetAnnotation(ctx, in.Target)
+		if err != nil {
+			return toolError(err), AnnotationOutput{}, nil
+		}
+		if got == nil {
+			return nil, AnnotationOutput{Annotation: Annotation{Target: in.Target}}, nil
+		}
+		return nil, AnnotationOutput{Annotation: *got}, nil
+	})
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "describe_schema",
+		Title:       "Schema with annotations joined",
+		Description: "Return the full schema (node + edge tables) joined with each element's annotation in a single payload. This is the highest-leverage starting point for an LLM: it shows table shape, column types, and the human-written description and example queries together. Cluster- and database-level annotations are surfaced at the top.",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in DescribeSchemaInput) (*mcp.CallToolResult, DescribeSchemaOutput, error) {
+		db := strings.TrimSpace(in.Database)
+		if db == "" {
+			db = "default"
+		}
+		schemaOut, err := cache.get(ctx, c)
+		if err != nil {
+			return toolError(err), DescribeSchemaOutput{}, nil
+		}
+		// Pull all annotations once and index by target. One round-trip
+		// is cheaper than N+M GETs for large schemas.
+		all, err := c.ListAnnotations(ctx, "")
+		if err != nil {
+			return toolError(err), DescribeSchemaOutput{}, nil
+		}
+		idx := make(map[string]*Annotation, len(all))
+		for i := range all {
+			idx[all[i].Target] = &all[i]
+		}
+		out := DescribeSchemaOutput{
+			Cluster:    idx["cluster"],
+			Database:   idx["db:"+db],
+			NodeTables: make([]AnnotatedTable, 0, len(schemaOut.NodeTables)),
+			EdgeTables: make([]AnnotatedTable, 0, len(schemaOut.EdgeTables)),
+		}
+		for i := range schemaOut.NodeTables {
+			t := schemaOut.NodeTables[i]
+			out.NodeTables = append(out.NodeTables, AnnotatedTable{
+				NodeTable:  &t,
+				Annotation: idx["db:"+db+"/table:"+t.Name],
+			})
+		}
+		for i := range schemaOut.EdgeTables {
+			t := schemaOut.EdgeTables[i]
+			out.EdgeTables = append(out.EdgeTables, AnnotatedTable{
+				EdgeTable:  &t,
+				Annotation: idx["db:"+db+"/edge:"+t.Name],
+			})
+		}
+		return nil, out, nil
+	})
+
+	if readonly {
+		return
+	}
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "set_annotation",
+		Title:       "Attach an annotation to a schema element",
+		Description: "Write the description, query examples, and tags for a schema element. Latest-wins: a SET on an existing target replaces the entire body. Targets follow 'cluster' / 'db:<name>' / 'db:<name>/table:<name>' / etc. — see the input schema for the full list. Use this to teach the system what a table or edge means and how to query it.",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in SetAnnotationInput) (*mcp.CallToolResult, AnnotationOutput, error) {
+		if strings.TrimSpace(in.Target) == "" {
+			return toolError(fmt.Errorf("target is required")), AnnotationOutput{}, nil
+		}
+		a := Annotation{
+			Target:      in.Target,
+			Description: in.Description,
+			Tags:        in.Tags,
+			Extra:       in.Extra,
+		}
+		for _, ex := range in.Examples {
+			a.Examples = append(a.Examples, AnnotationExample{
+				Title:       ex.Title,
+				Query:       ex.Query,
+				Params:      ex.Params,
+				Explanation: ex.Explanation,
+			})
+		}
+		if err := c.SetAnnotation(ctx, a); err != nil {
+			return toolError(err), AnnotationOutput{}, nil
+		}
+		// Re-fetch to get the server-stamped UpdatedAt.
+		got, err := c.GetAnnotation(ctx, in.Target)
+		if err != nil || got == nil {
+			return nil, AnnotationOutput{Annotation: a}, nil
+		}
+		return nil, AnnotationOutput{Annotation: *got}, nil
+	})
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "delete_annotation",
+		Title:       "Delete a schema annotation",
+		Description: "Remove the annotation attached to a target. The schema element itself is unaffected.",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in DeleteAnnotationInput) (*mcp.CallToolResult, DeleteAnnotationOutput, error) {
+		if strings.TrimSpace(in.Target) == "" {
+			return toolError(fmt.Errorf("target is required")), DeleteAnnotationOutput{}, nil
+		}
+		if err := c.DeleteAnnotation(ctx, in.Target); err != nil {
+			return toolError(err), DeleteAnnotationOutput{}, nil
+		}
+		return nil, DeleteAnnotationOutput{Status: "deleted", Target: in.Target}, nil
+	})
+}

--- a/pkg/mcp/tools_annotations.go
+++ b/pkg/mcp/tools_annotations.go
@@ -42,7 +42,12 @@ type ListAnnotationsInput struct {
 }
 
 // AnnotationOutput is the response for get_annotation / set_annotation.
+// Found is true when the annotation exists. After set_annotation it is
+// always true; after get_annotation it is false when no annotation has
+// been set for the target — the Annotation field still holds the
+// requested target so the caller can echo it without bookkeeping.
 type AnnotationOutput struct {
+	Found      bool       `json:"found"`
 	Annotation Annotation `json:"annotation"`
 }
 
@@ -96,7 +101,7 @@ func registerAnnotationTools(s *mcp.Server, c *Client, cache *schemaCache, reado
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "get_annotation",
 		Title:       "Read a schema annotation",
-		Description: "Return the annotation attached to a specific schema target (description, query examples, tags). Returns an empty annotation if none is set.",
+		Description: "Return the annotation attached to a specific schema target (description, query examples, tags). The `found` field tells you whether one is set — when false, the `annotation` body only carries back the target you asked for.",
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, in GetAnnotationInput) (*mcp.CallToolResult, AnnotationOutput, error) {
 		if strings.TrimSpace(in.Target) == "" {
 			return toolError(fmt.Errorf("target is required")), AnnotationOutput{}, nil
@@ -106,9 +111,9 @@ func registerAnnotationTools(s *mcp.Server, c *Client, cache *schemaCache, reado
 			return toolError(err), AnnotationOutput{}, nil
 		}
 		if got == nil {
-			return nil, AnnotationOutput{Annotation: Annotation{Target: in.Target}}, nil
+			return nil, AnnotationOutput{Found: false, Annotation: Annotation{Target: in.Target}}, nil
 		}
-		return nil, AnnotationOutput{Annotation: *got}, nil
+		return nil, AnnotationOutput{Found: true, Annotation: *got}, nil
 	})
 
 	mcp.AddTool(s, &mcp.Tool{
@@ -189,9 +194,9 @@ func registerAnnotationTools(s *mcp.Server, c *Client, cache *schemaCache, reado
 		// Re-fetch to get the server-stamped UpdatedAt.
 		got, err := c.GetAnnotation(ctx, in.Target)
 		if err != nil || got == nil {
-			return nil, AnnotationOutput{Annotation: a}, nil
+			return nil, AnnotationOutput{Found: true, Annotation: a}, nil
 		}
-		return nil, AnnotationOutput{Annotation: *got}, nil
+		return nil, AnnotationOutput{Found: true, Annotation: *got}, nil
 	})
 
 	mcp.AddTool(s, &mcp.Tool{

--- a/pkg/mcp/tools_annotations_test.go
+++ b/pkg/mcp/tools_annotations_test.go
@@ -1,0 +1,141 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestClientAnnotationsRoundTrip drives the four annotation client
+// methods against a fakeBackend that mimics the /annotations endpoints.
+func TestClientAnnotationsRoundTrip(t *testing.T) {
+	var mu sync.Mutex
+	store := make(map[string]Annotation)
+
+	srv := fakeBackend(t, map[string]http.HandlerFunc{
+		"/annotations": func(w http.ResponseWriter, r *http.Request) {
+			switch r.Method {
+			case http.MethodGet:
+				prefix := r.URL.Query().Get("prefix")
+				mu.Lock()
+				out := make([]Annotation, 0, len(store))
+				for k, v := range store {
+					if prefix == "" || strings.HasPrefix(k, prefix) {
+						out = append(out, v)
+					}
+				}
+				mu.Unlock()
+				writeJSON(w, map[string]any{"annotations": out})
+			case http.MethodPost:
+				var a Annotation
+				body, _ := io.ReadAll(r.Body)
+				if err := json.Unmarshal(body, &a); err != nil {
+					http.Error(w, "bad json", 400)
+					return
+				}
+				mu.Lock()
+				a.UpdatedAt = "2026-05-09T00:00:00Z"
+				store[a.Target] = a
+				mu.Unlock()
+				writeJSON(w, map[string]any{"status": "ok", "target": a.Target})
+			default:
+				http.Error(w, "bad method", 405)
+			}
+		},
+		"/annotations/": func(w http.ResponseWriter, r *http.Request) {
+			target := strings.TrimPrefix(r.URL.Path, "/annotations/")
+			switch r.Method {
+			case http.MethodGet:
+				mu.Lock()
+				a, ok := store[target]
+				mu.Unlock()
+				if !ok {
+					http.Error(w, `{"error":{"code":"NOT_FOUND","message":"no annotation"}}`, 404)
+					return
+				}
+				writeJSON(w, a)
+			case http.MethodDelete:
+				mu.Lock()
+				delete(store, target)
+				mu.Unlock()
+				writeJSON(w, map[string]string{"status": "deleted", "target": target})
+			default:
+				http.Error(w, "bad method", 405)
+			}
+		},
+	})
+	t.Cleanup(srv.Close)
+
+	c := NewClient(srv.URL, "", 2*time.Second)
+	ctx := context.Background()
+
+	// Empty get — should return (nil, nil).
+	got, err := c.GetAnnotation(ctx, "db:default/table:Person")
+	if err != nil {
+		t.Fatalf("get empty: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected nil for missing target, got %+v", got)
+	}
+
+	// Set.
+	want := Annotation{
+		Target:      "db:default/table:Person",
+		Description: "people",
+		Examples:    []AnnotationExample{{Title: "by name", Query: "MATCH (p:Person {name: $n}) RETURN p"}},
+		Tags:        []string{"core"},
+	}
+	if err := c.SetAnnotation(ctx, want); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+
+	// Get.
+	got, err = c.GetAnnotation(ctx, want.Target)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got == nil || got.Description != "people" || len(got.Examples) != 1 {
+		t.Fatalf("get returned %+v", got)
+	}
+
+	// List with prefix.
+	out, err := c.ListAnnotations(ctx, "db:default/")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(out) != 1 || out[0].Target != want.Target {
+		t.Fatalf("list returned %+v", out)
+	}
+
+	// Delete.
+	if err := c.DeleteAnnotation(ctx, want.Target); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	got, err = c.GetAnnotation(ctx, want.Target)
+	if err != nil {
+		t.Fatalf("get after delete: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected nil after delete, got %+v", got)
+	}
+}
+
+func TestQueryEscape(t *testing.T) {
+	cases := map[string]string{
+		"db:default/":         "db:default/",
+		"db:foo bar":          "db:foo%20bar",
+		"db:weird?x=y":        "db:weird%3Fx%3Dy",
+		"cluster":             "cluster",
+		"db:my-db_2/table:_a": "db:my-db_2/table:_a",
+	}
+	for in, want := range cases {
+		if got := queryEscape(in); got != want {
+			t.Errorf("queryEscape(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/skills/loveliness/SKILL.md
+++ b/skills/loveliness/SKILL.md
@@ -15,6 +15,8 @@ Read-only:
 - `cypher_read` — run a Cypher read query. Rejects writes (`CREATE`/`MERGE`/`SET`/`DELETE`/`DROP`/`REMOVE`/`LOAD`/`COPY`/`ALTER`/`DETACH`) and mutating `CALL` procedures.
 - `cluster_status` — leader, peers, per-shard assignment, registered schema.
 - `list_databases` — databases in the cluster catalog with state, shard count, and creation time.
+- `describe_schema` — schema joined with annotations in one payload. **Use this first** when you need to plan a query — it shows what each table holds and the example queries the operator left behind.
+- `list_annotations` / `get_annotation` — read schema annotations (descriptions, query examples, tags) for an element.
 
 Write (skipped when the server is launched with `--readonly`):
 
@@ -24,6 +26,7 @@ Write (skipped when the server is launched with `--readonly`):
 - `admin_cypher` — escape hatch for raw admin commands.
 - `bulk_nodes`, `bulk_edges` — synchronous CSV load. Provide either inline `csv_data` or a host-readable `csv_path`.
 - `ingest_nodes`, `ingest_edges` — async CSV load. Returns a `job_id` to poll with `ingest_status`.
+- `set_annotation`, `delete_annotation` — attach or remove a description, query examples, and tags on a schema target. Latest-wins (a SET replaces the previous body). Replicated through Raft alongside the schema, so annotations survive restart and follow the data.
 
 Resources (read-only blobs the client can fetch directly):
 
@@ -32,7 +35,7 @@ Resources (read-only blobs the client can fetch directly):
 
 ## Working pattern
 
-1. **Always run `schema` first.** Tool descriptions don't tell you what tables exist. The schema cache makes this cheap (30s).
+1. **Always start with `describe_schema`.** It returns the schema and the cluster's annotations (descriptions, query examples) joined. If `describe_schema` is missing, fall back to `schema` then `list_annotations`.
 2. **Use `params`, not string interpolation.** The `query` field accepts `$name` placeholders that map to the `params` object. Loveliness inlines parameters as escaped Cypher literals, so user-controlled strings stay safely quoted. Don't build queries with string concatenation.
 3. **Pick the right write tool:**
    - Schema (DDL): `create_node_table` / `create_edge_table` / `drop_table` over `cypher_write`. They validate identifiers and bust the schema cache.
@@ -88,6 +91,34 @@ ingest_edges(rel_table="KNOWS", from_table="Person", to_table="Person", csv_path
 ingest_status(job_id="abc123")
 → {"job": {"status": "running", "loaded": 1200000, ...}}
 ```
+
+Annotate a table so future LLM turns know what it holds:
+
+```
+set_annotation(
+  target="db:default/table:Person",
+  description="People in the social graph. Each row is a unique human. PII.",
+  examples=[
+    {"title": "by name",  "query": "MATCH (p:Person {name: $name}) RETURN p", "params": {"name": "Alice"}},
+    {"title": "top by friends", "query": "MATCH (p:Person)-[:KNOWS]->(f) RETURN p, count(f) AS n ORDER BY n DESC LIMIT $k", "params": {"k": 10}}
+  ],
+  tags=["core", "pii"]
+)
+```
+
+## Annotation targets
+
+`set_annotation` takes a hierarchical `target` string:
+
+- `cluster` — top-level "what is this cluster" description.
+- `db:<name>` — what a database holds.
+- `db:<name>/table:<name>` — node table description + example queries.
+- `db:<name>/table:<name>/property:<name>` — column-level note (units, format, deprecated, etc.).
+- `db:<name>/edge:<name>` — relationship table.
+- `db:<name>/edge:<name>/property:<name>` — edge column.
+- `db:<name>/saved_query:<id>` — a named, parameterized query template.
+
+For single-database clusters use `db:default`. Annotations are latest-wins (a SET replaces the body) and replicated through Raft like the schema and catalog — they survive restarts and follow snapshots.
 
 ## Common errors
 


### PR DESCRIPTION
## Summary

Make schema annotations first-class state in Loveliness so LLM agents can read and write the natural-language descriptions and parameterized query templates that bridge intent to Cypher. Annotations are replicated through Raft alongside the shard map and database catalog — they survive restart and follow snapshots like the rest of the cluster state.

- **`pkg/annotations`** — `Registry` with hierarchical targets (`cluster`, `db:<name>`, `db:<name>/table:<name>`, `.../property:<name>`, `.../edge:<name>`, `.../saved_query:<id>`), latest-wins `Set`/`Get`/`Delete`, prefix `List`, deep-copy `Snapshot`/`Restore`.
- **`pkg/cluster`** — new `CmdSetAnnotation` / `CmdDeleteAnnotation` Apply paths; FSM snapshot includes annotations and `Restore` tolerates older snapshots without them.
- **`pkg/api`** — `GET/POST/DELETE /annotations[/{target...}]` using Go 1.22 path wildcards so slash-bearing targets pass through unescaped. Mutating routes are leader-only.
- **`pkg/mcp`** — five new tools:
  - `list_annotations`, `get_annotation`, `describe_schema` (always registered)
  - `set_annotation`, `delete_annotation` (gated by `--readonly`, same gate as `cypher_write`)
  - `describe_schema` joins the schema with annotations in one round trip so an LLM can plan a query from a single tool call.
- **Docs + skill** — `skills/loveliness/SKILL.md`, `docs/mcp.md`, `docs/api.md` document the new tools, the target scheme, and the "describe_schema first" working pattern.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./pkg/annotations/...` — registry validate / latest-wins / list-prefix / snapshot-restore deep-copy
- [x] `go test ./pkg/cluster/...` — Apply set+delete, snapshot/restore round-trip preserves annotations
- [x] `go test ./pkg/mcp/...` — client round-trip against fake `/annotations` backend; `queryEscape` cases
- [x] MCP stdio probe (`initialize` → `tools/list`) advertises all five new tools with correct schemas
- [ ] End-to-end against a live single-node cluster (manual check before merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)