### PR TITLE
fix(cluster): drop new primary and dead primary from replicas on promote

### DIFF
--- a/pkg/cluster/rebalancer.go
+++ b/pkg/cluster/rebalancer.go
@@ -5,10 +5,18 @@ import (
 	"sort"
 )
 
+// rebalancerCluster is the surface Rebalancer needs from a cluster.
+// Pulled out as an interface so Execute can be unit-tested without a
+// live Raft FSM.
+type rebalancerCluster interface {
+	GetShardMap() ShardMap
+	AssignShard(shardID int, primary string, replicas []string) error
+}
+
 // Rebalancer computes shard migrations when nodes join or leave the cluster.
 // Runs on the leader. Produces a list of moves to equalize shard distribution.
 type Rebalancer struct {
-	cluster *Cluster
+	cluster rebalancerCluster
 }
 
 // NewRebalancer creates a rebalancer for the given cluster.
@@ -272,6 +280,10 @@ func (r *Rebalancer) Execute(moves []Move) error {
 		switch m.Role {
 		case "primary":
 			a.Primary = m.ToNode
+			// Promotion: the replica we just promoted must not also
+			// stay in the replicas list, and the dead old primary
+			// (FromNode) shouldn't sneak in either. Drop both.
+			a.Replicas = filterReplicas(a.Replicas, m.ToNode, m.FromNode)
 		case "replica":
 			idx := m.ReplicaIdx
 			if idx < 0 {
@@ -294,4 +306,26 @@ func (r *Rebalancer) Execute(moves []Move) error {
 		)
 	}
 	return nil
+}
+
+// filterReplicas returns replicas with any node in `drop` removed,
+// preserving order. Empty slots are dropped too — they're never useful
+// post-promotion and only confuse downstream consumers.
+func filterReplicas(replicas []string, drop ...string) []string {
+	if len(replicas) == 0 {
+		return replicas
+	}
+	bad := make(map[string]struct{}, len(drop)+1)
+	bad[""] = struct{}{}
+	for _, d := range drop {
+		bad[d] = struct{}{}
+	}
+	out := replicas[:0:0]
+	for _, r := range replicas {
+		if _, skip := bad[r]; skip {
+			continue
+		}
+		out = append(out, r)
+	}
+	return out
 }

--- a/pkg/cluster/rebalancer_test.go
+++ b/pkg/cluster/rebalancer_test.go
@@ -4,6 +4,22 @@ import (
 	"testing"
 )
 
+// fakeRebalancerCluster is a minimal rebalancerCluster that records
+// AssignShard calls into an in-memory shard map. Used to test Execute
+// without spinning up Raft.
+type fakeRebalancerCluster struct {
+	sm ShardMap
+}
+
+func (f *fakeRebalancerCluster) GetShardMap() ShardMap { return f.sm }
+func (f *fakeRebalancerCluster) AssignShard(shardID int, primary string, replicas []string) error {
+	if f.sm.Assignments == nil {
+		f.sm.Assignments = map[int]ShardAssignment{}
+	}
+	f.sm.Assignments[shardID] = ShardAssignment{Primary: primary, Replicas: replicas}
+	return nil
+}
+
 func TestPlanMoves_DeadPrimaryPromotesReplica(t *testing.T) {
 	assignments := map[int]ShardAssignment{
 		0: {Primary: "node-1", Replicas: []string{"node-2"}},
@@ -113,5 +129,79 @@ func TestPlanMoves_SingleNode_NoReplica(t *testing.T) {
 		if m.Role == "replica" {
 			t.Errorf("should not assign replica with single node: %+v", m)
 		}
+	}
+}
+
+func TestExecute_PromotionDropsNewPrimaryFromReplicas(t *testing.T) {
+	// node-1 is dead, node-2 was its replica. Promotion should land
+	// the shard at primary=node-2 with replicas that no longer
+	// contain node-2 (no duplicate) or node-1 (dead).
+	fake := &fakeRebalancerCluster{
+		sm: ShardMap{
+			Nodes: map[string]NodeInfo{
+				"node-1": {ID: "node-1", Alive: false},
+				"node-2": {ID: "node-2", Alive: true},
+				"node-3": {ID: "node-3", Alive: true},
+			},
+			Assignments: map[int]ShardAssignment{
+				0: {Primary: "node-1", Replicas: []string{"node-2", "node-3"}},
+			},
+		},
+	}
+	r := &Rebalancer{cluster: fake}
+	moves := r.Plan()
+	if err := r.Execute(moves); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	got := fake.sm.Assignments[0]
+	if got.Primary != "node-2" {
+		t.Errorf("expected primary=node-2, got %q", got.Primary)
+	}
+	for _, r := range got.Replicas {
+		if r == "node-2" {
+			t.Errorf("new primary node-2 must not appear in replicas: %v", got.Replicas)
+		}
+		if r == "node-1" {
+			t.Errorf("dead primary node-1 must not appear in replicas: %v", got.Replicas)
+		}
+	}
+}
+
+func TestExecute_PromotionWithoutReplicaList(t *testing.T) {
+	// No replicas at all — promotion picks the least-loaded alive node
+	// and replicas should remain empty (and certainly no duplicates).
+	fake := &fakeRebalancerCluster{
+		sm: ShardMap{
+			Nodes: map[string]NodeInfo{
+				"node-1": {ID: "node-1", Alive: false},
+				"node-2": {ID: "node-2", Alive: true},
+			},
+			Assignments: map[int]ShardAssignment{
+				0: {Primary: "node-1"},
+			},
+		},
+	}
+	r := &Rebalancer{cluster: fake}
+	if err := r.Execute(r.Plan()); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	got := fake.sm.Assignments[0]
+	if got.Primary != "node-2" {
+		t.Errorf("expected primary=node-2, got %q", got.Primary)
+	}
+	for _, rep := range got.Replicas {
+		if rep == "node-2" || rep == "node-1" {
+			t.Errorf("promotion should not put primary or dead node into replicas: %v", got.Replicas)
+		}
+	}
+}
+
+func TestFilterReplicas_DropsTargetsAndEmpties(t *testing.T) {
+	got := filterReplicas([]string{"node-2", "", "node-1", "node-3"}, "node-2", "node-1")
+	want := []string{"node-3"}
+	if len(got) != len(want) || got[0] != want[0] {
+		t.Errorf("filterReplicas: got %v, want %v", got, want)
 	}
 }


### PR DESCRIPTION
## Summary
- Phase-1 promotion left the new primary listed as both `Primary` and `Replicas[0]` (and the dead old primary could survive in there too)
- Phase 3 self-heals on the next tick, but until then the router, API, and metrics see inconsistent state
- `Execute` now strips the new primary, the dead old primary, and any empty slots out of `Replicas` at promotion time
- Refactored `Rebalancer` to depend on a small interface so `Execute` is unit-testable without Raft

Caught while reviewing the auto-promotion code from #35.

## Test plan
- [x] New tests: `TestExecute_PromotionDropsNewPrimaryFromReplicas`, `TestExecute_PromotionWithoutReplicaList`, `TestFilterReplicas_DropsTargetsAndEmpties`
- [x] `go test ./...` clean
- [x] `golangci-lint run ./...` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)