### PR TITLE
feat(replication): wire write replicator into router with consistency knob

### DIFF
--- a/cmd/loveliness/main.go
+++ b/cmd/loveliness/main.go
@@ -247,6 +247,26 @@ func main() {
 	r.SetWAL(wal)
 	r.SetWriteRewriter(replication.DefaultRewriter())
 
+	// Wire write replication. The router calls ReplicateWrite after a
+	// successful primary write; the replicator looks up live ownership
+	// from Raft state and fans the rewritten Cypher out to replicas
+	// according to the configured consistency level.
+	consistency := replication.ParseConsistency(cfg.WriteConsistency)
+	resolver := replication.ShardResolverFunc(func(shardID int) replication.ShardOwnership {
+		a := c.GetShardMap().Assignments[shardID]
+		return replication.ShardOwnership{
+			ShardID:  shardID,
+			Primary:  a.Primary,
+			Replicas: a.Replicas,
+		}
+	})
+	r.SetWriteReplicator(replication.NewRouterReplicator(
+		replication.NewReplicator(transportClient, queryTimeout),
+		resolver,
+		consistency,
+	))
+	slog.Info("write replication wired", "consistency", consistency.String())
+
 	// Initialize backup store (S3 if configured, otherwise local).
 	backupMgr := backup.NewManager(cfg.DataDir, cfg.NodeID)
 	dr := &api.DRExtension{

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -79,6 +79,14 @@ type Config struct {
 	// bootstrap and surface the shortfall through observability.
 	ReplicationFactor int
 
+	// WriteConsistency controls how many replicas must acknowledge a
+	// write before the primary returns success to the client.
+	//   "one"    — primary-only ack; replicas catch up async (default).
+	//   "quorum" — primary + ⌊RF/2⌋ replicas must apply.
+	//   "all"    — every replica must apply.
+	// Anything else is parsed as "quorum" by replication.ParseConsistency.
+	WriteConsistency string
+
 	// DNS discovery configuration.
 	DiscoverMode     string // "dns" to enable DNS-based peer discovery, empty to disable
 	DiscoverAddr     string // DNS name to resolve for peer discovery (e.g., "loveliness.internal")
@@ -103,6 +111,7 @@ func DefaultConfig() Config {
 		TLSMode:              "off",
 		TLSClientAuth:        "require",
 		ReplicationFactor:    1,
+		WriteConsistency:     "one",
 	}
 }
 
@@ -219,6 +228,9 @@ func FromEnv() Config {
 		if n, err := strconv.Atoi(v); err == nil && n > 0 {
 			c.ReplicationFactor = n
 		}
+	}
+	if v := os.Getenv("LOVELINESS_WRITE_CONSISTENCY"); v != "" {
+		c.WriteConsistency = v
 	}
 	return c
 }

--- a/pkg/replication/replicator.go
+++ b/pkg/replication/replicator.go
@@ -61,6 +61,16 @@ type ShardResolver interface {
 	GetShardOwner(shardID int) ShardOwnership
 }
 
+// ShardResolverFunc adapts a plain function to the ShardResolver interface
+// so callers can plug in a closure over their cluster state without a
+// dedicated adapter type.
+type ShardResolverFunc func(shardID int) ShardOwnership
+
+// GetShardOwner satisfies ShardResolver.
+func (f ShardResolverFunc) GetShardOwner(shardID int) ShardOwnership {
+	return f(shardID)
+}
+
 // Replicator handles write fan-out to replica shards after primary write.
 type Replicator struct {
 	client  *transport.Client

--- a/pkg/replication/router_replicator.go
+++ b/pkg/replication/router_replicator.go
@@ -1,0 +1,56 @@
+package replication
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// RouterReplicator adapts the existing fan-out Replicator to the simple
+// (shardID, cypher) call signature the router uses. It owns the consistency
+// level and the ShardResolver so the router never has to know about either.
+type RouterReplicator struct {
+	repl        *Replicator
+	resolver    ShardResolver
+	consistency Consistency
+}
+
+// NewRouterReplicator wires a Replicator + ShardResolver + Consistency level
+// into something the router can call as `WriteReplicator`. The resolver is
+// queried per-write so primary/replica reassignments take effect immediately.
+func NewRouterReplicator(repl *Replicator, resolver ShardResolver, consistency Consistency) *RouterReplicator {
+	return &RouterReplicator{
+		repl:        repl,
+		resolver:    resolver,
+		consistency: consistency,
+	}
+}
+
+// ReplicateWrite fans `cypher` out to the shard's replicas. For
+// ConsistencyOne this returns nil immediately and the underlying call
+// fires-and-forgets. For Quorum / All it blocks until enough replicas
+// have acknowledged or the inner replicator's timeout elapses; if the
+// required ack count is not reached, a non-nil error is returned and the
+// router surfaces it to the client as a write failure.
+func (rr *RouterReplicator) ReplicateWrite(ctx context.Context, shardID int, cypher string) error {
+	if rr.repl == nil || rr.resolver == nil {
+		return nil
+	}
+	ownership := rr.resolver.GetShardOwner(shardID)
+	if len(ownership.Replicas) == 0 {
+		return nil
+	}
+	result := rr.repl.Replicate(ctx, ownership, cypher, rr.consistency)
+	if rr.consistency == ConsistencyOne {
+		return nil
+	}
+	needed := 1
+	if rr.consistency == ConsistencyAll {
+		needed = len(ownership.Replicas)
+	}
+	if result.ReplicaACK < needed {
+		return fmt.Errorf("consistency=%s wanted %d acks, got %d (%s)",
+			rr.consistency, needed, result.ReplicaACK, strings.Join(result.ReplicaErr, "; "))
+	}
+	return nil
+}

--- a/pkg/replication/router_replicator_test.go
+++ b/pkg/replication/router_replicator_test.go
@@ -1,0 +1,118 @@
+package replication
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/johnjansen/loveliness/pkg/shard"
+	"github.com/johnjansen/loveliness/pkg/transport"
+)
+
+func TestRouterReplicator_NoReplicasIsNoop(t *testing.T) {
+	rr := NewRouterReplicator(
+		NewReplicator(transport.NewClient(time.Second), time.Second),
+		ShardResolverFunc(func(shardID int) ShardOwnership {
+			return ShardOwnership{ShardID: shardID, Primary: "primary-1"}
+		}),
+		ConsistencyQuorum,
+	)
+	if err := rr.ReplicateWrite(context.Background(), 0, "CREATE (n:Test)"); err != nil {
+		t.Errorf("expected nil error with no replicas, got %v", err)
+	}
+}
+
+func TestRouterReplicator_ConsistencyOneAlwaysSucceeds(t *testing.T) {
+	// ConsistencyOne is fire-and-forget — even an unreachable replica must
+	// not surface an error to the router.
+	client := transport.NewClient(200 * time.Millisecond)
+	client.SetPeer("dead-replica", "127.0.0.1:1") // nothing listening
+
+	rr := NewRouterReplicator(
+		NewReplicator(client, 200*time.Millisecond),
+		ShardResolverFunc(func(shardID int) ShardOwnership {
+			return ShardOwnership{ShardID: shardID, Primary: "primary-1", Replicas: []string{"dead-replica"}}
+		}),
+		ConsistencyOne,
+	)
+	if err := rr.ReplicateWrite(context.Background(), 0, "CREATE (n:Test)"); err != nil {
+		t.Errorf("ConsistencyOne must not surface async errors, got %v", err)
+	}
+}
+
+func TestRouterReplicator_QuorumSucceedsWithLiveReplica(t *testing.T) {
+	srv := newReplicaTestServer(t, "replica-live")
+	defer srv.Close()
+
+	client := transport.NewClient(time.Second)
+	client.SetPeer("replica-live", srv.Listener.Addr().String())
+
+	rr := NewRouterReplicator(
+		NewReplicator(client, time.Second),
+		ShardResolverFunc(func(shardID int) ShardOwnership {
+			return ShardOwnership{ShardID: shardID, Primary: "primary-1", Replicas: []string{"replica-live"}}
+		}),
+		ConsistencyQuorum,
+	)
+	if err := rr.ReplicateWrite(context.Background(), 0, "CREATE (n:Test)"); err != nil {
+		t.Errorf("quorum should succeed with one live replica, got %v", err)
+	}
+}
+
+func TestRouterReplicator_QuorumFailsWhenAllReplicasDown(t *testing.T) {
+	client := transport.NewClient(200 * time.Millisecond)
+	client.SetPeer("dead-replica", "127.0.0.1:1")
+
+	rr := NewRouterReplicator(
+		NewReplicator(client, 200*time.Millisecond),
+		ShardResolverFunc(func(shardID int) ShardOwnership {
+			return ShardOwnership{ShardID: shardID, Primary: "primary-1", Replicas: []string{"dead-replica"}}
+		}),
+		ConsistencyQuorum,
+	)
+	err := rr.ReplicateWrite(context.Background(), 0, "CREATE (n:Test)")
+	if err == nil {
+		t.Fatal("expected quorum failure when only replica is down")
+	}
+	if !strings.Contains(err.Error(), "consistency=QUORUM") {
+		t.Errorf("error should describe consistency level; got %v", err)
+	}
+}
+
+func TestRouterReplicator_AllRequiresEveryReplica(t *testing.T) {
+	srv := newReplicaTestServer(t, "replica-up")
+	defer srv.Close()
+
+	client := transport.NewClient(200 * time.Millisecond)
+	client.SetPeer("replica-up", srv.Listener.Addr().String())
+	client.SetPeer("replica-down", "127.0.0.1:1")
+
+	rr := NewRouterReplicator(
+		NewReplicator(client, 300*time.Millisecond),
+		ShardResolverFunc(func(shardID int) ShardOwnership {
+			return ShardOwnership{
+				ShardID:  shardID,
+				Primary:  "primary-1",
+				Replicas: []string{"replica-up", "replica-down"},
+			}
+		}),
+		ConsistencyAll,
+	)
+	err := rr.ReplicateWrite(context.Background(), 0, "CREATE (n:Test)")
+	if err == nil {
+		t.Fatal("ConsistencyAll must fail when any replica is unreachable")
+	}
+}
+
+func newReplicaTestServer(t *testing.T, nodeID string) *httptest.Server {
+	t.Helper()
+	m := shard.NewTestManager(nodeID)
+	m.UpdateAssignments(map[int]shard.Assignment{0: {Primary: nodeID}})
+	h := transport.NewHandler(m)
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+	return httptest.NewServer(mux)
+}

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -67,6 +67,11 @@ type Router struct {
 	// replicas reproduce identical state when they replay the WAL.
 	writeRewriter WriteRewriter
 
+	// Replicator fans successful primary writes out to replica nodes.
+	// Only invoked when this node is the primary for the shard, to keep
+	// replicated writes from looping back through the same path.
+	replicator WriteReplicator
+
 	// DDL hook for replicating schema changes via Raft.
 	ddlHook DDLHook
 
@@ -105,6 +110,18 @@ type WALAppender interface {
 // live in pkg/replication to keep this package import-free.
 type WriteRewriter interface {
 	Rewrite(cypher string) string
+}
+
+// WriteReplicator fans a successful primary write out to the shard's replica
+// nodes. The implementation owns its own consistency level and ownership
+// resolution, so the router only has to hand it the (shard, cypher) pair.
+//
+// For ConsistencyOne / async modes the call should return quickly (errors
+// logged internally). For Quorum / All modes the call blocks until enough
+// acks arrive; a non-nil error from those modes is surfaced to the client
+// as a write failure. Implementations live in pkg/replication.
+type WriteReplicator interface {
+	ReplicateWrite(ctx context.Context, shardID int, cypher string) error
 }
 
 // NewRouter creates a Router over the given shards.
@@ -153,6 +170,24 @@ func (r *Router) SetWAL(w WALAppender) {
 // execution. Pass nil to disable.
 func (r *Router) SetWriteRewriter(rw WriteRewriter) {
 	r.writeRewriter = rw
+}
+
+// SetWriteReplicator installs a write replicator. After a successful primary
+// write the router calls ReplicateWrite to fan the rewritten Cypher out to
+// replica nodes. Pass nil to disable replication (single-node deployments).
+func (r *Router) SetWriteReplicator(wr WriteReplicator) {
+	r.replicator = wr
+}
+
+// isPrimaryForShard reports whether this node is the primary for the shard.
+// Used to gate write fan-out so a replica receiving a propagated write does
+// not re-replicate it. In standalone mode (no placement / nodeID) treat as
+// primary so single-node setups still WAL-append normally.
+func (r *Router) isPrimaryForShard(shardID int) bool {
+	if r.placement == nil || r.nodeID == "" {
+		return true
+	}
+	return r.placement.PrimaryForShard(shardID) == r.nodeID
 }
 
 // SetDDLHook sets a hook that replicates schema DDL changes (e.g. via Raft).
@@ -383,6 +418,8 @@ func (r *Router) queryShard(ctx context.Context, shardID int, cypher string) (*R
 		}
 	}
 
+	isWrite := isWriteQuery(cypher)
+
 	type queryResult struct {
 		resp *shard.QueryResponse
 		err  error
@@ -393,6 +430,15 @@ func (r *Router) queryShard(ctx context.Context, shardID int, cypher string) (*R
 		var err error
 		if isLocal {
 			resp, err = r.shards[shardID].Query(cypher)
+			// After a successful primary write, fan the rewritten Cypher
+			// out to replica nodes. Replicas receiving this via the remote
+			// query path are gated by isPrimaryForShard so they do not
+			// re-replicate.
+			if err == nil && isWrite && r.replicator != nil && r.isPrimaryForShard(shardID) {
+				if rerr := r.replicator.ReplicateWrite(ctx, shardID, cypher); rerr != nil {
+					err = fmt.Errorf("replication: %w", rerr)
+				}
+			}
 		} else {
 			nodeID := r.placement.PrimaryForShard(shardID)
 			if nodeID == "" {

--- a/pkg/router/router_test.go
+++ b/pkg/router/router_test.go
@@ -367,3 +367,113 @@ func TestRouter_NoRewriterStillWALs(t *testing.T) {
 		t.Errorf("without rewriter, WAL keeps original cypher; got: %q", wal.entries[0].cypher)
 	}
 }
+
+// --- Write replicator tests ---
+
+// fakeReplicator records each ReplicateWrite call and can be configured to
+// return an error to simulate a sync-replication quorum failure.
+type fakeReplicator struct {
+	mu    sync.Mutex
+	calls []replicateCall
+	err   error
+}
+
+type replicateCall struct {
+	shardID int
+	cypher  string
+}
+
+func (f *fakeReplicator) ReplicateWrite(_ context.Context, shardID int, cypher string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, replicateCall{shardID: shardID, cypher: cypher})
+	return f.err
+}
+
+// fakePlacement is a minimal PlacementResolver used to simulate a multi-node
+// cluster — the router asks it to decide whether the local node is the
+// primary for a given shard.
+type fakePlacement struct {
+	primary map[int]string
+}
+
+func (f *fakePlacement) PrimaryForShard(shardID int) string { return f.primary[shardID] }
+
+func TestRouter_ReplicatorCalledAfterWrite(t *testing.T) {
+	shards := makeTestShards(3)
+	r := NewRouter(shards, 5*time.Second)
+	r.SetWAL(&fakeWAL{})
+	r.SetWriteRewriter(fakeRewriter{})
+	rep := &fakeReplicator{}
+	r.SetWriteReplicator(rep)
+
+	_, err := r.Execute(context.Background(), "CREATE (p:Person {name: 'alice'})")
+	if err != nil {
+		t.Fatal(err)
+	}
+	rep.mu.Lock()
+	defer rep.mu.Unlock()
+	if len(rep.calls) != 1 {
+		t.Fatalf("expected 1 replicator call, got %d", len(rep.calls))
+	}
+	if !strings.Contains(rep.calls[0].cypher, "CREATE") {
+		t.Errorf("replicator should receive the rewritten write cypher; got %q", rep.calls[0].cypher)
+	}
+}
+
+func TestRouter_ReplicatorNotCalledForReads(t *testing.T) {
+	shards := makeTestShards(3)
+	r := NewRouter(shards, 5*time.Second)
+	rep := &fakeReplicator{}
+	r.SetWriteReplicator(rep)
+
+	_, err := r.Execute(context.Background(), "MATCH (p:Person {name: 'alice'}) RETURN p")
+	if err != nil {
+		t.Fatal(err)
+	}
+	rep.mu.Lock()
+	defer rep.mu.Unlock()
+	if len(rep.calls) != 0 {
+		t.Errorf("read queries must not invoke the replicator; got %d calls", len(rep.calls))
+	}
+}
+
+func TestRouter_ReplicatorSkippedWhenNotPrimary(t *testing.T) {
+	shards := makeTestShards(3)
+	r := NewRouter(shards, 5*time.Second)
+	r.SetWAL(&fakeWAL{})
+	rep := &fakeReplicator{}
+	r.SetWriteReplicator(rep)
+
+	// Mark every shard as primary on a different node — this node is the
+	// receiving replica, so it must apply the write but NOT re-replicate.
+	r.SetRemoteTransport("local-node", nil, &fakePlacement{
+		primary: map[int]string{0: "other-node", 1: "other-node", 2: "other-node"},
+	})
+
+	_, err := r.Execute(context.Background(), "CREATE (p:Person {name: 'alice'})")
+	if err != nil {
+		t.Fatal(err)
+	}
+	rep.mu.Lock()
+	defer rep.mu.Unlock()
+	if len(rep.calls) != 0 {
+		t.Errorf("non-primary node must not re-fan-out replicated writes; got %d calls", len(rep.calls))
+	}
+}
+
+func TestRouter_ReplicatorErrorSurfacesAsWriteFailure(t *testing.T) {
+	shards := makeTestShards(3)
+	r := NewRouter(shards, 5*time.Second)
+	r.SetWAL(&fakeWAL{})
+	rep := &fakeReplicator{err: context.DeadlineExceeded}
+	r.SetWriteReplicator(rep)
+
+	_, err := r.Execute(context.Background(), "CREATE (p:Person {name: 'alice'})")
+	if err == nil {
+		t.Fatal("expected write failure when sync replication fails")
+	}
+	if !strings.Contains(err.Error(), "replication") {
+		t.Errorf("error should mention replication; got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

The `replication.Replicator` had full quorum/all/one consistency logic but was never invoked from the write path. This PR wires it in.

- Router gains a `WriteReplicator` interface + `SetWriteReplicator` hook. After a successful primary write the router calls `ReplicateWrite`, which fans the rewritten Cypher out to replicas.
- **Anti-loop**: replicas receiving a propagated write are gated by `isPrimaryForShard` — only the node listed as Primary in the placement map fans out, so propagated writes are applied locally and stop.
- New `pkg/replication.RouterReplicator` wraps the existing `Replicator` with a `ShardResolver` + `Consistency` level so the router never has to know about either. `ShardResolverFunc` lets callers inline a closure over cluster state.
- `LOVELINESS_WRITE_CONSISTENCY` env var (`one`|`quorum`|`all`, default `one`) picks the level at startup. `one` is fire-and-forget (preserves current behavior); `quorum`/`all` block the primary write until enough replicas ack and surface failure as a write error to the client.
- `main.go` wires `NewRouterReplicator` over the live placement map so primary/replica reassignments take effect immediately.

Slice (b) of issue #7. Builds on #28 (multi-replica placement), #29 (non-determinism rewriter) and #31 (lag metrics).

## Test plan
- [x] `go test ./pkg/router/...` — 4 new tests cover: replicator called after write, skipped for reads, skipped on non-primary nodes, surfaces sync errors as write failures
- [x] `go test ./pkg/replication/...` — 5 new `RouterReplicator` tests cover: no-op without replicas, ConsistencyOne never fails, Quorum succeeds with one live replica, Quorum fails when all replicas down, ConsistencyAll requires every replica
- [x] `go test ./...` — full suite green
- [x] `golangci-lint run ./pkg/router/... ./pkg/replication/... ./pkg/config/... ./cmd/loveliness/...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)