### PR TITLE
fix(router): reject ALL SHORTEST queries to prevent CGo segfault

### DIFF
--- a/cmd/benchmark/main.go
+++ b/cmd/benchmark/main.go
@@ -1240,7 +1240,11 @@ func main() {
 	fmt.Printf("%s (p50=%s)\n", fmtDur(r.Mean()), fmtDur(r.P(50)))
 	results = append(results, r)
 
-	// ALL SHORTEST can crash LadybugDB on certain graph shapes — skipped.
+	// ALL SHORTEST is rejected at the router (UNSAFE_QUERY) because the
+	// LadybugDB native layer segfaults under load — see issue #1. Until
+	// worker-process isolation lands, this benchmark stays disabled
+	// even with LOVELINESS_ALLOW_ALL_SHORTEST_UNSAFE=true: a host
+	// crash makes timing data meaningless.
 	// fmt.Print("  all_shortest_paths... ")
 	// r = benchAllShortestPaths()
 	// fmt.Printf("%s (p50=%s)\n", fmtDur(r.Mean()), fmtDur(r.P(50)))

--- a/cmd/loveliness/main.go
+++ b/cmd/loveliness/main.go
@@ -93,6 +93,11 @@ func main() {
 
 	logging.Setup(cfg.NodeID)
 
+	router.SetAllowAllShortestUnsafe(cfg.AllowAllShortestUnsafe)
+	if cfg.AllowAllShortestUnsafe {
+		slog.Warn("ALL SHORTEST path queries enabled — LadybugDB may segfault under load (see GitHub issue #1)")
+	}
+
 	slog.Info("starting",
 		"bind", cfg.BindAddr,
 		"raft", cfg.RaftAddr,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -45,6 +45,24 @@ Precedence for `max-memory-per-shard`: **flag > env > auto** (`host_ram × 0.7 /
 | `LOVELINESS_DISCOVER_INTERVAL` | `5` | Seconds between DNS discovery attempts |
 | `LOVELINESS_EXPECTED_NODES` | `0` | Expected node count for quorum-gated auto-bootstrap (0 = no expectation) |
 | `LOVELINESS_SHARD_BUFFER_MB` | *(auto)* | Per-shard LadybugDB buffer pool cap in MB. Default: `(host_ram × 0.7) / shard_count`. Set explicitly to override. The CLI flag `--max-memory-per-shard` overrides this. |
+| `LOVELINESS_ALLOW_ALL_SHORTEST_UNSAFE` | `false` | Opt in to forwarding `ALL SHORTEST` path queries despite the known LadybugDB segfault (see [Unsafe queries](#unsafe-queries)). |
+
+## Unsafe queries
+
+The router rejects `ALL SHORTEST` variable-length path queries by default with an `UNSAFE_QUERY` error:
+
+```
+ALL SHORTEST variable-length path queries are disabled — they segfault the LadybugDB native layer (see github.com/johnjansen/loveliness#1). Use SHORTEST (single shortest path) instead.
+```
+
+This is a defensive gate: the segfault originates in LadybugDB's CGo/C++ shortest-path implementation and bypasses Go's `recover()`, so a single query can kill the entire node. Until worker-process isolation lands, the only safe response is to refuse the query.
+
+Workarounds:
+
+- **Use `SHORTEST` instead** — single shortest path works reliably on the same data.
+- **Set `LOVELINESS_ALLOW_ALL_SHORTEST_UNSAFE=true`** to accept the risk on a per-node basis. The node logs a warning at startup and forwards the query as-is. Do this only when you have an external supervisor that can restart the process.
+
+The detector strips Cypher comments and string literals before matching, so a query like `MATCH (n {note: 'use ALL SHORTEST instead'}) RETURN n` is not rejected.
 
 ## Memory sizing
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -64,6 +64,14 @@ type Config struct {
 	// LadybugDB defaults to 80% of system memory PER shard, which OOMs with multiple shards.
 	ShardBufferMB int
 
+	// AllowAllShortestUnsafe opts the node into accepting `ALL SHORTEST`
+	// path queries. The default (false) makes the router reject them
+	// with an UNSAFE_QUERY error because the LadybugDB native layer
+	// segfaults on this construct under load (see GitHub issue #1).
+	// Operators who have isolated workers or simply accept the risk
+	// can flip this to true.
+	AllowAllShortestUnsafe bool
+
 	// DNS discovery configuration.
 	DiscoverMode     string // "dns" to enable DNS-based peer discovery, empty to disable
 	DiscoverAddr     string // DNS name to resolve for peer discovery (e.g., "loveliness.internal")
@@ -195,6 +203,9 @@ func FromEnv() Config {
 		if n, err := strconv.Atoi(v); err == nil && n > 0 {
 			c.ShardBufferMB = n
 		}
+	}
+	if v := os.Getenv("LOVELINESS_ALLOW_ALL_SHORTEST_UNSAFE"); v == "true" || v == "1" {
+		c.AllowAllShortestUnsafe = true
 	}
 	return c
 }

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -193,6 +193,14 @@ func (r *Router) Pipeline() *PipelineExecutor {
 
 // Execute parses a Cypher query, resolves target shards, and executes.
 func (r *Router) Execute(ctx context.Context, cypher string) (*Result, error) {
+	// Defensive gate: reject query shapes that crash the LadybugDB
+	// native layer. CGo segfaults bypass Go's recover(), so the only
+	// safe response is to refuse the query before it ever reaches the
+	// shard. See pkg/router/unsafe.go and GitHub issue #1.
+	if qe := rejectIfUnsafe(cypher); qe != nil {
+		return nil, qe
+	}
+
 	parsed, err := ParseWithSchema(cypher, r.schema)
 	if err != nil {
 		return nil, &QueryError{Code: "CYPHER_PARSE_ERROR", Message: err.Error()}

--- a/pkg/router/unsafe.go
+++ b/pkg/router/unsafe.go
@@ -1,0 +1,118 @@
+package router
+
+import "regexp"
+
+// allShortestPattern matches `ALL SHORTEST` as bare keywords, allowing
+// any whitespace (including newlines) between them. Word boundaries
+// keep `OVERALL SHORTEST` or `ALLSHORTEST` from triggering.
+var allShortestPattern = regexp.MustCompile(`(?i)\bALL\s+SHORTEST\b`)
+
+// containsAllShortest reports whether the query uses LadybugDB's
+// `ALL SHORTEST` variable-length path syntax once string literals and
+// Cypher comments are stripped — those are the contexts where the
+// keywords could appear without being parsed as the unsafe construct.
+//
+// This is a defensive scanner, not a full parser. It accepts false
+// positives only on inputs that look syntactically like Cypher with
+// `ALL SHORTEST` at the top level. False negatives would require a
+// quoting/comment style we don't recognise, which would also fail to
+// parse downstream.
+func containsAllShortest(cypher string) bool {
+	return allShortestPattern.MatchString(stripLiteralsAndComments(cypher))
+}
+
+// stripLiteralsAndComments replaces the contents of Cypher string
+// literals (single-quoted, double-quoted, backticked) and comments
+// (`//...` to end of line, `/* ... */`) with spaces, preserving
+// length so error positions still line up. Only the keyword scanner
+// uses this — the original cypher is what gets handed to LadybugDB.
+func stripLiteralsAndComments(s string) string {
+	out := []byte(s)
+	i := 0
+	for i < len(out) {
+		c := out[i]
+		switch {
+		case c == '\'' || c == '"' || c == '`':
+			quote := c
+			out[i] = ' '
+			i++
+			for i < len(out) {
+				if out[i] == '\\' && i+1 < len(out) {
+					out[i] = ' '
+					out[i+1] = ' '
+					i += 2
+					continue
+				}
+				if out[i] == quote {
+					out[i] = ' '
+					i++
+					break
+				}
+				out[i] = ' '
+				i++
+			}
+		case c == '/' && i+1 < len(out) && out[i+1] == '/':
+			for i < len(out) && out[i] != '\n' {
+				out[i] = ' '
+				i++
+			}
+		case c == '/' && i+1 < len(out) && out[i+1] == '*':
+			out[i] = ' '
+			out[i+1] = ' '
+			i += 2
+			for i+1 < len(out) {
+				if out[i] == '*' && out[i+1] == '/' {
+					out[i] = ' '
+					out[i+1] = ' '
+					i += 2
+					break
+				}
+				if out[i] != '\n' {
+					out[i] = ' '
+				}
+				i++
+			}
+			// If we exited without finding `*/`, blank the rest.
+			for ; i < len(out); i++ {
+				if out[i] != '\n' {
+					out[i] = ' '
+				}
+			}
+		default:
+			i++
+		}
+	}
+	return string(out)
+}
+
+// errAllShortestUnsafe is the message returned when an `ALL SHORTEST`
+// query is rejected. Includes a workaround pointer so end users have
+// somewhere to go; see GitHub issue #1.
+const errAllShortestUnsafe = "ALL SHORTEST variable-length path queries are disabled — they segfault the LadybugDB native layer (see github.com/johnjansen/loveliness#1). Use SHORTEST (single shortest path) instead."
+
+// allShortestEnabled is set by the binary when the operator opts in
+// via LOVELINESS_ALLOW_ALL_SHORTEST_UNSAFE=true. Default is off; the
+// query rejection is the only thing standing between the user and a
+// host-process segfault, so flipping this requires a deliberate act.
+var allShortestEnabled = false
+
+// SetAllowAllShortestUnsafe toggles the runtime gate at startup.
+// Tests use it to assert both branches; production code wires it from
+// config.AllowAllShortestUnsafe.
+func SetAllowAllShortestUnsafe(allow bool) {
+	allShortestEnabled = allow
+}
+
+// rejectIfUnsafe returns a *QueryError if cypher contains a known
+// crash-trigger pattern and the unsafe gate is closed. Returning nil
+// means the query is safe to forward.
+func rejectIfUnsafe(cypher string) *QueryError {
+	if allShortestEnabled {
+		return nil
+	}
+	if containsAllShortest(cypher) {
+		return &QueryError{Code: "UNSAFE_QUERY", Message: errAllShortestUnsafe}
+	}
+	return nil
+}
+

--- a/pkg/router/unsafe_test.go
+++ b/pkg/router/unsafe_test.go
@@ -1,0 +1,147 @@
+package router
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/johnjansen/loveliness/pkg/shard"
+)
+
+func TestContainsAllShortest(t *testing.T) {
+	cases := []struct {
+		name  string
+		query string
+		want  bool
+	}{
+		{
+			name:  "canonical positive",
+			query: "MATCH (a:Person)-[r:KNOWS* ALL SHORTEST 1..6]->(b:Person) RETURN length(r)",
+			want:  true,
+		},
+		{
+			name:  "lowercase positive",
+			query: "match (a)-[r* all shortest 1..3]->(b) return r",
+			want:  true,
+		},
+		{
+			name:  "mixed case + tab",
+			query: "MATCH (a)-[r*\tAll\tShortest 1..3]->(b) RETURN r",
+			want:  true,
+		},
+		{
+			name:  "newline between keywords",
+			query: "MATCH (a)-[r* ALL\n      SHORTEST 1..3]->(b) RETURN r",
+			want:  true,
+		},
+		{
+			name:  "SHORTEST without ALL is safe",
+			query: "MATCH (a)-[r* SHORTEST 1..6]->(b) RETURN r",
+			want:  false,
+		},
+		{
+			name:  "string literal containing keywords does not trigger",
+			query: "MATCH (n {comment: 'use ALL SHORTEST instead'}) RETURN n",
+			want:  false,
+		},
+		{
+			name:  "double-quoted literal does not trigger",
+			query: `MATCH (n {note: "ALL SHORTEST"}) RETURN n`,
+			want:  false,
+		},
+		{
+			name:  "backtick identifier does not trigger",
+			query: "MATCH (n:`ALL SHORTEST table`) RETURN n",
+			want:  false,
+		},
+		{
+			name:  "line comment masks keywords",
+			query: "MATCH (n) RETURN n // ALL SHORTEST commentary\n",
+			want:  false,
+		},
+		{
+			name:  "block comment masks keywords",
+			query: "MATCH (n) /* ALL SHORTEST in a comment */ RETURN n",
+			want:  false,
+		},
+		{
+			name:  "OVERALL SHORTEST should not trigger (word boundary)",
+			query: "MATCH (n) RETURN n.overall_shortest",
+			want:  false,
+		},
+		{
+			name:  "ALLSHORTEST run together does not trigger",
+			query: "RETURN 'ALLSHORTEST'",
+			want:  false,
+		},
+		{
+			name:  "escaped quote inside literal still treated as literal",
+			query: `MATCH (n {note: 'it\'s ALL SHORTEST'}) RETURN n`,
+			want:  false,
+		},
+		{
+			name:  "ALL SHORTEST after comment is detected",
+			query: "// safe comment\nMATCH (a)-[r* ALL SHORTEST 1..3]->(b) RETURN r",
+			want:  true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := containsAllShortest(tc.query)
+			if got != tc.want {
+				t.Fatalf("containsAllShortest(%q) = %v, want %v", tc.query, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRejectIfUnsafeRespectsGate(t *testing.T) {
+	t.Cleanup(func() { SetAllowAllShortestUnsafe(false) })
+
+	q := "MATCH (a)-[r* ALL SHORTEST 1..3]->(b) RETURN r"
+
+	SetAllowAllShortestUnsafe(false)
+	if err := rejectIfUnsafe(q); err == nil {
+		t.Fatal("expected rejection when gate is closed, got nil")
+	} else if err.Code != "UNSAFE_QUERY" {
+		t.Fatalf("unexpected error code: %s", err.Code)
+	}
+
+	SetAllowAllShortestUnsafe(true)
+	if err := rejectIfUnsafe(q); err != nil {
+		t.Fatalf("expected pass when gate is open, got %v", err)
+	}
+}
+
+func TestRouterExecuteRejectsAllShortest(t *testing.T) {
+	t.Cleanup(func() { SetAllowAllShortestUnsafe(false) })
+	SetAllowAllShortestUnsafe(false)
+
+	r := NewRouter([]*shard.Shard{}, 1*time.Second)
+
+	_, err := r.Execute(context.Background(),
+		"MATCH (a:Person)-[r* ALL SHORTEST 1..6]->(b:Person) RETURN length(r)")
+	if err == nil {
+		t.Fatal("expected Router.Execute to reject ALL SHORTEST, got nil")
+	}
+	qe, ok := err.(*QueryError)
+	if !ok {
+		t.Fatalf("expected *QueryError, got %T: %v", err, err)
+	}
+	if qe.Code != "UNSAFE_QUERY" {
+		t.Fatalf("unexpected error code: %s", qe.Code)
+	}
+	if !strings.Contains(qe.Message, "SHORTEST") {
+		t.Fatalf("error message should mention SHORTEST: %s", qe.Message)
+	}
+}
+
+func TestStripLiteralsAndCommentsPreservesLength(t *testing.T) {
+	in := `MATCH (n {note: 'ALL SHORTEST'}) /* and ALL SHORTEST */ RETURN n // line\n`
+	out := stripLiteralsAndComments(in)
+	if len(out) != len(in) {
+		t.Fatalf("length changed: %d -> %d", len(in), len(out))
+	}
+}


### PR DESCRIPTION
Mitigates #1. Full fix tracked in #25.

## Why

LadybugDB segfaults the host process on \`ALL SHORTEST\` variable-length path queries over sparse random graphs. CGo crashes bypass Go's \`recover()\`, so a single offending query kills the entire node — every shard, every client.

go-ladybug v0.13.1 is the latest release upstream — no engine bump available. Full worker-process isolation is a much larger change tracked in #25.

## What

Defensive bandage: refuse the query shape before it reaches the shard.

- \`pkg/router/unsafe.go\` — \`containsAllShortest\` strips Cypher comments and string literals, then matches \`\\bALL\\s+SHORTEST\\b\`.
  - Handles single, double, and backtick quotes
  - Strips line (\`//\`) and block (\`/* */\`) comments
  - Word-boundary matching (no false positives on \`OVERALL_SHORTEST\` or \`ALLSHORTEST\`)
  - Escape-aware inside string literals
- \`Router.Execute\` calls \`rejectIfUnsafe\` before parsing; returns \`UNSAFE_QUERY\` with a workaround pointer.
- New env knob \`LOVELINESS_ALLOW_ALL_SHORTEST_UNSAFE\` lets operators opt back in (logs a warning at startup).
- \`docs/configuration.md\` documents the gate and workarounds.
- \`cmd/benchmark/main.go\` comment refreshed (\`ALL SHORTEST\` benchmark stays disabled — host crashes make timing data meaningless).

## What this does NOT do

- Fix the underlying segfault — would require child-process isolation per shard, tracked in #25.
- Catch crashes from other yet-undocumented unsafe query shapes — same supervisor work.
- Re-enable the \`ALL SHORTEST\` benchmark.

## Test plan

- [x] \`go test ./pkg/router/...\` — 14 detector cases (positive + negative + edge), gate flip, Router.Execute rejection
- [x] \`go test ./...\` — full suite green
- [x] \`golangci-lint run ./...\` — 0 issues
- [ ] Manual: run benchmark with offending query, confirm UNSAFE_QUERY response instead of crash
- [ ] Manual: set \`LOVELINESS_ALLOW_ALL_SHORTEST_UNSAFE=true\`, confirm query forwards (with risk)

🤖 Generated with [Claude Code](https://claude.com/claude-code)