### PR TITLE
feat(api): /health/live + /health/ready split, enriched health JSON (#12)

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -51,6 +51,10 @@ type Server struct {
 
 	// discoveryInfo holds this node's join info for the public /discovery endpoint.
 	discoveryInfo *cluster.JoinInfo
+
+	// startTime is captured at NewServer time so /health can report uptime
+	// without piping a clock through every call site.
+	startTime time.Time
 }
 
 // NewServer creates a new API server.
@@ -63,6 +67,7 @@ func NewServer(r *router.Router, c *cluster.Cluster, shards []*shard.Shard, reg 
 		timeout:    timeout,
 		refTracker: make(map[int]map[string]bool),
 		joinTokens: cluster.NewTokenStore(),
+		startTime:  time.Now(),
 	}
 }
 
@@ -107,6 +112,8 @@ func (s *Server) Handler() http.Handler {
 	// Top-level mux: health and discovery are public, everything else goes through auth.
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /health", s.handleHealth)
+	mux.HandleFunc("GET /health/live", s.handleHealthLive)
+	mux.HandleFunc("GET /health/ready", s.handleHealthReady)
 	mux.HandleFunc("GET /discovery", s.handleDiscovery)
 	mux.HandleFunc("GET /metrics", s.handleMetrics)
 	if s.auth != nil && s.auth.Enabled() {
@@ -293,40 +300,106 @@ func (s *Server) replicateSchemaDDL(cypher string) {
 	}
 }
 
-func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
-	resp := map[string]any{
-		"status": "ok",
+// healthSnapshot is the structured form of /health used by both the JSON
+// handler and the /health/ready gate. Splitting it out keeps the readiness
+// gate honest: ready returns 503 iff this snapshot says the node is
+// degraded or not-yet-ready, rather than re-deriving the same checks.
+type healthSnapshot struct {
+	Status         string            `json:"status"` // "ok" | "degraded"
+	NodeID         string            `json:"node_id,omitempty"`
+	Mode           string            `json:"mode,omitempty"` // "standalone" when no cluster
+	Role           string            `json:"role,omitempty"`
+	LeaderID       string            `json:"leader_id,omitempty"`
+	UptimeSeconds  float64           `json:"uptime_seconds"`
+	PlacementEpoch uint64            `json:"placement_epoch,omitempty"`
+	Shards         map[string]string `json:"shards,omitempty"`
+}
+
+// snapshotHealth gathers the current node's health into a structured form.
+// Both /health and /health/ready consume it; keeping a single function
+// means they can never disagree on what "ready" means.
+func (s *Server) snapshotHealth() healthSnapshot {
+	snap := healthSnapshot{
+		Status:        "ok",
+		UptimeSeconds: time.Since(s.startTime).Seconds(),
 	}
 
 	if s.cluster != nil {
-		role := "follower"
-		if s.cluster.IsLeader() {
-			role = "leader"
-		}
-		resp["role"] = role
-		resp["node_id"] = s.cluster.NodeID()
+		snap.Role = s.cluster.Role()
+		snap.NodeID = s.cluster.NodeID()
+		snap.LeaderID = s.cluster.LeaderID()
+		snap.PlacementEpoch = maxShardEpoch(s.cluster.GetShardMap())
 	} else {
-		resp["mode"] = "standalone"
+		snap.Mode = "standalone"
 	}
 
 	if len(s.shards) > 0 {
-		shardStatus := make(map[string]string, len(s.shards))
+		snap.Shards = make(map[string]string, len(s.shards))
 		allHealthy := true
 		for _, sh := range s.shards {
 			if sh.IsHealthy() {
-				shardStatus[strconv.Itoa(sh.ID)] = "healthy"
+				snap.Shards[strconv.Itoa(sh.ID)] = "healthy"
 			} else {
-				shardStatus[strconv.Itoa(sh.ID)] = "unhealthy"
+				snap.Shards[strconv.Itoa(sh.ID)] = "unhealthy"
 				allHealthy = false
 			}
 		}
-		resp["shards"] = shardStatus
 		if !allHealthy {
-			resp["status"] = "degraded"
+			snap.Status = "degraded"
 		}
 	}
 
-	writeJSON(w, http.StatusOK, resp)
+	return snap
+}
+
+// maxShardEpoch returns the highest per-shard placement epoch in the map,
+// or 0 if the map is empty. Surfaced as a coarse cluster-wide "placement
+// generation" indicator on /health — fine-grained per-shard epochs stay
+// in /cluster.
+func maxShardEpoch(sm cluster.ShardMap) uint64 {
+	var max uint64
+	for _, a := range sm.Assignments {
+		if a.Epoch > max {
+			max = a.Epoch
+		}
+	}
+	return max
+}
+
+func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusOK, s.snapshotHealth())
+}
+
+// handleHealthLive is a Kubernetes-style liveness probe. It only confirms
+// the process is up and the HTTP mux is serving — it deliberately does
+// NOT check shard or cluster state, because a degraded cluster shouldn't
+// trigger pod restarts on its own (that would amplify outages).
+func (s *Server) handleHealthLive(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusOK, map[string]string{"status": "alive"})
+}
+
+// handleHealthReady is a Kubernetes-style readiness probe. It returns 503
+// when the node should be removed from load-balancer rotation: any local
+// shard unhealthy, or (when clustered) no leader is yet known.
+func (s *Server) handleHealthReady(w http.ResponseWriter, r *http.Request) {
+	snap := s.snapshotHealth()
+	reasons := []string{}
+
+	if snap.Status != "ok" {
+		reasons = append(reasons, "shards_degraded")
+	}
+	if s.cluster != nil && snap.LeaderID == "" {
+		reasons = append(reasons, "no_leader")
+	}
+
+	if len(reasons) > 0 {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]any{
+			"status":  "not_ready",
+			"reasons": reasons,
+		})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ready"})
 }
 
 func (s *Server) handleCluster(w http.ResponseWriter, r *http.Request) {

--- a/pkg/api/health_endpoints_test.go
+++ b/pkg/api/health_endpoints_test.go
@@ -1,0 +1,134 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/johnjansen/loveliness/pkg/router"
+	"github.com/johnjansen/loveliness/pkg/shard"
+)
+
+func TestHealthLive_AlwaysOK(t *testing.T) {
+	srv := setupTestServer()
+	req := httptest.NewRequest("GET", "/health/live", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp["status"] != "alive" {
+		t.Errorf("expected status=alive, got %q", resp["status"])
+	}
+}
+
+func TestHealthLive_StaysOKWhenShardUnhealthy(t *testing.T) {
+	// Liveness must not flip when shards degrade — that would cause
+	// restart loops on a problem the pod itself can't fix.
+	shards := []*shard.Shard{
+		shard.NewShard(0, &panicStore{}, 4),
+	}
+	shards[0].Query("MATCH (n) RETURN n")
+	r := router.NewRouter(shards, 5*time.Second)
+	srv := NewServer(r, nil, shards, nil, 5*time.Second)
+
+	req := httptest.NewRequest("GET", "/health/live", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("liveness must stay OK when shards are degraded, got %d", w.Code)
+	}
+}
+
+func TestHealthReady_OKWhenAllHealthy(t *testing.T) {
+	srv := setupTestServer()
+	req := httptest.NewRequest("GET", "/health/ready", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]string
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["status"] != "ready" {
+		t.Errorf("expected status=ready, got %q", resp["status"])
+	}
+}
+
+func TestHealthReady_503WhenShardUnhealthy(t *testing.T) {
+	shards := []*shard.Shard{
+		shard.NewShard(0, shard.NewMemoryStore(), 4),
+		shard.NewShard(1, &panicStore{}, 4),
+	}
+	shards[1].Query("MATCH (n) RETURN n") // trip the panicStore
+	r := router.NewRouter(shards, 5*time.Second)
+	srv := NewServer(r, nil, shards, nil, 5*time.Second)
+
+	req := httptest.NewRequest("GET", "/health/ready", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["status"] != "not_ready" {
+		t.Errorf("expected status=not_ready, got %v", resp["status"])
+	}
+	reasons, ok := resp["reasons"].([]any)
+	if !ok || len(reasons) == 0 {
+		t.Errorf("expected non-empty reasons array, got %v", resp["reasons"])
+	}
+}
+
+func TestHealth_StructuredFieldsPresent(t *testing.T) {
+	srv := setupTestServer()
+	req := httptest.NewRequest("GET", "/health", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if _, ok := resp["uptime_seconds"]; !ok {
+		t.Errorf("expected uptime_seconds in /health response: %v", resp)
+	}
+	if resp["mode"] != "standalone" {
+		t.Errorf("expected mode=standalone (no cluster), got %v", resp["mode"])
+	}
+	if resp["status"] != "ok" {
+		t.Errorf("expected status=ok, got %v", resp["status"])
+	}
+}
+
+func TestHealth_UptimeIsNonNegative(t *testing.T) {
+	srv := setupTestServer()
+	// Sleep a tick so uptime is meaningfully > 0; we mostly want to
+	// confirm it's not negative or absurd.
+	time.Sleep(2 * time.Millisecond)
+
+	req := httptest.NewRequest("GET", "/health", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	var resp map[string]any
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	uptime, ok := resp["uptime_seconds"].(float64)
+	if !ok {
+		t.Fatalf("uptime_seconds missing or wrong type: %v", resp["uptime_seconds"])
+	}
+	if uptime < 0 {
+		t.Errorf("uptime_seconds must be non-negative, got %v", uptime)
+	}
+}

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -93,8 +93,35 @@ func (c *Cluster) IsLeader() bool {
 	return c.raft.State() == raft.Leader
 }
 
+// Role returns the current Raft role as a lowercase string:
+// "leader", "follower", "candidate", "shutdown", or "unknown".
+// Operationally surfaced via /health and the raft_state metric.
+func (c *Cluster) Role() string {
+	switch c.raft.State() {
+	case raft.Leader:
+		return "leader"
+	case raft.Follower:
+		return "follower"
+	case raft.Candidate:
+		return "candidate"
+	case raft.Shutdown:
+		return "shutdown"
+	default:
+		return "unknown"
+	}
+}
+
 // LeaderAddr returns the address of the current leader.
 func (c *Cluster) LeaderAddr() string {
+	_, id := c.raft.LeaderWithID()
+	return string(id)
+}
+
+// LeaderID returns the node ID of the current leader (or empty if unknown).
+// hashicorp/raft uses ServerID for the logical identity, distinct from the
+// raft transport address — they happen to be equal in our setup but tests
+// and dashboards should not assume that.
+func (c *Cluster) LeaderID() string {
 	_, id := c.raft.LeaderWithID()
 	return string(id)
 }


### PR DESCRIPTION
## Summary
- Adds `GET /health/live` (always 200 while process is up — deliberately no shard/cluster checks so liveness can't trigger pointless restarts) and `GET /health/ready` (503 when any local shard is unhealthy or, when clustered, no leader yet known).
- Existing `GET /health` preserves status/role/node_id/mode/shards and adds `uptime_seconds`, `leader_id`, `placement_epoch` (max per-shard epoch).
- Adds `Cluster.Role()` and `Cluster.LeaderID()` so the API layer doesn't poke at `raft.State()` directly.
- Slice of #12 — leaves `/metrics` work and Grafana dashboards for future slices.

## Test plan
- [x] `go test ./pkg/api/... -run TestHealth` — 9 tests pass (3 existing + 6 new)
- [x] `go test ./...` — full suite green
- [x] `golangci-lint run ./...` — 0 issues
- [x] Existing `/health` JSON shape unchanged for current consumers (just additive fields)

## Follow-ups (still on #12)
- `/metrics` query histogram, query counter, raft_state gauge, shard RSS/vertex/edge gauges, bulk_load counter
- Per-shard detail array on `/health` (id, rss_bytes, replication_lag_s, reason)
- `deploy/grafana/loveliness-overview.json`
- Label budget docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)