### PR TITLE
feat(api): expose Prometheus /metrics for replication lag

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -24,12 +24,12 @@ import (
 
 // Server is the HTTP API server for a Loveliness node.
 type Server struct {
-	router  *router.Router
+	router   *router.Router
 	dbRouter *router.DatabaseRouter
-	cluster *cluster.Cluster
-	shards  []*shard.Shard
-	schema  *schema.Registry
-	timeout time.Duration
+	cluster  *cluster.Cluster
+	shards   []*shard.Shard
+	schema   *schema.Registry
+	timeout  time.Duration
 
 	// refTracker tracks known node keys per shard for fast duplicate
 	// detection during bulk edge loading. Avoids expensive full-table
@@ -108,6 +108,7 @@ func (s *Server) Handler() http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /health", s.handleHealth)
 	mux.HandleFunc("GET /discovery", s.handleDiscovery)
+	mux.HandleFunc("GET /metrics", s.handleMetrics)
 	if s.auth != nil && s.auth.Enabled() {
 		mux.Handle("/", s.auth.Middleware(protected))
 	} else {
@@ -294,12 +295,12 @@ func (s *Server) handleCluster(w http.ResponseWriter, r *http.Request) {
 	sm := s.cluster.GetShardMap()
 	schemaTables := s.cluster.GetSchema()
 	writeJSON(w, http.StatusOK, map[string]any{
-		"leader":      s.cluster.LeaderAddr(),
-		"node_id":     s.cluster.NodeID(),
-		"is_leader":   s.cluster.IsLeader(),
-		"shard_map":   sm.Assignments,
-		"nodes":       sm.Nodes,
-		"schema":      schemaTables,
+		"leader":    s.cluster.LeaderAddr(),
+		"node_id":   s.cluster.NodeID(),
+		"is_leader": s.cluster.IsLeader(),
+		"shard_map": sm.Assignments,
+		"nodes":     sm.Nodes,
+		"schema":    schemaTables,
 	})
 }
 

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -1,0 +1,173 @@
+package api
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+)
+
+// handleMetrics serves Prometheus text-format metrics. We hand-roll the
+// exposition format (one line per series, "# HELP" + "# TYPE" headers) to
+// avoid dragging in the prometheus client_golang dependency just to publish
+// a handful of gauges.
+//
+// Series exposed (issue #7 acceptance criteria):
+//
+//	loveliness_replication_lag_seconds{shard_id, replica_id}  gauge
+//	loveliness_replication_lag_bytes{shard_id, replica_id}    gauge
+//	loveliness_replication_lag_entries{shard_id, replica_id}  gauge
+//	loveliness_wal_head_sequence{shard_id}                    gauge
+//	loveliness_wal_global_sequence                            gauge
+//	loveliness_local_shards                                   gauge
+func (s *Server) handleMetrics(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+	writeMetrics(w, s)
+}
+
+// metricsWAL is the slice of *replication.WAL the metrics handler needs. An
+// interface lets tests inject lightweight fakes without spinning up a real
+// WAL on disk.
+type metricsWAL interface {
+	LastSequence() uint64
+	ShardSequence(shardID int) uint64
+	HeadTimestamp(shardID int) time.Time
+	LagBytes(shardID int, afterSeq uint64) int64
+}
+
+// metricsReplicaState is the slice of *replication.ReplicaState the metrics
+// handler needs.
+type metricsReplicaState interface {
+	GetPosition(shardID int, nodeID string) uint64
+	GetTimestamp(shardID int, nodeID string) time.Time
+}
+
+// replicaLagPair identifies a (shard, replica) pair the handler should emit.
+type replicaLagPair struct {
+	ShardID int
+	Replica string
+}
+
+func writeMetrics(w io.Writer, s *Server) {
+	emitHelp(w, "loveliness_local_shards", "Number of shards opened on this node.", "gauge")
+	fprintf(w, "loveliness_local_shards %d\n", len(s.shards))
+
+	if s.dr == nil || s.dr.WAL == nil {
+		return
+	}
+
+	shardIDs := make([]int, 0, len(s.shards))
+	for _, sh := range s.shards {
+		shardIDs = append(shardIDs, sh.ID)
+	}
+
+	var pairs []replicaLagPair
+	if s.dr.ReplicaState != nil && s.cluster != nil {
+		sm := s.cluster.GetShardMap()
+		for shardID, assignment := range sm.Assignments {
+			for _, r := range assignment.Replicas {
+				if r == "" {
+					continue
+				}
+				pairs = append(pairs, replicaLagPair{ShardID: shardID, Replica: r})
+			}
+		}
+	}
+
+	writeWALMetrics(w, s.dr.WAL, shardIDs, s.dr.ReplicaState, pairs)
+}
+
+// writeWALMetrics emits the WAL- and replica-related series. It's split out
+// so tests can drive it with fakes instead of a full Server + cluster.
+func writeWALMetrics(w io.Writer, wal metricsWAL, shardIDs []int, rs metricsReplicaState, pairs []replicaLagPair) {
+	emitHelp(w, "loveliness_wal_global_sequence", "Monotonic global WAL sequence across all shards.", "gauge")
+	fprintf(w, "loveliness_wal_global_sequence %d\n", wal.LastSequence())
+
+	emitHelp(w, "loveliness_wal_head_sequence", "Highest WAL sequence written for a shard.", "gauge")
+	sortedShards := append([]int(nil), shardIDs...)
+	sort.Ints(sortedShards)
+	for _, sid := range sortedShards {
+		fprintf(w, "loveliness_wal_head_sequence{shard_id=\"%d\"} %d\n",
+			sid, wal.ShardSequence(sid))
+	}
+
+	if rs == nil || len(pairs) == 0 {
+		return
+	}
+
+	sortedPairs := append([]replicaLagPair(nil), pairs...)
+	sort.Slice(sortedPairs, func(i, j int) bool {
+		if sortedPairs[i].ShardID != sortedPairs[j].ShardID {
+			return sortedPairs[i].ShardID < sortedPairs[j].ShardID
+		}
+		return sortedPairs[i].Replica < sortedPairs[j].Replica
+	})
+
+	emitHelp(w, "loveliness_replication_lag_entries", "Replica lag in WAL entries (head_seq - applied_seq).", "gauge")
+	for _, p := range sortedPairs {
+		head := wal.ShardSequence(p.ShardID)
+		pos := rs.GetPosition(p.ShardID, p.Replica)
+		var lag uint64
+		if head > pos {
+			lag = head - pos
+		}
+		fprintf(w, "loveliness_replication_lag_entries{shard_id=\"%d\",replica_id=%q} %d\n",
+			p.ShardID, p.Replica, lag)
+	}
+
+	emitHelp(w, "loveliness_replication_lag_bytes", "Replica lag in WAL bytes (sum of unapplied entry sizes on disk).", "gauge")
+	for _, p := range sortedPairs {
+		pos := rs.GetPosition(p.ShardID, p.Replica)
+		fprintf(w, "loveliness_replication_lag_bytes{shard_id=\"%d\",replica_id=%q} %d\n",
+			p.ShardID, p.Replica, wal.LagBytes(p.ShardID, pos))
+	}
+
+	emitHelp(w, "loveliness_replication_lag_seconds", "Replica lag in seconds (WAL head timestamp - replica's last-applied entry timestamp).", "gauge")
+	for _, p := range sortedPairs {
+		head := wal.HeadTimestamp(p.ShardID)
+		applied := rs.GetTimestamp(p.ShardID, p.Replica)
+		pos := rs.GetPosition(p.ShardID, p.Replica)
+		seconds := computeLagSeconds(head, applied, pos)
+		fprintf(w, "loveliness_replication_lag_seconds{shard_id=\"%d\",replica_id=%q} %s\n",
+			p.ShardID, p.Replica, formatGaugeFloat(seconds))
+	}
+}
+
+// computeLagSeconds mirrors the API JSON formula: when both the head and the
+// applied timestamp are known, it's the difference between them; when the
+// replica has applied nothing yet but the WAL has data, it's the wall-clock
+// age of the WAL head; otherwise zero.
+func computeLagSeconds(head, applied time.Time, pos uint64) float64 {
+	if !head.IsZero() && !applied.IsZero() {
+		return head.Sub(applied).Seconds()
+	}
+	if !head.IsZero() && pos == 0 {
+		return time.Since(head).Seconds()
+	}
+	return 0.0
+}
+
+func emitHelp(w io.Writer, name, help, typ string) {
+	fprintf(w, "# HELP %s %s\n", name, help)
+	fprintf(w, "# TYPE %s %s\n", name, typ)
+}
+
+// fprintf wraps fmt.Fprintf for the metrics writer. We deliberately drop the
+// error: the writer is an http.ResponseWriter and there's nothing useful to do
+// if the client disconnected mid-stream.
+func fprintf(w io.Writer, format string, a ...any) {
+	_, _ = fmt.Fprintf(w, format, a...)
+}
+
+// formatGaugeFloat avoids scientific notation, which the Prometheus text
+// parser accepts but downstream tools sometimes mishandle.
+func formatGaugeFloat(v float64) string {
+	s := fmt.Sprintf("%.6f", v)
+	s = strings.TrimRight(strings.TrimRight(s, "0"), ".")
+	if s == "" || s == "-" {
+		s = "0"
+	}
+	return s
+}

--- a/pkg/api/metrics_test.go
+++ b/pkg/api/metrics_test.go
@@ -1,0 +1,219 @@
+package api
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fakeWAL implements metricsWAL with hand-set values.
+type fakeWAL struct {
+	last     uint64
+	shardSeq map[int]uint64
+	headTS   map[int]time.Time
+	lagBytes map[int]int64
+}
+
+func (f *fakeWAL) LastSequence() uint64                        { return f.last }
+func (f *fakeWAL) ShardSequence(shardID int) uint64            { return f.shardSeq[shardID] }
+func (f *fakeWAL) HeadTimestamp(shardID int) time.Time         { return f.headTS[shardID] }
+func (f *fakeWAL) LagBytes(shardID int, afterSeq uint64) int64 { return f.lagBytes[shardID] }
+
+// fakeReplicaState implements metricsReplicaState.
+type fakeReplicaState struct {
+	pos map[string]uint64
+	ts  map[string]time.Time
+}
+
+func key(shard int, node string) string {
+	return node + "/" + string(rune('0'+shard))
+}
+func (f *fakeReplicaState) GetPosition(shardID int, nodeID string) uint64 {
+	return f.pos[key(shardID, nodeID)]
+}
+func (f *fakeReplicaState) GetTimestamp(shardID int, nodeID string) time.Time {
+	return f.ts[key(shardID, nodeID)]
+}
+
+func TestWriteWALMetrics_BasicShape(t *testing.T) {
+	headTS := time.Date(2026, 5, 9, 12, 0, 0, 0, time.UTC)
+	appliedTS := headTS.Add(-2 * time.Second)
+
+	wal := &fakeWAL{
+		last:     17,
+		shardSeq: map[int]uint64{0: 10, 1: 7},
+		headTS:   map[int]time.Time{0: headTS, 1: headTS},
+		lagBytes: map[int]int64{0: 256, 1: 0},
+	}
+	rs := &fakeReplicaState{
+		pos: map[string]uint64{key(0, "node-2"): 8, key(1, "node-2"): 7},
+		ts:  map[string]time.Time{key(0, "node-2"): appliedTS, key(1, "node-2"): headTS},
+	}
+	pairs := []replicaLagPair{
+		{ShardID: 0, Replica: "node-2"},
+		{ShardID: 1, Replica: "node-2"},
+	}
+
+	var buf bytes.Buffer
+	writeWALMetrics(&buf, wal, []int{0, 1}, rs, pairs)
+	out := buf.String()
+
+	// Headers and series must be present.
+	mustContain := []string{
+		"# HELP loveliness_wal_global_sequence",
+		"# TYPE loveliness_wal_global_sequence gauge",
+		"loveliness_wal_global_sequence 17",
+		`loveliness_wal_head_sequence{shard_id="0"} 10`,
+		`loveliness_wal_head_sequence{shard_id="1"} 7`,
+		"# HELP loveliness_replication_lag_entries",
+		`loveliness_replication_lag_entries{shard_id="0",replica_id="node-2"} 2`,
+		`loveliness_replication_lag_entries{shard_id="1",replica_id="node-2"} 0`,
+		`loveliness_replication_lag_bytes{shard_id="0",replica_id="node-2"} 256`,
+		`loveliness_replication_lag_bytes{shard_id="1",replica_id="node-2"} 0`,
+		`loveliness_replication_lag_seconds{shard_id="0",replica_id="node-2"} 2`,
+		`loveliness_replication_lag_seconds{shard_id="1",replica_id="node-2"} 0`,
+	}
+	for _, s := range mustContain {
+		if !strings.Contains(out, s) {
+			t.Errorf("output missing %q\nfull output:\n%s", s, out)
+		}
+	}
+}
+
+func TestWriteWALMetrics_NoReplicas(t *testing.T) {
+	wal := &fakeWAL{
+		last:     5,
+		shardSeq: map[int]uint64{0: 5},
+		headTS:   map[int]time.Time{0: time.Now()},
+	}
+	var buf bytes.Buffer
+	writeWALMetrics(&buf, wal, []int{0}, nil, nil)
+	out := buf.String()
+	if !strings.Contains(out, "loveliness_wal_global_sequence 5") {
+		t.Error("expected wal_global_sequence")
+	}
+	if strings.Contains(out, "loveliness_replication_lag_entries") {
+		t.Errorf("must not emit lag series with no replicas; got:\n%s", out)
+	}
+}
+
+func TestWriteWALMetrics_StableOrder(t *testing.T) {
+	wal := &fakeWAL{
+		shardSeq: map[int]uint64{2: 1, 0: 1, 1: 1},
+		headTS:   map[int]time.Time{0: {}, 1: {}, 2: {}},
+	}
+	rs := &fakeReplicaState{}
+	// Pass shards out of order to confirm sort.
+	pairs := []replicaLagPair{
+		{ShardID: 1, Replica: "z"},
+		{ShardID: 0, Replica: "b"},
+		{ShardID: 0, Replica: "a"},
+	}
+	var buf bytes.Buffer
+	writeWALMetrics(&buf, wal, []int{2, 0, 1}, rs, pairs)
+	out := buf.String()
+
+	idxA := strings.Index(out, `replica_id="a"`)
+	idxB := strings.Index(out, `replica_id="b"`)
+	idxZ := strings.Index(out, `replica_id="z"`)
+	if idxA < 0 || idxA >= idxB || idxB >= idxZ {
+		t.Errorf("expected stable shard/replica ordering a<b<z; got positions a=%d b=%d z=%d in:\n%s",
+			idxA, idxB, idxZ, out)
+	}
+
+	// Shard ordering for head_sequence series.
+	idx0 := strings.Index(out, `loveliness_wal_head_sequence{shard_id="0"}`)
+	idx1 := strings.Index(out, `loveliness_wal_head_sequence{shard_id="1"}`)
+	idx2 := strings.Index(out, `loveliness_wal_head_sequence{shard_id="2"}`)
+	if idx0 < 0 || idx0 >= idx1 || idx1 >= idx2 {
+		t.Errorf("expected stable shard ordering 0<1<2 in head_sequence; got %d %d %d", idx0, idx1, idx2)
+	}
+}
+
+func TestComputeLagSeconds(t *testing.T) {
+	zero := time.Time{}
+	head := time.Date(2026, 5, 9, 12, 0, 0, 0, time.UTC)
+	applied := head.Add(-3 * time.Second)
+
+	cases := []struct {
+		name    string
+		head    time.Time
+		applied time.Time
+		pos     uint64
+		check   func(t *testing.T, got float64)
+	}{
+		{
+			name:    "both timestamps known",
+			head:    head,
+			applied: applied,
+			pos:     5,
+			check: func(t *testing.T, got float64) {
+				if got != 3.0 {
+					t.Errorf("expected 3, got %v", got)
+				}
+			},
+		},
+		{
+			name:    "replica fresh, head set",
+			head:    time.Now().Add(-time.Second),
+			applied: zero,
+			pos:     0,
+			check: func(t *testing.T, got float64) {
+				if got <= 0 {
+					t.Errorf("expected positive lag for fresh replica, got %v", got)
+				}
+			},
+		},
+		{
+			name:    "no head",
+			head:    zero,
+			applied: zero,
+			pos:     0,
+			check: func(t *testing.T, got float64) {
+				if got != 0 {
+					t.Errorf("expected 0, got %v", got)
+				}
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.check(t, computeLagSeconds(tc.head, tc.applied, tc.pos))
+		})
+	}
+}
+
+func TestFormatGaugeFloat(t *testing.T) {
+	cases := map[float64]string{
+		0:        "0",
+		1:        "1",
+		2.5:      "2.5",
+		0.000001: "0.000001",
+	}
+	for in, want := range cases {
+		if got := formatGaugeFloat(in); got != want {
+			t.Errorf("formatGaugeFloat(%v) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestMetricsHandler_RoutesAndContentType(t *testing.T) {
+	srv := setupTestServer()
+	req := httptest.NewRequest("GET", "/metrics", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	ct := w.Header().Get("Content-Type")
+	if !strings.HasPrefix(ct, "text/plain") {
+		t.Errorf("expected text/plain content type, got %q", ct)
+	}
+	if !strings.Contains(w.Body.String(), "loveliness_local_shards") {
+		t.Errorf("expected loveliness_local_shards in output:\n%s", w.Body.String())
+	}
+}


### PR DESCRIPTION
## Summary

- Adds a public `GET /metrics` endpoint emitting Prometheus text-format 0.0.4. No client_golang dependency — the surface is six gauges.
- Series exposed: `loveliness_local_shards`, `loveliness_wal_global_sequence`, `loveliness_wal_head_sequence{shard_id}`, `loveliness_replication_lag_entries{shard_id, replica_id}`, `loveliness_replication_lag_bytes{shard_id, replica_id}`, `loveliness_replication_lag_seconds{shard_id, replica_id}`.
- `writeWALMetrics` takes `metricsWAL` / `metricsReplicaState` interfaces so tests drive it with fakes; output is sorted by shard_id then replica_id for deterministic scrapes.

Slice (a) of issue #7 (Shard replication observability) — exposes data plumbed in #31.

## Test plan
- [x] `go test ./pkg/api/...` (new `metrics_test.go` covers shape, label format, ordering, no-replica case, lag formula, content-type, route registration)
- [x] `go test ./...` — full suite green
- [x] `golangci-lint run ./pkg/api/...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)