### PR TITLE
feat(replication): rewrite non-deterministic Cypher before WAL append

### DIFF
--- a/cmd/loveliness/main.go
+++ b/cmd/loveliness/main.go
@@ -245,6 +245,7 @@ func main() {
 	}
 	slog.Info("WAL initialized", "dir", walDir, "sequence", wal.LastSequence())
 	r.SetWAL(wal)
+	r.SetWriteRewriter(replication.DefaultRewriter())
 
 	// Initialize backup store (S3 if configured, otherwise local).
 	backupMgr := backup.NewManager(cfg.DataDir, cfg.NodeID)

--- a/pkg/replication/rewriter.go
+++ b/pkg/replication/rewriter.go
@@ -1,0 +1,296 @@
+package replication
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	mathrand "math/rand/v2"
+	"strings"
+	"time"
+)
+
+// Rewriter pre-computes non-deterministic Cypher functions so that replicas
+// replay the same statement and reach the same state as the primary. The
+// rewriter must run BEFORE the Cypher is appended to the WAL and BEFORE the
+// primary executes the query, so that primary, WAL record, and every replica
+// see the identical (deterministic) statement.
+//
+// Supported substitutions (case-insensitive on the function name, scoped to
+// token boundaries — matches inside string literals or backtick-quoted
+// identifiers are left untouched):
+//
+//	now()           → datetime('<RFC3339Nano UTC>')
+//	datetime()      → datetime('<RFC3339Nano UTC>')
+//	localdatetime() → localdatetime('<RFC3339 without TZ>')
+//	date()          → date('YYYY-MM-DD')
+//	time()          → time('HH:MM:SS.NNNNNNNNN+00:00')
+//	localtime()     → localtime('HH:MM:SS.NNNNNNNNN')
+//	timestamp()     → integer ms-since-epoch literal
+//	rand()          → float literal in [0,1)
+//	random()        → float literal in [0,1)
+//	randomUUID()    → string literal containing a v4 UUID
+//
+// `datetime('...')` and `date('...')` calls with arguments are deterministic
+// and are passed through unchanged. The rewriter only fires when the function
+// is invoked with empty parentheses.
+type Rewriter struct {
+	Now  func() time.Time
+	Rand func() float64
+	UUID func() string
+}
+
+// DefaultRewriter returns a Rewriter that uses real wall-clock time, the
+// math/rand/v2 PRNG (seeded by the runtime), and a crypto-random v4 UUID
+// generator.
+func DefaultRewriter() *Rewriter {
+	return &Rewriter{
+		Now:  time.Now,
+		Rand: mathrand.Float64,
+		UUID: newUUIDv4,
+	}
+}
+
+// Rewrite returns cypher with non-deterministic function calls replaced by
+// literal values. If no rewrites are needed the original string is returned
+// unchanged.
+func (rw *Rewriter) Rewrite(cypher string) string {
+	if cypher == "" {
+		return cypher
+	}
+	// Cheap pre-check: if the input doesn't contain a paren or any keyword
+	// candidate, skip the full walk.
+	if !mayContainNonDet(cypher) {
+		return cypher
+	}
+	return walkAndRewrite(cypher, rw)
+}
+
+// mayContainNonDet does a fast lower-cased substring scan. False positives
+// are fine — the full walker re-validates token boundaries.
+func mayContainNonDet(s string) bool {
+	if !strings.ContainsRune(s, '(') {
+		return false
+	}
+	lower := strings.ToLower(s)
+	for _, k := range nonDetKeywords {
+		if strings.Contains(lower, k) {
+			return true
+		}
+	}
+	return false
+}
+
+var nonDetKeywords = []string{
+	"now", "datetime", "localdatetime", "date", "time", "localtime",
+	"timestamp", "rand", "random", "randomuuid",
+}
+
+func walkAndRewrite(s string, rw *Rewriter) string {
+	var out strings.Builder
+	out.Grow(len(s))
+	i := 0
+	for i < len(s) {
+		c := s[i]
+
+		// Single-, double-, and backtick-quoted regions are passed through
+		// verbatim. We do not interpret their contents.
+		if c == '\'' || c == '"' || c == '`' {
+			j := skipQuoted(s, i)
+			out.WriteString(s[i:j])
+			i = j
+			continue
+		}
+
+		// Line and block comments — passed through verbatim.
+		if c == '/' && i+1 < len(s) {
+			if s[i+1] == '/' {
+				j := i + 2
+				for j < len(s) && s[j] != '\n' {
+					j++
+				}
+				out.WriteString(s[i:j])
+				i = j
+				continue
+			}
+			if s[i+1] == '*' {
+				j := i + 2
+				for j+1 < len(s) && !(s[j] == '*' && s[j+1] == '/') {
+					j++
+				}
+				if j+1 < len(s) {
+					j += 2
+				}
+				out.WriteString(s[i:j])
+				i = j
+				continue
+			}
+		}
+
+		// Identifier candidate — must start at a token boundary.
+		if isIdentStart(c) && (i == 0 || !isIdentRune(s[i-1])) {
+			end := i + 1
+			for end < len(s) && isIdentRune(s[end]) {
+				end++
+			}
+			ident := s[i:end]
+			if replacement, consumed, ok := matchNonDet(s, i, end, ident, rw); ok {
+				out.WriteString(replacement)
+				i += consumed
+				continue
+			}
+			out.WriteString(ident)
+			i = end
+			continue
+		}
+
+		out.WriteByte(c)
+		i++
+	}
+	return out.String()
+}
+
+// skipQuoted returns the index just past the closing quote at s[i]. Handles
+// backslash escapes for single/double quotes; backtick-quoted identifiers
+// have no escape syntax and end at the next backtick.
+func skipQuoted(s string, i int) int {
+	quote := s[i]
+	j := i + 1
+	for j < len(s) {
+		ch := s[j]
+		if quote != '`' && ch == '\\' && j+1 < len(s) {
+			j += 2
+			continue
+		}
+		if ch == quote {
+			return j + 1
+		}
+		j++
+	}
+	return j // unterminated — consume to end
+}
+
+// matchNonDet checks whether the identifier at s[start:end] is a
+// non-deterministic function call we should rewrite. Returns (replacement,
+// total bytes consumed from start, ok). If ok is false the caller emits the
+// original identifier unchanged.
+func matchNonDet(s string, start, end int, ident string, rw *Rewriter) (string, int, bool) {
+	lower := strings.ToLower(ident)
+
+	// Most rewrites require empty parens. randomUUID and timestamp also
+	// require parens (to avoid clobbering property names).
+	parenEnd, hasEmptyParens := scanEmptyParens(s, end)
+
+	switch lower {
+	case "now":
+		if !hasEmptyParens {
+			return "", 0, false
+		}
+		ts := rw.Now().UTC()
+		return fmt.Sprintf("datetime('%s')", ts.Format(time.RFC3339Nano)), parenEnd - start, true
+
+	case "datetime":
+		if !hasEmptyParens {
+			return "", 0, false
+		}
+		ts := rw.Now().UTC()
+		return fmt.Sprintf("datetime('%s')", ts.Format(time.RFC3339Nano)), parenEnd - start, true
+
+	case "localdatetime":
+		if !hasEmptyParens {
+			return "", 0, false
+		}
+		ts := rw.Now()
+		return fmt.Sprintf("localdatetime('%s')", ts.Format("2006-01-02T15:04:05.999999999")), parenEnd - start, true
+
+	case "date":
+		if !hasEmptyParens {
+			return "", 0, false
+		}
+		ts := rw.Now()
+		return fmt.Sprintf("date('%s')", ts.Format("2006-01-02")), parenEnd - start, true
+
+	case "time":
+		if !hasEmptyParens {
+			return "", 0, false
+		}
+		ts := rw.Now().UTC()
+		return fmt.Sprintf("time('%s')", ts.Format("15:04:05.999999999-07:00")), parenEnd - start, true
+
+	case "localtime":
+		if !hasEmptyParens {
+			return "", 0, false
+		}
+		ts := rw.Now()
+		return fmt.Sprintf("localtime('%s')", ts.Format("15:04:05.999999999")), parenEnd - start, true
+
+	case "timestamp":
+		if !hasEmptyParens {
+			return "", 0, false
+		}
+		ms := rw.Now().UnixMilli()
+		return fmt.Sprintf("%d", ms), parenEnd - start, true
+
+	case "rand", "random":
+		if !hasEmptyParens {
+			return "", 0, false
+		}
+		return formatFloat(rw.Rand()), parenEnd - start, true
+
+	case "randomuuid":
+		if !hasEmptyParens {
+			return "", 0, false
+		}
+		return "'" + rw.UUID() + "'", parenEnd - start, true
+	}
+
+	return "", 0, false
+}
+
+// scanEmptyParens checks whether s[end:] begins (after optional whitespace)
+// with "()" — i.e. the function is invoked with no arguments. Returns the
+// index just past the closing paren and true. If args are present (or no
+// parens), returns 0/false.
+func scanEmptyParens(s string, end int) (int, bool) {
+	j := end
+	for j < len(s) && (s[j] == ' ' || s[j] == '\t') {
+		j++
+	}
+	if j >= len(s) || s[j] != '(' {
+		return 0, false
+	}
+	j++
+	for j < len(s) && (s[j] == ' ' || s[j] == '\t') {
+		j++
+	}
+	if j >= len(s) || s[j] != ')' {
+		return 0, false
+	}
+	return j + 1, true
+}
+
+func isIdentStart(c byte) bool {
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '_'
+}
+
+func isIdentRune(c byte) bool {
+	return isIdentStart(c) || (c >= '0' && c <= '9')
+}
+
+// formatFloat returns a Cypher-safe decimal representation. We avoid
+// scientific notation because some Cypher dialects refuse it.
+func formatFloat(v float64) string {
+	return strings.TrimRight(strings.TrimRight(fmt.Sprintf("%.15f", v), "0"), ".")
+}
+
+// newUUIDv4 returns an RFC 4122 v4 UUID string. We avoid pulling in a
+// third-party library for one function.
+func newUUIDv4() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "00000000-0000-4000-8000-000000000000"
+	}
+	b[6] = (b[6] & 0x0f) | 0x40 // version 4
+	b[8] = (b[8] & 0x3f) | 0x80 // RFC 4122 variant
+	hexed := hex.EncodeToString(b[:])
+	return hexed[0:8] + "-" + hexed[8:12] + "-" + hexed[12:16] + "-" + hexed[16:20] + "-" + hexed[20:32]
+}

--- a/pkg/replication/rewriter.go
+++ b/pkg/replication/rewriter.go
@@ -114,7 +114,7 @@ func walkAndRewrite(s string, rw *Rewriter) string {
 			}
 			if s[i+1] == '*' {
 				j := i + 2
-				for j+1 < len(s) && !(s[j] == '*' && s[j+1] == '/') {
+				for j+1 < len(s) && (s[j] != '*' || s[j+1] != '/') {
 					j++
 				}
 				if j+1 < len(s) {

--- a/pkg/replication/rewriter_test.go
+++ b/pkg/replication/rewriter_test.go
@@ -1,0 +1,261 @@
+package replication
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+func itoa(v int64) string { return strconv.FormatInt(v, 10) }
+
+// frozenAt builds a Rewriter with a frozen clock and deterministic rand/UUID
+// so output assertions are exact.
+func frozenAt(t time.Time, randVal float64, uuid string) *Rewriter {
+	return &Rewriter{
+		Now:  func() time.Time { return t },
+		Rand: func() float64 { return randVal },
+		UUID: func() string { return uuid },
+	}
+}
+
+func TestRewriter_NoOpForCleanCypher(t *testing.T) {
+	rw := DefaultRewriter()
+	in := "MATCH (n:Person {name: 'Alice'}) RETURN n"
+	if got := rw.Rewrite(in); got != in {
+		t.Errorf("expected unchanged, got: %q", got)
+	}
+}
+
+func TestRewriter_NowToDatetimeLiteral(t *testing.T) {
+	ts := time.Date(2026, 5, 9, 12, 34, 56, 0, time.UTC)
+	rw := frozenAt(ts, 0, "")
+	got := rw.Rewrite("CREATE (n:Event {ts: now()})")
+	want := "CREATE (n:Event {ts: datetime('2026-05-09T12:34:56Z')})"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestRewriter_DatetimeEmptyParens(t *testing.T) {
+	ts := time.Date(2026, 5, 9, 12, 34, 56, 0, time.UTC)
+	rw := frozenAt(ts, 0, "")
+	got := rw.Rewrite("RETURN datetime()")
+	want := "RETURN datetime('2026-05-09T12:34:56Z')"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestRewriter_DatetimeWithArgsUnchanged(t *testing.T) {
+	rw := DefaultRewriter()
+	in := "RETURN datetime('2024-01-01T00:00:00Z')"
+	if got := rw.Rewrite(in); got != in {
+		t.Errorf("datetime(arg) must not be rewritten; got %q", got)
+	}
+}
+
+func TestRewriter_TimestampReturnsInteger(t *testing.T) {
+	ts := time.Date(2026, 5, 9, 12, 34, 56, 0, time.UTC)
+	rw := frozenAt(ts, 0, "")
+	got := rw.Rewrite("RETURN timestamp()")
+	wantMs := ts.UnixMilli()
+	want := "RETURN " + itoa(wantMs)
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestRewriter_Rand(t *testing.T) {
+	rw := frozenAt(time.Now(), 0.5, "")
+	got := rw.Rewrite("RETURN rand()")
+	if got != "RETURN 0.5" {
+		t.Errorf("got %q, want %q", got, "RETURN 0.5")
+	}
+}
+
+func TestRewriter_RandomAlias(t *testing.T) {
+	rw := frozenAt(time.Now(), 0.25, "")
+	got := rw.Rewrite("RETURN random()")
+	if got != "RETURN 0.25" {
+		t.Errorf("got %q, want %q", got, "RETURN 0.25")
+	}
+}
+
+func TestRewriter_RandomUUID(t *testing.T) {
+	rw := frozenAt(time.Now(), 0, "abc-uuid")
+	got := rw.Rewrite("CREATE (n {id: randomUUID()})")
+	want := "CREATE (n {id: 'abc-uuid'})"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestRewriter_CaseInsensitive(t *testing.T) {
+	ts := time.Date(2026, 5, 9, 12, 0, 0, 0, time.UTC)
+	rw := frozenAt(ts, 0, "")
+	got := rw.Rewrite("RETURN NOW(), Datetime(), TIMESTAMP()")
+	if !strings.Contains(got, "datetime('2026-05-09T12:00:00Z')") {
+		t.Errorf("expected NOW() and Datetime() rewritten; got: %q", got)
+	}
+	wantMs := itoa(ts.UnixMilli())
+	if !strings.Contains(got, wantMs) {
+		t.Errorf("expected TIMESTAMP() rewritten to ms-since-epoch %s; got: %q", wantMs, got)
+	}
+}
+
+func TestRewriter_PreservesSingleQuotedStrings(t *testing.T) {
+	rw := DefaultRewriter()
+	in := "CREATE (n:Note {body: 'see now() in docs'})"
+	if got := rw.Rewrite(in); got != in {
+		t.Errorf("must not rewrite inside '...'; got %q", got)
+	}
+}
+
+func TestRewriter_PreservesDoubleQuotedStrings(t *testing.T) {
+	rw := DefaultRewriter()
+	in := `CREATE (n:Note {body: "rand() should stay literal"})`
+	if got := rw.Rewrite(in); got != in {
+		t.Errorf("must not rewrite inside \"...\"; got %q", got)
+	}
+}
+
+func TestRewriter_PreservesBacktickIdentifiers(t *testing.T) {
+	rw := DefaultRewriter()
+	in := "MATCH (n) WHERE n.`now()` IS NOT NULL RETURN n"
+	if got := rw.Rewrite(in); got != in {
+		t.Errorf("must not rewrite inside `...`; got %q", got)
+	}
+}
+
+func TestRewriter_BareNowNotRewritten(t *testing.T) {
+	rw := DefaultRewriter()
+	in := "MATCH (n) WHERE n.now > 5 RETURN n"
+	if got := rw.Rewrite(in); got != in {
+		t.Errorf("bare 'now' identifier must not be rewritten; got %q", got)
+	}
+}
+
+func TestRewriter_NowNeedsParens(t *testing.T) {
+	rw := DefaultRewriter()
+	// `now` followed by something other than `()` is a property name, not
+	// the function. Leave alone.
+	in := "RETURN nowhere"
+	if got := rw.Rewrite(in); got != in {
+		t.Errorf("'nowhere' must not be split; got %q", got)
+	}
+}
+
+func TestRewriter_LineCommentSafe(t *testing.T) {
+	rw := DefaultRewriter()
+	in := "RETURN 1 // call now() later\n"
+	if got := rw.Rewrite(in); got != in {
+		t.Errorf("must not rewrite inside line comment; got %q", got)
+	}
+}
+
+func TestRewriter_BlockCommentSafe(t *testing.T) {
+	rw := DefaultRewriter()
+	in := "/* now() */ RETURN 1"
+	if got := rw.Rewrite(in); got != in {
+		t.Errorf("must not rewrite inside block comment; got %q", got)
+	}
+}
+
+func TestRewriter_DeterministicForFrozenClock(t *testing.T) {
+	ts := time.Date(2026, 5, 9, 12, 34, 56, 0, time.UTC)
+	rw := frozenAt(ts, 0.5, "uuid-x")
+	in := "CREATE (n {ts: now(), r: rand(), id: randomUUID()})"
+	a := rw.Rewrite(in)
+	b := rw.Rewrite(in)
+	if a != b {
+		t.Errorf("rewriter must be deterministic for frozen inputs:\n a: %q\n b: %q", a, b)
+	}
+}
+
+func TestRewriter_MultipleSubstitutionsInOneStatement(t *testing.T) {
+	ts := time.Date(2026, 5, 9, 12, 0, 0, 0, time.UTC)
+	rw := frozenAt(ts, 0.1, "")
+	in := "CREATE (n {a: now(), b: now(), c: rand()})"
+	got := rw.Rewrite(in)
+	if strings.Count(got, "datetime('2026-05-09T12:00:00Z')") != 2 {
+		t.Errorf("expected 2 datetime() rewrites; got: %q", got)
+	}
+	if !strings.Contains(got, "0.1") {
+		t.Errorf("expected rand() rewrite; got: %q", got)
+	}
+}
+
+func TestRewriter_EmptyParenSpaceTolerant(t *testing.T) {
+	ts := time.Date(2026, 5, 9, 12, 0, 0, 0, time.UTC)
+	rw := frozenAt(ts, 0, "")
+	got := rw.Rewrite("RETURN now (   )")
+	want := "RETURN datetime('2026-05-09T12:00:00Z')"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestRewriter_DateAndTimeFamily(t *testing.T) {
+	ts := time.Date(2026, 5, 9, 12, 34, 56, 0, time.UTC)
+	rw := frozenAt(ts, 0, "")
+
+	got := rw.Rewrite("RETURN date()")
+	if got != "RETURN date('2026-05-09')" {
+		t.Errorf("date(): got %q", got)
+	}
+
+	got = rw.Rewrite("RETURN time()")
+	if !strings.HasPrefix(got, "RETURN time('12:34:56") {
+		t.Errorf("time(): got %q", got)
+	}
+
+	got = rw.Rewrite("RETURN localdatetime()")
+	if !strings.HasPrefix(got, "RETURN localdatetime('2026-05-09T12:34:56") {
+		t.Errorf("localdatetime(): got %q", got)
+	}
+
+	got = rw.Rewrite("RETURN localtime()")
+	if !strings.HasPrefix(got, "RETURN localtime('12:34:56") {
+		t.Errorf("localtime(): got %q", got)
+	}
+}
+
+func TestRewriter_FormatFloatNoScientific(t *testing.T) {
+	if formatFloat(0.0000001) == "" || strings.Contains(formatFloat(0.0000001), "e") {
+		t.Errorf("formatFloat must not return scientific notation: %q", formatFloat(0.0000001))
+	}
+}
+
+func TestRewriter_NilSafe_EmptyInput(t *testing.T) {
+	rw := DefaultRewriter()
+	if rw.Rewrite("") != "" {
+		t.Error("empty input should pass through")
+	}
+}
+
+func TestRewriter_PreservesEscapedQuotes(t *testing.T) {
+	rw := DefaultRewriter()
+	in := `CREATE (n {body: 'it\'s now() o\'clock'})`
+	if got := rw.Rewrite(in); got != in {
+		t.Errorf("escaped quote should keep us inside the string; got %q", got)
+	}
+}
+
+func TestRewriter_UUIDFormat(t *testing.T) {
+	uuid := newUUIDv4()
+	// 8-4-4-4-12 hex chars = 36 with dashes
+	if len(uuid) != 36 {
+		t.Errorf("UUID length expected 36, got %d (%q)", len(uuid), uuid)
+	}
+	// Version 4: 14th nibble must be '4'
+	if uuid[14] != '4' {
+		t.Errorf("UUID v4 marker missing: %q", uuid)
+	}
+	// Variant: 19th nibble must be 8/9/a/b
+	switch uuid[19] {
+	case '8', '9', 'a', 'b':
+	default:
+		t.Errorf("UUID variant marker invalid: %q", uuid)
+	}
+}

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -63,6 +63,10 @@ type Router struct {
 	// WAL appender for recording writes (disaster recovery).
 	walAppender WALAppender
 
+	// Rewriter applied to write Cypher before WAL append + execution so
+	// replicas reproduce identical state when they replay the WAL.
+	writeRewriter WriteRewriter
+
 	// DDL hook for replicating schema changes via Raft.
 	ddlHook DDLHook
 
@@ -92,6 +96,15 @@ type PlacementResolver interface {
 // intent log. Implementations live in pkg/replication to avoid circular imports.
 type WALAppender interface {
 	Append(shardID int, cypher string) (uint64, error)
+}
+
+// WriteRewriter normalises non-deterministic Cypher functions (now(), rand(),
+// randomUUID(), …) to literal values BEFORE the statement is appended to the
+// WAL or executed on the primary. The same rewritten string is what replicas
+// replay, so primary and replicas converge to the same state. Implementations
+// live in pkg/replication to keep this package import-free.
+type WriteRewriter interface {
+	Rewrite(cypher string) string
 }
 
 // NewRouter creates a Router over the given shards.
@@ -133,6 +146,13 @@ func (r *Router) EdgeCut() *EdgeCutReplicator {
 // SetWAL attaches a WAL appender for recording write operations.
 func (r *Router) SetWAL(w WALAppender) {
 	r.walAppender = w
+}
+
+// SetWriteRewriter installs a rewriter that normalises non-deterministic
+// Cypher (now(), rand(), …) to literal values before WAL append and primary
+// execution. Pass nil to disable.
+func (r *Router) SetWriteRewriter(rw WriteRewriter) {
+	r.writeRewriter = rw
 }
 
 // SetDDLHook sets a hook that replicates schema DDL changes (e.g. via Raft).
@@ -348,9 +368,17 @@ func (r *Router) queryShard(ctx context.Context, shardID int, cypher string) (*R
 		if !s.IsHealthy() {
 			return nil, &QueryError{Code: "SHARD_UNAVAILABLE", Message: fmt.Sprintf("shard %d is unhealthy", shardID), ShardID: shardID}
 		}
-		if r.walAppender != nil && isWriteQuery(cypher) {
-			if _, err := r.walAppender.Append(shardID, cypher); err != nil {
-				return nil, &QueryError{Code: "WAL_ERROR", Message: fmt.Sprintf("WAL append failed: %v", err), ShardID: shardID}
+		if isWriteQuery(cypher) {
+			// Normalise non-deterministic functions (now(), rand(), …) to
+			// literals BEFORE WAL append AND execution so replicas replay the
+			// exact same statement and converge to the primary's state.
+			if r.writeRewriter != nil {
+				cypher = r.writeRewriter.Rewrite(cypher)
+			}
+			if r.walAppender != nil {
+				if _, err := r.walAppender.Append(shardID, cypher); err != nil {
+					return nil, &QueryError{Code: "WAL_ERROR", Message: fmt.Sprintf("WAL append failed: %v", err), ShardID: shardID}
+				}
 			}
 		}
 	}

--- a/pkg/router/router_test.go
+++ b/pkg/router/router_test.go
@@ -2,6 +2,8 @@ package router
 
 import (
 	"context"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -256,5 +258,112 @@ func TestRouter_OptionalMatchIsRead(t *testing.T) {
 	}
 	if len(result.Rows) != 3 {
 		t.Errorf("expected 3 rows from scatter-gather, got %d", len(result.Rows))
+	}
+}
+
+// --- Write rewriter tests ---
+
+// fakeWAL records each Append call.
+type fakeWAL struct {
+	mu      sync.Mutex
+	entries []walAppendCall
+	nextSeq uint64
+}
+
+type walAppendCall struct {
+	shardID int
+	cypher  string
+}
+
+func (f *fakeWAL) Append(shardID int, cypher string) (uint64, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.nextSeq++
+	f.entries = append(f.entries, walAppendCall{shardID: shardID, cypher: cypher})
+	return f.nextSeq, nil
+}
+
+// fakeRewriter swaps any "now()" for a fixed literal — easy to assert on.
+type fakeRewriter struct{}
+
+func (fakeRewriter) Rewrite(cypher string) string {
+	return strings.ReplaceAll(cypher, "now()", "datetime('FIXED')")
+}
+
+func TestRouter_RewriterRunsBeforeWAL(t *testing.T) {
+	shards := makeTestShards(3)
+	r := NewRouter(shards, 5*time.Second)
+	wal := &fakeWAL{}
+	r.SetWAL(wal)
+	r.SetWriteRewriter(fakeRewriter{})
+
+	// Use a write query with a shard key so it routes to a single shard.
+	_, err := r.Execute(context.Background(), "CREATE (p:Person {name: 'alice', ts: now()})")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(wal.entries) != 1 {
+		t.Fatalf("expected 1 WAL entry, got %d", len(wal.entries))
+	}
+	if !strings.Contains(wal.entries[0].cypher, "datetime('FIXED')") {
+		t.Errorf("WAL entry should contain rewritten literal; got: %q", wal.entries[0].cypher)
+	}
+	if strings.Contains(wal.entries[0].cypher, "now()") {
+		t.Errorf("WAL entry should NOT contain raw now(); got: %q", wal.entries[0].cypher)
+	}
+
+	// And the shard that executed must have received the SAME rewritten string,
+	// not the original. This is the correctness invariant: primary's local
+	// state derives from the same statement that replicas will replay.
+	var executed string
+	for _, s := range shards {
+		ms := s.Store.(*shard.MemoryStore)
+		log := ms.QueryLog()
+		if len(log) > 0 {
+			executed = log[0]
+			break
+		}
+	}
+	if executed == "" {
+		t.Fatal("no shard saw the query")
+	}
+	if !strings.Contains(executed, "datetime('FIXED')") {
+		t.Errorf("primary execution must use rewritten cypher; got: %q", executed)
+	}
+}
+
+func TestRouter_RewriterSkippedForReads(t *testing.T) {
+	shards := makeTestShards(3)
+	r := NewRouter(shards, 5*time.Second)
+	wal := &fakeWAL{}
+	r.SetWAL(wal)
+	r.SetWriteRewriter(fakeRewriter{})
+
+	_, err := r.Execute(context.Background(), "MATCH (p:Person {name: 'alice'}) RETURN p")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(wal.entries) != 0 {
+		t.Errorf("read query must not append to WAL, got %d entries", len(wal.entries))
+	}
+}
+
+func TestRouter_NoRewriterStillWALs(t *testing.T) {
+	shards := makeTestShards(3)
+	r := NewRouter(shards, 5*time.Second)
+	wal := &fakeWAL{}
+	r.SetWAL(wal)
+	// No rewriter set — write must still be recorded verbatim.
+
+	_, err := r.Execute(context.Background(), "CREATE (p:Person {name: 'alice', ts: now()})")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(wal.entries) != 1 {
+		t.Fatalf("expected 1 WAL entry, got %d", len(wal.entries))
+	}
+	if !strings.Contains(wal.entries[0].cypher, "now()") {
+		t.Errorf("without rewriter, WAL keeps original cypher; got: %q", wal.entries[0].cypher)
 	}
 }


### PR DESCRIPTION
## Summary
- Adds `replication.Rewriter` that pre-computes non-deterministic Cypher functions (`now()`, `rand()`, `randomUUID()`, …) to literal values
- Router applies the rewriter to every write Cypher BEFORE WAL append and BEFORE primary execution, so primary, WAL record, and every replica converge to the identical statement
- Closes one of the explicit edge-cases for issue #7: *"Non-deterministic Cypher (functions like `rand()`, `now()`) — must be resolved to concrete values on the primary before logging"*

## What rewrites
Only fires when called with empty parens (so already-deterministic forms like `datetime('2024-01-01')` pass through unchanged):

| Input | Output |
|-|-|
| `now()` / `datetime()` | `datetime('<RFC3339Nano UTC>')` |
| `localdatetime()` | `localdatetime('…')` |
| `date()` / `time()` / `localtime()` | typed literal |
| `timestamp()` | integer ms-since-epoch |
| `rand()` / `random()` | float in [0,1) |
| `randomUUID()` | quoted v4 UUID |

## Token safety
The walker skips quoted strings (`'…'`, `"…"`), backtick identifiers (`` `…` ``), `// line` comments, and `/* block */` comments before pattern-matching. Bare identifiers (`now`, `nowhere`) are left alone — only `name()` form rewrites.

## Test plan
- [x] `go build ./...` clean
- [x] `pkg/replication/rewriter_test.go` — 22 unit tests covering each function, case-insensitivity, string/comment/backtick safety, escaped quotes, multiple substitutions, deterministic output for frozen clock, UUID v4 format, no-op on clean Cypher
- [x] `pkg/router/router_test.go` — 3 integration tests verifying rewriter runs before WAL append, the same rewritten cypher reaches the primary's local shard, reads bypass both rewriter and WAL, and the WAL still records writes when no rewriter is installed
- [x] `go test ./...` — every package green

## Scope (deliberately small)
This is one slice of issue #7. Remaining items still tracked there: gRPC streaming WAL replication, sync replication acks, replica auto-promotion on primary failure, Prometheus replication-lag metrics, bootstrap-from-empty snapshot, epoch fence for split-brain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)