### PR TITLE
fix(shard): correct per-shard buffer pool default + add --max-memory-per-shard flag (closes #9)

### DIFF
--- a/cmd/loveliness/main.go
+++ b/cmd/loveliness/main.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"flag"
 	"fmt"
 	"log/slog"
 	"net"
@@ -28,12 +29,34 @@ import (
 	"github.com/johnjansen/loveliness/pkg/router"
 	"github.com/johnjansen/loveliness/pkg/schema"
 	"github.com/johnjansen/loveliness/pkg/shard"
+	"github.com/johnjansen/loveliness/pkg/sysmem"
 	"github.com/johnjansen/loveliness/pkg/tlsutil"
 	"github.com/johnjansen/loveliness/pkg/transport"
 )
 
+// serveFlags holds CLI overrides for the serve command. Only options
+// that need command-line ergonomics are surfaced here; everything else
+// stays env-driven via pkg/config. Precedence per option: flag > env >
+// auto-derived default.
+type serveFlags struct {
+	maxMemoryPerShardMB int
+}
+
+func parseServeFlags(args []string) serveFlags {
+	fs := flag.NewFlagSet("serve", flag.ExitOnError)
+	var f serveFlags
+	fs.IntVar(&f.maxMemoryPerShardMB, "max-memory-per-shard", 0,
+		"Per-shard buffer pool cap in MB. 0 = use LOVELINESS_SHARD_BUFFER_MB env or auto-derived default (host RAM * 0.7 / shard count).")
+	if err := fs.Parse(args); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(2)
+	}
+	return f
+}
+
 func main() {
 	// Subcommand dispatch.
+	var serveArgs []string
 	if len(os.Args) > 1 {
 		switch os.Args[1] {
 		case "up":
@@ -52,13 +75,15 @@ func main() {
 			fmt.Println("loveliness dev")
 			return
 		case "serve":
-			// Fall through to normal server startup.
+			serveArgs = os.Args[2:]
 		default:
 			fmt.Fprintf(os.Stderr, "unknown command: %s\n\n", os.Args[1])
 			printUsage()
 			os.Exit(1)
 		}
 	}
+
+	flags := parseServeFlags(serveArgs)
 
 	cfg := config.FromEnv()
 	if err := cfg.Validate(); err != nil {
@@ -81,27 +106,44 @@ func main() {
 		threadsPerShard = 1
 	}
 
-	// Calculate per-shard buffer pool size.
-	// LadybugDB defaults to 80% of system memory PER shard — with N shards
-	// that's N*80% which guarantees OOM. Auto-calculate a safe limit.
-	var bufferPoolBytes uint64
-	if cfg.ShardBufferMB > 0 {
+	// Resolve per-shard buffer pool cap. LadybugDB defaults to 80% of
+	// system memory PER shard, so with N shards that's N*80% — a
+	// guaranteed OOM. Precedence: --max-memory-per-shard flag > env
+	// LOVELINESS_SHARD_BUFFER_MB > host_ram * 0.7 / shard_count.
+	var (
+		bufferPoolBytes uint64
+		bufferSource    string
+	)
+	switch {
+	case flags.maxMemoryPerShardMB > 0:
+		bufferPoolBytes = uint64(flags.maxMemoryPerShardMB) * 1024 * 1024
+		bufferSource = "flag"
+	case cfg.ShardBufferMB > 0:
 		bufferPoolBytes = uint64(cfg.ShardBufferMB) * 1024 * 1024
-	} else {
-		// Auto: 70% of total memory / shard count, minimum 256MB.
-		var m runtime.MemStats
-		runtime.ReadMemStats(&m)
-		totalMem := m.Sys
-		if totalMem < 512*1024*1024 {
-			// Sys can underreport early; fall back to a conservative estimate.
-			totalMem = 2 * 1024 * 1024 * 1024 // 2GB minimum assumption
+		bufferSource = "env"
+	default:
+		totalMem, err := sysmem.Total()
+		if err != nil {
+			// Unsupported platform — be loud and pick a defensive
+			// floor. Operators should set the flag or env on these
+			// hosts.
+			slog.Warn("sysmem.Total unavailable; falling back to 2 GiB assumption", "err", err)
+			totalMem = 2 * 1024 * 1024 * 1024
 		}
 		bufferPoolBytes = (totalMem * 7 / 10) / uint64(cfg.ShardCount)
-		if bufferPoolBytes < 256*1024*1024 {
-			bufferPoolBytes = 256 * 1024 * 1024
-		}
+		bufferSource = "auto"
 	}
-	slog.Info("buffer pool configured", "per_shard_mb", bufferPoolBytes/(1024*1024), "shards", cfg.ShardCount)
+	const minBufferBytes = 256 * 1024 * 1024
+	if bufferPoolBytes < minBufferBytes {
+		slog.Warn("buffer pool below recommended floor; clamping to 256 MiB",
+			"requested_mb", bufferPoolBytes/(1024*1024), "source", bufferSource)
+		bufferPoolBytes = minBufferBytes
+	}
+	slog.Info("buffer pool configured",
+		"per_shard_mb", bufferPoolBytes/(1024*1024),
+		"shards", cfg.ShardCount,
+		"source", bufferSource,
+	)
 
 	// Open local shards.
 	// Note: LadybugDB must create its own database directory. We only create

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,18 @@
 # Configuration
 
-All configuration is via environment variables.
+Most configuration is via environment variables. A few options also expose CLI flags on the `serve` subcommand; flags take precedence over env vars.
+
+## CLI flags
+
+```
+loveliness serve [flags]
+
+  --max-memory-per-shard MB   Per-shard LadybugDB buffer pool cap in MB.
+                              0 = use LOVELINESS_SHARD_BUFFER_MB env or
+                              auto-derived default.
+```
+
+Precedence for `max-memory-per-shard`: **flag > env > auto** (`host_ram × 0.7 / shard_count`).
 
 | Variable | Default | Description |
 |---|---|---|
@@ -32,7 +44,37 @@ All configuration is via environment variables.
 | `LOVELINESS_DISCOVER_ADDR` | *(empty)* | DNS name to resolve for peer discovery (e.g., `loveliness.internal`) |
 | `LOVELINESS_DISCOVER_INTERVAL` | `5` | Seconds between DNS discovery attempts |
 | `LOVELINESS_EXPECTED_NODES` | `0` | Expected node count for quorum-gated auto-bootstrap (0 = no expectation) |
-| `LOVELINESS_SHARD_BUFFER_MB` | *(auto)* | Per-shard LadybugDB buffer pool cap in MB. Default: `(total_memory × 0.7) / shard_count`. Set explicitly to override. |
+| `LOVELINESS_SHARD_BUFFER_MB` | *(auto)* | Per-shard LadybugDB buffer pool cap in MB. Default: `(host_ram × 0.7) / shard_count`. Set explicitly to override. The CLI flag `--max-memory-per-shard` overrides this. |
+
+## Memory sizing
+
+LadybugDB uses mmap for storage; during bulk `COPY FROM` the resident write footprint can spike well above the steady-state read footprint. By default each LadybugDB handle would claim 80% of host RAM as its buffer pool — with N shards on one host, that's N×80%, a guaranteed OOM.
+
+Loveliness caps each shard's buffer pool to keep total usage safe:
+
+- **Auto default**: `host_ram × 0.7 / shard_count`. Host RAM is read from `/proc/meminfo` on Linux and `sysctl hw.memsize` on macOS. On other platforms a 2 GiB assumption is used and a warning is logged — set the flag or env var explicitly there.
+- **Floor**: 256 MiB per shard. If the resolved value is below that, it is clamped and a warning is logged. Below this floor, warm reads will thrash the page cache.
+- **Recommended floor for production**: 1 GiB per shard. Below 1 GiB, expect frequent eviction under any non-trivial working set.
+- **Recommended ceiling**: leave at least 15% of host RAM unallocated for the OS, Raft Bolt store, and Go runtime overhead. The 0.7 factor in the default already accounts for this.
+
+### Sample sizings
+
+| Host RAM | Shards | Auto cap per shard | Notes |
+|---|---|---|---|
+| 8 GiB | 3 | ~1.87 GiB | Comfortable for development. |
+| 16 GiB | 4 | ~2.8 GiB | Good for small production workloads. |
+| 48 GiB | 6 | ~5.6 GiB | This is the host that originally OOMed at 23M nodes — the cap fixes it. |
+| 128 GiB | 8 | ~11.2 GiB | Large production node. |
+
+### Startup logging
+
+The resolved cap is logged at startup with the source it came from:
+
+```
+buffer pool configured per_shard_mb=5734 shards=6 source=auto
+buffer pool configured per_shard_mb=4096 shards=6 source=flag
+buffer pool configured per_shard_mb=2048 shards=6 source=env
+```
 
 ## Authentication
 

--- a/pkg/sysmem/sysmem.go
+++ b/pkg/sysmem/sysmem.go
@@ -1,0 +1,8 @@
+// Package sysmem reports total host memory.
+//
+// We need this for sizing per-shard buffer pools. The previous
+// implementation used runtime.MemStats.Sys, which reports Go's heap
+// reservation rather than host RAM — at startup that's tens of MB,
+// so a 48 GB host got the conservative fallback and clamped each
+// shard to 256 MB. Reading the kernel directly fixes that.
+package sysmem

--- a/pkg/sysmem/total.go
+++ b/pkg/sysmem/total.go
@@ -1,0 +1,19 @@
+package sysmem
+
+import (
+	"fmt"
+	"runtime"
+)
+
+// Total returns the host's total physical memory in bytes.
+//
+// It reads /proc/meminfo on Linux and `hw.memsize` on macOS. On other
+// platforms it returns an error so the caller can pick a fallback and
+// log a warning rather than silently using a misleading value.
+func Total() (uint64, error) {
+	n, err := total()
+	if err != nil {
+		return 0, fmt.Errorf("total memory on %s: %w", runtime.GOOS, err)
+	}
+	return n, nil
+}

--- a/pkg/sysmem/total_darwin.go
+++ b/pkg/sysmem/total_darwin.go
@@ -1,0 +1,7 @@
+package sysmem
+
+import "golang.org/x/sys/unix"
+
+func total() (uint64, error) {
+	return unix.SysctlUint64("hw.memsize")
+}

--- a/pkg/sysmem/total_linux.go
+++ b/pkg/sysmem/total_linux.go
@@ -1,0 +1,51 @@
+package sysmem
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+func total() (uint64, error) {
+	return parseMeminfo("/proc/meminfo")
+}
+
+// parseMeminfo extracts MemTotal from a /proc/meminfo file. Split out
+// for testability — exported via an internal test that points it at a
+// fixture.
+func parseMeminfo(path string) (uint64, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return 0, err
+	}
+	defer f.Close()
+
+	s := bufio.NewScanner(f)
+	for s.Scan() {
+		line := s.Text()
+		if !strings.HasPrefix(line, "MemTotal:") {
+			continue
+		}
+		// "MemTotal:       49355436 kB"
+		fields := strings.Fields(line)
+		if len(fields) < 3 {
+			return 0, fmt.Errorf("meminfo MemTotal malformed: %q", line)
+		}
+		kb, err := strconv.ParseUint(fields[1], 10, 64)
+		if err != nil {
+			return 0, fmt.Errorf("meminfo MemTotal value: %w", err)
+		}
+		// /proc/meminfo always reports in kB regardless of the unit
+		// suffix, but check anyway in case that ever changes.
+		if fields[2] != "kB" {
+			return 0, fmt.Errorf("meminfo MemTotal unit %q not handled", fields[2])
+		}
+		return kb * 1024, nil
+	}
+	if err := s.Err(); err != nil {
+		return 0, err
+	}
+	return 0, fmt.Errorf("MemTotal not found in %s", path)
+}

--- a/pkg/sysmem/total_linux_test.go
+++ b/pkg/sysmem/total_linux_test.go
@@ -1,0 +1,39 @@
+package sysmem
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseMeminfoFixture(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "meminfo")
+	const fixture = `MemTotal:       49355436 kB
+MemFree:        12345678 kB
+MemAvailable:   45000000 kB
+Buffers:           12345 kB
+`
+	if err := os.WriteFile(path, []byte(fixture), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := parseMeminfo(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := uint64(49355436) * 1024
+	if got != want {
+		t.Fatalf("parseMeminfo = %d, want %d", got, want)
+	}
+}
+
+func TestParseMeminfoMissing(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "meminfo")
+	if err := os.WriteFile(path, []byte("MemFree: 1024 kB\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := parseMeminfo(path); err == nil {
+		t.Fatal("expected error when MemTotal is absent")
+	}
+}

--- a/pkg/sysmem/total_other.go
+++ b/pkg/sysmem/total_other.go
@@ -1,0 +1,12 @@
+//go:build !linux && !darwin
+
+package sysmem
+
+import (
+	"fmt"
+	"runtime"
+)
+
+func total() (uint64, error) {
+	return 0, fmt.Errorf("no sysmem implementation for %s", runtime.GOOS)
+}

--- a/pkg/sysmem/total_test.go
+++ b/pkg/sysmem/total_test.go
@@ -1,0 +1,17 @@
+package sysmem
+
+import "testing"
+
+func TestTotalReturnsRealValue(t *testing.T) {
+	n, err := Total()
+	if err != nil {
+		// On unsupported platforms, that's a clear error — don't fail
+		// the suite just because it ran in CI without /proc.
+		t.Skipf("sysmem.Total unsupported here: %v", err)
+	}
+	// The smallest CI runner we use has at least 2 GB. Anything below
+	// that means we're reading something other than host RAM.
+	if n < 1<<30 {
+		t.Fatalf("Total() = %d bytes, want at least 1 GiB", n)
+	}
+}


### PR DESCRIPTION
Closes #9.

## Summary

The auto-derived per-shard buffer pool cap was reading `runtime.MemStats.Sys` (Go's heap reservation, ~MB at startup), not host RAM. On a 48 GB host the conservative fallback then kicked in and **clamped each shard to 256 MB regardless of host size**. That's the OOM the issue describes — the engine cap was either ignored or set absurdly low.

## Changes

- New `pkg/sysmem` reads `MemTotal:` from `/proc/meminfo` on Linux and `hw.memsize` via `sysctl` on macOS. Unsupported platforms return an error so the caller can warn and fall back rather than silently misbehave.
- `cmd/loveliness/main.go` uses `sysmem.Total()` for the auto path. A 48 GB / 6-shard host now correctly resolves to ~5.6 GB per shard instead of 256 MB.
- New CLI flag `--max-memory-per-shard <MB>` on the `serve` subcommand. Precedence: **flag > env (`LOVELINESS_SHARD_BUFFER_MB`) > auto**. The startup log line includes the resolved `source`.
- `docs/configuration.md` gains a **Memory sizing** section with sample sizings, the 256 MiB floor, the 1 GiB recommended floor, and the source of host-RAM reads per platform.

## Out of scope (deferred)

- `loveliness_shard_rss_bytes` / `loveliness_shard_buffer_cap_bytes` Prometheus metrics — folded into #12 because there's no `/metrics` endpoint yet.
- `madvise(MADV_DONTNEED)` fallback — only worth it if the engine cap proves insufficient. Let's measure first.
- Cgroups v2 path — depends on #1's CGo isolation work.
- Write-path token-bucket backpressure — premature without metrics.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./pkg/...` clean (incl. new `pkg/sysmem` tests)
- [x] `golangci-lint run ./...` clean
- [x] `loveliness serve --help` shows the new flag
- [ ] CI green on this PR (test / lint / docker)
- [ ] Spot-check the startup log on a real host shows `source=auto` with a sensible `per_shard_mb`

🤖 Generated with [Claude Code](https://claude.com/claude-code)