### PR TITLE
feat(metrics): loveliness_raft_state one-hot gauge (#12)

### DIFF
--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -44,6 +44,20 @@ type metricsReplicaState interface {
 	GetTimestamp(shardID int, nodeID string) time.Time
 }
 
+// metricsCluster is the slice of *cluster.Cluster the metrics handler
+// needs for raft_state. Kept narrow so tests inject fakes without
+// standing up a real Raft.
+type metricsCluster interface {
+	NodeID() string
+	Role() string
+}
+
+// raftStates is the set of one-hot label values emitted by
+// loveliness_raft_state. Listed explicitly so the metric shape doesn't
+// drift if we ever add more raft.RaftState values upstream — all known
+// states get a 0/1 value at every scrape, alerts can pick any one.
+var raftStates = []string{"leader", "follower", "candidate", "shutdown", "unknown"}
+
 // replicaLagPair identifies a (shard, replica) pair the handler should emit.
 type replicaLagPair struct {
 	ShardID int
@@ -53,6 +67,10 @@ type replicaLagPair struct {
 func writeMetrics(w io.Writer, s *Server) {
 	emitHelp(w, "loveliness_local_shards", "Number of shards opened on this node.", "gauge")
 	fprintf(w, "loveliness_local_shards %d\n", len(s.shards))
+
+	if s.cluster != nil {
+		writeRaftStateMetric(w, s.cluster)
+	}
 
 	if s.dr == nil || s.dr.WAL == nil {
 		return
@@ -77,6 +95,24 @@ func writeMetrics(w io.Writer, s *Server) {
 	}
 
 	writeWALMetrics(w, s.dr.WAL, shardIDs, s.dr.ReplicaState, pairs)
+}
+
+// writeRaftStateMetric emits loveliness_raft_state as a one-hot gauge:
+// one series per known state, value=1 for the active one, 0 for the rest.
+// One-hot is the standard Prometheus shape for enum-like metrics — it
+// lets dashboards alert on any single state without having to map an int.
+func writeRaftStateMetric(w io.Writer, c metricsCluster) {
+	emitHelp(w, "loveliness_raft_state",
+		"Current Raft role for this node, one-hot encoded across known states.", "gauge")
+	current := c.Role()
+	nodeID := c.NodeID()
+	for _, st := range raftStates {
+		v := 0
+		if st == current {
+			v = 1
+		}
+		fprintf(w, "loveliness_raft_state{node_id=%q,state=%q} %d\n", nodeID, st, v)
+	}
 }
 
 // writeWALMetrics emits the WAL- and replica-related series. It's split out

--- a/pkg/api/metrics_test.go
+++ b/pkg/api/metrics_test.go
@@ -133,6 +133,71 @@ func TestWriteWALMetrics_StableOrder(t *testing.T) {
 	}
 }
 
+// fakeCluster implements metricsCluster with hand-set values.
+type fakeCluster struct {
+	nodeID string
+	role   string
+}
+
+func (f *fakeCluster) NodeID() string { return f.nodeID }
+func (f *fakeCluster) Role() string   { return f.role }
+
+func TestRaftState_OneHotForCurrentRole(t *testing.T) {
+	var buf bytes.Buffer
+	writeRaftStateMetric(&buf, &fakeCluster{nodeID: "node-1", role: "leader"})
+	out := buf.String()
+
+	mustContain := []string{
+		"# HELP loveliness_raft_state",
+		"# TYPE loveliness_raft_state gauge",
+		`loveliness_raft_state{node_id="node-1",state="leader"} 1`,
+		`loveliness_raft_state{node_id="node-1",state="follower"} 0`,
+		`loveliness_raft_state{node_id="node-1",state="candidate"} 0`,
+		`loveliness_raft_state{node_id="node-1",state="shutdown"} 0`,
+		`loveliness_raft_state{node_id="node-1",state="unknown"} 0`,
+	}
+	for _, s := range mustContain {
+		if !strings.Contains(out, s) {
+			t.Errorf("output missing %q\nfull output:\n%s", s, out)
+		}
+	}
+}
+
+func TestRaftState_FollowerOneHot(t *testing.T) {
+	var buf bytes.Buffer
+	writeRaftStateMetric(&buf, &fakeCluster{nodeID: "node-2", role: "follower"})
+	out := buf.String()
+	if !strings.Contains(out, `loveliness_raft_state{node_id="node-2",state="follower"} 1`) {
+		t.Errorf("follower must be 1, got:\n%s", out)
+	}
+	if !strings.Contains(out, `loveliness_raft_state{node_id="node-2",state="leader"} 0`) {
+		t.Errorf("leader must be 0 when follower is current, got:\n%s", out)
+	}
+}
+
+func TestRaftState_UnknownRoleFallback(t *testing.T) {
+	// If Role() returns something we don't enumerate, no series should be 1.
+	var buf bytes.Buffer
+	writeRaftStateMetric(&buf, &fakeCluster{nodeID: "node-3", role: "garbled"})
+	out := buf.String()
+	if strings.Contains(out, "} 1\n") {
+		t.Errorf("no state should be 1 for unrecognized role, got:\n%s", out)
+	}
+}
+
+func TestRaftState_AlwaysEmitsAllStates(t *testing.T) {
+	// Even in shutdown, the full enum is emitted so dashboards show
+	// continuous lines instead of breaking when a node gets demoted.
+	var buf bytes.Buffer
+	writeRaftStateMetric(&buf, &fakeCluster{nodeID: "n", role: "shutdown"})
+	out := buf.String()
+	for _, st := range []string{"leader", "follower", "candidate", "shutdown", "unknown"} {
+		if !strings.Contains(out, `state="`+st+`"`) {
+			t.Errorf("missing series for state=%q in:\n%s", st, out)
+		}
+	}
+}
+
 func TestComputeLagSeconds(t *testing.T) {
 	zero := time.Time{}
 	head := time.Date(2026, 5, 9, 12, 0, 0, 0, time.UTC)


### PR DESCRIPTION
## Summary
- Adds `loveliness_raft_state{node_id, state}` as a one-hot gauge: one series per known state (leader/follower/candidate/shutdown/unknown), value=1 for the current state, 0 for the rest.
- Always emits the full enum so dashboards stay continuous through transitions.
- Wired via a narrow `metricsCluster` interface (NodeID/Role) so tests inject fakes without a real Raft.

## Test plan
- [x] `go test ./pkg/api/... -run TestRaftState` — 4 new tests pass
- [x] `go test ./...` — full suite green
- [x] `golangci-lint run ./...` — 0 issues

## Follow-ups (still on #12)
- `loveliness_query_duration_seconds` histogram + `loveliness_query_total` counter
- `loveliness_shard_rss_bytes`, `loveliness_shard_vertex_count`, `loveliness_shard_edge_count`
- `loveliness_bulk_load_rows_total`
- Per-shard detail array on /health
- `deploy/grafana/loveliness-overview.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)