### PR TITLE
feat(cluster): leader-only failure detector with auto-promotion

### DIFF
--- a/cmd/loveliness/main.go
+++ b/cmd/loveliness/main.go
@@ -527,6 +527,20 @@ func main() {
 		go autoJoin(cfg)
 	}
 
+	// Leader-only failure detector + auto-promotion. Pings every other
+	// alive peer, marks consistently-failing peers down via Raft, then
+	// asks the rebalancer to promote a replica wherever the primary
+	// just died. No-ops on followers; safe to run on every node.
+	var fdCancel context.CancelFunc
+	if cfg.FailureDetectorEnabled {
+		fdInterval := time.Duration(cfg.FailureDetectorIntervalMs) * time.Millisecond
+		fd := cluster.NewFailureDetector(c, fdInterval, cfg.FailureDetectorThreshold)
+		var fdCtx context.Context
+		fdCtx, fdCancel = context.WithCancel(context.Background())
+		go fd.Run(fdCtx)
+		slog.Info("failure detector started", "interval", fdInterval, "threshold", cfg.FailureDetectorThreshold)
+	}
+
 	// Wait for shutdown signal.
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
@@ -534,6 +548,9 @@ func main() {
 	slog.Info("shutting down", "signal", sig.String())
 
 	// Graceful shutdown: stop workers, drain HTTP, close WAL, raft, shards.
+	if fdCancel != nil {
+		fdCancel()
+	}
 	if disc != nil {
 		disc.Stop()
 	}

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -172,6 +172,14 @@ func (c *Cluster) PromoteReplica(shardID int, newPrimary string) error {
 	return c.Apply(Command{Type: CmdPromoteReplica, Payload: payload})
 }
 
+// MarkNodeDown flips a node's Alive flag to false in the shard map. Used
+// by the failure detector when a peer fails repeated liveness pings; the
+// rebalancer then sees a dead node and plans replica promotion.
+func (c *Cluster) MarkNodeDown(nodeID string) error {
+	payload, _ := json.Marshal(RemoveNodePayload{NodeID: nodeID})
+	return c.Apply(Command{Type: CmdRemoveNode, Payload: payload})
+}
+
 // RegisterTable replicates a schema registration (table name → shard key) via Raft.
 func (c *Cluster) RegisterTable(name, shardKey string) error {
 	payload, _ := json.Marshal(RegisterTablePayload{Name: name, ShardKey: shardKey})

--- a/pkg/cluster/failure_detector.go
+++ b/pkg/cluster/failure_detector.go
@@ -1,0 +1,165 @@
+package cluster
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// Pinger reports whether a peer is alive. Decoupled from the failure
+// detector so unit tests can drive it with deterministic results without
+// real HTTP round-trips.
+type Pinger interface {
+	Ping(ctx context.Context, nodeID, httpAddr string) bool
+}
+
+// HTTPPinger issues GET <addr>/health and treats any 2xx response as alive.
+type HTTPPinger struct {
+	Client  *http.Client
+	Timeout time.Duration
+}
+
+// NewHTTPPinger returns a pinger with sensible defaults.
+func NewHTTPPinger(timeout time.Duration) *HTTPPinger {
+	return &HTTPPinger{
+		Client:  &http.Client{Timeout: timeout},
+		Timeout: timeout,
+	}
+}
+
+// Ping issues a GET /health and returns true on a 2xx response. Any
+// network failure, non-2xx status, or timeout is treated as down.
+func (p *HTTPPinger) Ping(ctx context.Context, nodeID, httpAddr string) bool {
+	if httpAddr == "" {
+		return false
+	}
+	url := "http://" + httpAddr + "/health"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return false
+	}
+	resp, err := p.Client.Do(req)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode >= 200 && resp.StatusCode < 300
+}
+
+// rebalancerOps is the surface FailureDetector uses from the rebalancer.
+// It's an interface so tests can plug in a fake.
+type rebalancerOps interface {
+	Plan() []Move
+	Execute(moves []Move) error
+}
+
+// failureDetectorCluster is the surface FailureDetector uses from the
+// cluster. Interface for testability.
+type failureDetectorCluster interface {
+	IsLeader() bool
+	NodeID() string
+	GetShardMap() ShardMap
+	MarkNodeDown(nodeID string) error
+}
+
+// FailureDetector runs on the leader, pings every other alive peer in the
+// shard map, and marks unresponsive peers as down after `Threshold`
+// consecutive failures. After each tick it asks the rebalancer for moves
+// and executes them — that's where dead-primary auto-promotion happens
+// (see Rebalancer.planMoves Phase 1).
+//
+// Non-leaders no-op; if leadership flips mid-loop the next tick will
+// notice and resume work on the new leader.
+type FailureDetector struct {
+	cluster    failureDetectorCluster
+	rebalancer rebalancerOps
+	pinger     Pinger
+	interval   time.Duration
+	threshold  int
+
+	mu       sync.Mutex
+	failures map[string]int
+}
+
+// NewFailureDetector wires the failure detector to a live cluster + rebalancer.
+// `interval` is the tick period; `threshold` is how many consecutive failed
+// pings flip a node to Alive=false. Sensible defaults: interval=2s, threshold=3.
+func NewFailureDetector(c *Cluster, interval time.Duration, threshold int) *FailureDetector {
+	return newFailureDetector(c, NewRebalancer(c), NewHTTPPinger(interval), interval, threshold)
+}
+
+// newFailureDetector is the test-friendly constructor.
+func newFailureDetector(c failureDetectorCluster, rb rebalancerOps, p Pinger, interval time.Duration, threshold int) *FailureDetector {
+	return &FailureDetector{
+		cluster:    c,
+		rebalancer: rb,
+		pinger:     p,
+		interval:   interval,
+		threshold:  threshold,
+		failures:   map[string]int{},
+	}
+}
+
+// Run loops on the configured interval until ctx is cancelled. Spawn it
+// once per process; it's leader-gated internally so multiple nodes with
+// detectors running is safe.
+func (fd *FailureDetector) Run(ctx context.Context) {
+	ticker := time.NewTicker(fd.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			fd.Tick(ctx)
+		}
+	}
+}
+
+// Tick performs one round of pings + rebalance. Exported for tests.
+func (fd *FailureDetector) Tick(ctx context.Context) {
+	if !fd.cluster.IsLeader() {
+		return
+	}
+	selfID := fd.cluster.NodeID()
+	sm := fd.cluster.GetShardMap()
+	for id, info := range sm.Nodes {
+		if id == selfID || !info.Alive {
+			continue
+		}
+		alive := fd.pinger.Ping(ctx, id, info.HTTPAddr)
+		fd.recordResult(id, alive)
+	}
+	moves := fd.rebalancer.Plan()
+	if len(moves) == 0 {
+		return
+	}
+	if err := fd.rebalancer.Execute(moves); err != nil {
+		slog.Warn("failure detector: rebalance execute failed", "err", err, "moves", len(moves))
+		return
+	}
+	slog.Info("failure detector: rebalanced after liveness change", "moves", len(moves))
+}
+
+// recordResult updates the failure counter for a peer and marks the
+// peer down once threshold is reached. Exported via Tick only.
+func (fd *FailureDetector) recordResult(nodeID string, alive bool) {
+	fd.mu.Lock()
+	defer fd.mu.Unlock()
+	if alive {
+		delete(fd.failures, nodeID)
+		return
+	}
+	fd.failures[nodeID]++
+	if fd.failures[nodeID] < fd.threshold {
+		return
+	}
+	delete(fd.failures, nodeID)
+	if err := fd.cluster.MarkNodeDown(nodeID); err != nil {
+		slog.Warn("failure detector: mark down failed", "node", nodeID, "err", err)
+		return
+	}
+	slog.Warn("failure detector: marked node down", "node", nodeID, "threshold", fd.threshold)
+}

--- a/pkg/cluster/failure_detector_test.go
+++ b/pkg/cluster/failure_detector_test.go
@@ -1,0 +1,226 @@
+package cluster
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fakeFDCluster is a minimal failureDetectorCluster used to drive Tick in
+// isolation from a real Raft FSM.
+type fakeFDCluster struct {
+	mu         sync.Mutex
+	leader     bool
+	nodeID     string
+	shardMap   ShardMap
+	markedDown []string
+}
+
+func (f *fakeFDCluster) IsLeader() bool { f.mu.Lock(); defer f.mu.Unlock(); return f.leader }
+func (f *fakeFDCluster) NodeID() string { return f.nodeID }
+func (f *fakeFDCluster) GetShardMap() ShardMap {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.shardMap
+}
+func (f *fakeFDCluster) MarkNodeDown(nodeID string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.markedDown = append(f.markedDown, nodeID)
+	if info, ok := f.shardMap.Nodes[nodeID]; ok {
+		info.Alive = false
+		f.shardMap.Nodes[nodeID] = info
+	}
+	return nil
+}
+
+// fakePinger returns canned ping results keyed by nodeID.
+type fakePinger struct {
+	mu      sync.Mutex
+	results map[string]bool
+	calls   []string
+}
+
+func (f *fakePinger) Ping(_ context.Context, nodeID, _ string) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, nodeID)
+	if r, ok := f.results[nodeID]; ok {
+		return r
+	}
+	return true
+}
+
+// fakeRebalancer records Plan + Execute calls for assertions.
+type fakeRebalancer struct {
+	mu       sync.Mutex
+	moves    []Move
+	executed [][]Move
+}
+
+func (f *fakeRebalancer) Plan() []Move {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]Move(nil), f.moves...)
+}
+func (f *fakeRebalancer) Execute(moves []Move) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.executed = append(f.executed, append([]Move(nil), moves...))
+	return nil
+}
+
+func TestFailureDetector_NonLeaderNoops(t *testing.T) {
+	c := &fakeFDCluster{
+		leader: false,
+		shardMap: ShardMap{Nodes: map[string]NodeInfo{
+			"node-1": {ID: "node-1", Alive: true, HTTPAddr: "x"},
+		}},
+	}
+	pinger := &fakePinger{}
+	rb := &fakeRebalancer{moves: []Move{{ShardID: 0, Role: "primary"}}}
+	fd := newFailureDetector(c, rb, pinger, time.Second, 3)
+
+	fd.Tick(context.Background())
+
+	if len(pinger.calls) != 0 {
+		t.Errorf("non-leader must not ping; got %d calls", len(pinger.calls))
+	}
+	if len(rb.executed) != 0 {
+		t.Errorf("non-leader must not rebalance; got %d executes", len(rb.executed))
+	}
+}
+
+func TestFailureDetector_PingsOnlyOtherAliveNodes(t *testing.T) {
+	c := &fakeFDCluster{
+		leader: true,
+		nodeID: "node-1",
+		shardMap: ShardMap{Nodes: map[string]NodeInfo{
+			"node-1": {ID: "node-1", Alive: true, HTTPAddr: "self"},
+			"node-2": {ID: "node-2", Alive: true, HTTPAddr: "addr-2"},
+			"node-3": {ID: "node-3", Alive: false, HTTPAddr: "addr-3"}, // already dead
+		}},
+	}
+	pinger := &fakePinger{}
+	fd := newFailureDetector(c, &fakeRebalancer{}, pinger, time.Second, 3)
+
+	fd.Tick(context.Background())
+
+	if len(pinger.calls) != 1 || pinger.calls[0] != "node-2" {
+		t.Errorf("expected single ping to node-2, got %v", pinger.calls)
+	}
+}
+
+func TestFailureDetector_MarksDownAfterThreshold(t *testing.T) {
+	c := &fakeFDCluster{
+		leader: true,
+		nodeID: "node-1",
+		shardMap: ShardMap{Nodes: map[string]NodeInfo{
+			"node-1": {ID: "node-1", Alive: true},
+			"node-2": {ID: "node-2", Alive: true, HTTPAddr: "addr-2"},
+		}},
+	}
+	pinger := &fakePinger{results: map[string]bool{"node-2": false}}
+	fd := newFailureDetector(c, &fakeRebalancer{}, pinger, time.Second, 3)
+
+	// First two failures should not flip the flag.
+	fd.Tick(context.Background())
+	fd.Tick(context.Background())
+	if len(c.markedDown) != 0 {
+		t.Errorf("must not mark down before threshold; got %v", c.markedDown)
+	}
+	// Third failure crosses the threshold.
+	fd.Tick(context.Background())
+	if len(c.markedDown) != 1 || c.markedDown[0] != "node-2" {
+		t.Errorf("expected node-2 marked down once, got %v", c.markedDown)
+	}
+}
+
+func TestFailureDetector_FailureCounterResetsOnSuccess(t *testing.T) {
+	c := &fakeFDCluster{
+		leader: true,
+		nodeID: "node-1",
+		shardMap: ShardMap{Nodes: map[string]NodeInfo{
+			"node-1": {ID: "node-1", Alive: true},
+			"node-2": {ID: "node-2", Alive: true, HTTPAddr: "addr-2"},
+		}},
+	}
+	pinger := &fakePinger{results: map[string]bool{"node-2": false}}
+	fd := newFailureDetector(c, &fakeRebalancer{}, pinger, time.Second, 3)
+
+	// Two failures.
+	fd.Tick(context.Background())
+	fd.Tick(context.Background())
+
+	// Recover.
+	pinger.mu.Lock()
+	pinger.results["node-2"] = true
+	pinger.mu.Unlock()
+	fd.Tick(context.Background())
+
+	// Two more failures should not yet trip the threshold (counter reset).
+	pinger.mu.Lock()
+	pinger.results["node-2"] = false
+	pinger.mu.Unlock()
+	fd.Tick(context.Background())
+	fd.Tick(context.Background())
+	if len(c.markedDown) != 0 {
+		t.Errorf("counter must reset on success; got premature mark-downs: %v", c.markedDown)
+	}
+}
+
+func TestFailureDetector_ExecutesRebalancePlan(t *testing.T) {
+	c := &fakeFDCluster{
+		leader: true,
+		nodeID: "node-1",
+		shardMap: ShardMap{Nodes: map[string]NodeInfo{
+			"node-1": {ID: "node-1", Alive: true},
+			"node-2": {ID: "node-2", Alive: true, HTTPAddr: "addr-2"},
+		}},
+	}
+	planned := []Move{{ShardID: 0, Role: "primary", FromNode: "dead", ToNode: "node-1"}}
+	rb := &fakeRebalancer{moves: planned}
+	fd := newFailureDetector(c, rb, &fakePinger{}, time.Second, 3)
+
+	fd.Tick(context.Background())
+
+	if len(rb.executed) != 1 || len(rb.executed[0]) != 1 || rb.executed[0][0].ShardID != 0 {
+		t.Errorf("expected one Execute with the planned moves; got %v", rb.executed)
+	}
+}
+
+func TestHTTPPinger_LiveServerIsAlive(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	p := NewHTTPPinger(time.Second)
+	addr := srv.Listener.Addr().String()
+	if !p.Ping(context.Background(), "node-x", addr) {
+		t.Error("expected live server to ping alive")
+	}
+}
+
+func TestHTTPPinger_DeadServerIsDown(t *testing.T) {
+	p := NewHTTPPinger(200 * time.Millisecond)
+	if p.Ping(context.Background(), "node-x", "127.0.0.1:1") {
+		t.Error("expected dead server to ping down")
+	}
+}
+
+func TestHTTPPinger_5xxIsDown(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	p := NewHTTPPinger(time.Second)
+	addr := srv.Listener.Addr().String()
+	if p.Ping(context.Background(), "node-x", addr) {
+		t.Error("5xx must be treated as down")
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -87,6 +87,19 @@ type Config struct {
 	// Anything else is parsed as "quorum" by replication.ParseConsistency.
 	WriteConsistency string
 
+	// FailureDetectorEnabled controls whether the leader-only failure
+	// detector pings peers and auto-promotes replicas on dead primaries.
+	// Disable for tests or maintenance windows where flapping liveness
+	// would cause unwanted shard moves.
+	FailureDetectorEnabled bool
+
+	// FailureDetectorIntervalMs is the gap between liveness pings.
+	FailureDetectorIntervalMs int
+
+	// FailureDetectorThreshold is the consecutive failed-ping count that
+	// trips a peer to Alive=false in the shard map.
+	FailureDetectorThreshold int
+
 	// DNS discovery configuration.
 	DiscoverMode     string // "dns" to enable DNS-based peer discovery, empty to disable
 	DiscoverAddr     string // DNS name to resolve for peer discovery (e.g., "loveliness.internal")
@@ -112,6 +125,10 @@ func DefaultConfig() Config {
 		TLSClientAuth:        "require",
 		ReplicationFactor:    1,
 		WriteConsistency:     "one",
+
+		FailureDetectorEnabled:    true,
+		FailureDetectorIntervalMs: 2000,
+		FailureDetectorThreshold:  3,
 	}
 }
 
@@ -231,6 +248,19 @@ func FromEnv() Config {
 	}
 	if v := os.Getenv("LOVELINESS_WRITE_CONSISTENCY"); v != "" {
 		c.WriteConsistency = v
+	}
+	if v := os.Getenv("LOVELINESS_FAILURE_DETECTOR_ENABLED"); v != "" {
+		c.FailureDetectorEnabled = v != "false" && v != "0"
+	}
+	if v := os.Getenv("LOVELINESS_FAILURE_DETECTOR_INTERVAL_MS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			c.FailureDetectorIntervalMs = n
+		}
+	}
+	if v := os.Getenv("LOVELINESS_FAILURE_DETECTOR_THRESHOLD"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			c.FailureDetectorThreshold = n
+		}
 	}
 	return c
 }


### PR DESCRIPTION
## Summary
- Leader-only `FailureDetector` runs on every node; followers no-op so the loop survives leadership flips
- `HTTPPinger` polls `/health` on every other alive peer; N consecutive failures flip `Alive=false` via Raft (`CmdRemoveNode`)
- After each liveness pass we hand the existing `Rebalancer` the wheel — its Phase 1 (dead-primary → first alive replica) finally has a trigger
- Counter resets on a successful ping so flap doesn't mark nodes down

This closes the gap in #7: replicas existed, the rebalancer knew how to promote, but nothing ever decided a primary was actually dead.

Config: `LOVELINESS_FAILURE_DETECTOR_{ENABLED,INTERVAL_MS,THRESHOLD}` (defaults: on / 2s / 3).

## Test plan
- [x] `go test ./...` — all packages green, including 8 new tests in `pkg/cluster/failure_detector_test.go`
- [x] `golangci-lint run ./...` — clean
- [x] `go build ./...` — clean
- [ ] CI green on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)