### PR TITLE
chore(ci): disable docker push workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,10 +1,7 @@
 name: Build Docker
 
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- Switch `.github/workflows/docker.yml` to `workflow_dispatch:` only — no more PR/push triggers that buildx multi-arch + push to Docker Hub.
- amd64 `docker build` in `ci.yml` remains as a Dockerfile sanity check on every PR.
- Re-enable publishing later by restoring the `push:` / `pull_request:` triggers in `docker.yml`.

## Test plan
- [ ] CI workflow still runs (test, lint, docker build) on this PR.
- [ ] Build Docker workflow does NOT auto-trigger on this PR or on merge.
- [ ] `gh workflow run "Build Docker"` still works for manual publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)