### PR TITLE
feat(metrics): loveliness_query_duration_seconds histogram (#12)

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -59,20 +59,25 @@ type Server struct {
 	// queryCounters tracks /cypher request counts by (query_type, status)
 	// for the loveliness_query_total metric.
 	queryCounters *queryCounters
+
+	// queryHistogram tracks /cypher latencies by (query_type, status)
+	// for the loveliness_query_duration_seconds metric.
+	queryHistogram *queryHistogram
 }
 
 // NewServer creates a new API server.
 func NewServer(r *router.Router, c *cluster.Cluster, shards []*shard.Shard, reg *schema.Registry, timeout time.Duration) *Server {
 	return &Server{
-		router:        r,
-		cluster:       c,
-		shards:        shards,
-		schema:        reg,
-		timeout:       timeout,
-		refTracker:    make(map[int]map[string]bool),
-		joinTokens:    cluster.NewTokenStore(),
-		startTime:     time.Now(),
-		queryCounters: newQueryCounters(),
+		router:         r,
+		cluster:        c,
+		shards:         shards,
+		schema:         reg,
+		timeout:        timeout,
+		refTracker:     make(map[int]map[string]bool),
+		joinTokens:     cluster.NewTokenStore(),
+		startTime:      time.Now(),
+		queryCounters:  newQueryCounters(),
+		queryHistogram: newQueryHistogram(),
 	}
 }
 
@@ -197,16 +202,23 @@ func (s *Server) handleCypherLegacy(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleCypher(w http.ResponseWriter, r *http.Request) {
+	start := time.Now()
+	record := func(qtype string, code int) {
+		bucket := statusBucket(code)
+		s.queryCounters.Inc(qtype, bucket)
+		s.queryHistogram.Observe(qtype, bucket, time.Since(start).Seconds())
+	}
+
 	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20)) // 1 MB max
 	if err != nil {
 		writeError(w, http.StatusBadRequest, "BAD_REQUEST", "cannot read body: "+err.Error(), 0)
-		s.queryCounters.Inc("unknown", statusBucket(http.StatusBadRequest))
+		record("unknown", http.StatusBadRequest)
 		return
 	}
 	cypher := strings.TrimSpace(string(body))
 	if cypher == "" {
 		writeError(w, http.StatusBadRequest, "BAD_REQUEST", "empty query body", 0)
-		s.queryCounters.Inc("unknown", statusBucket(http.StatusBadRequest))
+		record("unknown", http.StatusBadRequest)
 		return
 	}
 
@@ -228,11 +240,11 @@ func (s *Server) handleCypher(w http.ResponseWriter, r *http.Request) {
 				status = http.StatusGatewayTimeout
 			}
 			writeError(w, status, qe.Code, qe.Message, qe.ShardID)
-			s.queryCounters.Inc(qtype, statusBucket(status))
+			record(qtype, status)
 			return
 		}
 		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", err.Error(), 0)
-		s.queryCounters.Inc(qtype, statusBucket(http.StatusInternalServerError))
+		record(qtype, http.StatusInternalServerError)
 		return
 	}
 
@@ -242,7 +254,7 @@ func (s *Server) handleCypher(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeNegotiated(w, r, result)
-	s.queryCounters.Inc(qtype, statusBucket(http.StatusOK))
+	record(qtype, http.StatusOK)
 }
 
 // writeNegotiated picks the response format based on the request's

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -3,6 +3,7 @@ package api
 import (
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"sort"
 	"strings"
@@ -76,6 +77,10 @@ func writeMetrics(w io.Writer, s *Server) {
 		writeQueryCounterMetrics(w, s.queryCounters.Snapshot())
 	}
 
+	if s.queryHistogram != nil {
+		writeQueryHistogramMetrics(w, s.queryHistogram.Snapshot())
+	}
+
 	if s.dr == nil || s.dr.WAL == nil {
 		return
 	}
@@ -99,6 +104,42 @@ func writeMetrics(w io.Writer, s *Server) {
 	}
 
 	writeWALMetrics(w, s.dr.WAL, shardIDs, s.dr.ReplicaState, pairs)
+}
+
+// writeQueryHistogramMetrics emits loveliness_query_duration_seconds in
+// the standard Prometheus histogram shape: one `_bucket{...,le="..."}`
+// series per cumulative bucket, plus `_sum` and `_count`. Exposition is
+// per-(query_type, status) series in stable order.
+func writeQueryHistogramMetrics(w io.Writer, snaps []histogramSnapshot) {
+	if len(snaps) == 0 {
+		return
+	}
+	emitHelp(w, "loveliness_query_duration_seconds",
+		"/cypher request latency in seconds, bucketed by query type and status.", "histogram")
+	for _, h := range snaps {
+		for _, p := range h.Buckets {
+			fprintf(w,
+				"loveliness_query_duration_seconds_bucket{query_type=%q,status=%q,le=%q} %d\n",
+				h.QueryType, h.Status, formatBucketBound(p.UpperBound), p.Count)
+		}
+		fprintf(w,
+			"loveliness_query_duration_seconds_sum{query_type=%q,status=%q} %s\n",
+			h.QueryType, h.Status, formatGaugeFloat(h.Sum))
+		fprintf(w,
+			"loveliness_query_duration_seconds_count{query_type=%q,status=%q} %d\n",
+			h.QueryType, h.Status, h.Count)
+	}
+}
+
+// formatBucketBound renders a bucket upper-bound exactly the way
+// Prometheus expects: positive infinity as "+Inf", everything else as
+// a trimmed decimal so dashboards built against the standard exposition
+// (`le="0.005"`, `le="+Inf"`) keep working.
+func formatBucketBound(v float64) string {
+	if math.IsInf(v, 1) {
+		return "+Inf"
+	}
+	return formatGaugeFloat(v)
 }
 
 // writeQueryCounterMetrics emits loveliness_query_total{query_type, status}

--- a/pkg/api/query_metrics.go
+++ b/pkg/api/query_metrics.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"math"
 	"sort"
 	"strings"
 	"sync"
@@ -96,6 +97,106 @@ func classifyQueryType(cypher string) string {
 		}
 	}
 	return "unknown"
+}
+
+// queryDurationBuckets are the histogram bucket upper bounds in seconds.
+// Aligned with the latency targets in #12 (0.25 ms → 2.5 s) — we expect
+// most reads under 25 ms and most writes under 250 ms; buckets span both
+// regimes with enough resolution to spot a tail moving.
+var queryDurationBuckets = []float64{
+	0.00025, 0.0005, 0.001, 0.002, 0.005, 0.01,
+	0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5,
+}
+
+// queryHistogram is a hand-rolled Prometheus histogram for /cypher
+// latencies grouped by (query_type, status). Avoids dragging in the
+// prometheus/client_golang dep just for one series; pulls its weight
+// here because the only thing we need is `Observe + Snapshot`.
+type queryHistogram struct {
+	mu      sync.Mutex
+	buckets []float64 // upper bounds (sec), strictly ascending
+	series  map[queryCounterKey]*histogramSeries
+}
+
+type histogramSeries struct {
+	bucketCounts []uint64 // len == len(buckets), cumulative at write time
+	count        uint64
+	sum          float64
+}
+
+func newQueryHistogram() *queryHistogram {
+	return &queryHistogram{
+		buckets: append([]float64(nil), queryDurationBuckets...),
+		series:  make(map[queryCounterKey]*histogramSeries),
+	}
+}
+
+// Observe records a single duration in seconds against (qtype, status).
+func (h *queryHistogram) Observe(qtype, status string, seconds float64) {
+	if h == nil {
+		return
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	k := queryCounterKey{qtype: qtype, status: status}
+	s := h.series[k]
+	if s == nil {
+		s = &histogramSeries{bucketCounts: make([]uint64, len(h.buckets))}
+		h.series[k] = s
+	}
+	for i, b := range h.buckets {
+		if seconds <= b {
+			s.bucketCounts[i]++
+		}
+	}
+	s.count++
+	s.sum += seconds
+}
+
+// histogramSnapshot is the deterministic, sorted dump used by the
+// metrics writer.
+type histogramSnapshot struct {
+	QueryType string
+	Status    string
+	Buckets   []bucketPoint // one per bucket bound, +Inf appended at the end
+	Count     uint64
+	Sum       float64
+}
+
+type bucketPoint struct {
+	UpperBound float64
+	Count      uint64
+}
+
+// Snapshot returns a deterministic dump of the histogram. Each series
+// gets the configured bucket bounds plus a synthetic +Inf bucket whose
+// count equals the total observations — required by the Prometheus
+// histogram contract.
+func (h *queryHistogram) Snapshot() []histogramSnapshot {
+	if h == nil {
+		return nil
+	}
+	h.mu.Lock()
+	out := make([]histogramSnapshot, 0, len(h.series))
+	for k, s := range h.series {
+		points := make([]bucketPoint, 0, len(h.buckets)+1)
+		for i, b := range h.buckets {
+			points = append(points, bucketPoint{UpperBound: b, Count: s.bucketCounts[i]})
+		}
+		points = append(points, bucketPoint{UpperBound: math.Inf(1), Count: s.count})
+		out = append(out, histogramSnapshot{
+			QueryType: k.qtype, Status: k.status,
+			Buckets: points, Count: s.count, Sum: s.sum,
+		})
+	}
+	h.mu.Unlock()
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].QueryType != out[j].QueryType {
+			return out[i].QueryType < out[j].QueryType
+		}
+		return out[i].Status < out[j].Status
+	})
+	return out
 }
 
 // statusBucket collapses an HTTP status into the three buckets exposed

--- a/pkg/api/query_metrics_test.go
+++ b/pkg/api/query_metrics_test.go
@@ -170,6 +170,123 @@ func TestWriteQueryCounterMetrics_Format(t *testing.T) {
 	}
 }
 
+func TestQueryHistogram_ObserveAndSnapshot(t *testing.T) {
+	h := newQueryHistogram()
+	h.Observe("read", "ok", 0.001)   // ≤ 0.001
+	h.Observe("read", "ok", 0.003)   // ≤ 0.005
+	h.Observe("read", "ok", 0.4)     // ≤ 0.5
+	h.Observe("read", "ok", 5.0)     // > 2.5 → only +Inf
+	h.Observe("write", "ok", 0.0001) // ≤ 0.00025
+
+	snaps := h.Snapshot()
+	if len(snaps) != 2 {
+		t.Fatalf("expected 2 series, got %d", len(snaps))
+	}
+
+	read := snaps[0]
+	if read.QueryType != "read" || read.Status != "ok" {
+		t.Fatalf("first should be read/ok, got %+v", read)
+	}
+	if read.Count != 4 {
+		t.Errorf("read count = %d, want 4", read.Count)
+	}
+	wantSum := 0.001 + 0.003 + 0.4 + 5.0
+	if read.Sum < wantSum-1e-9 || read.Sum > wantSum+1e-9 {
+		t.Errorf("read sum = %v, want %v", read.Sum, wantSum)
+	}
+
+	// +Inf bucket must equal total count.
+	last := read.Buckets[len(read.Buckets)-1]
+	if last.UpperBound == 0 {
+		t.Fatal("expected +Inf bucket at the end")
+	}
+	if last.Count != read.Count {
+		t.Errorf("+Inf bucket count %d != total count %d", last.Count, read.Count)
+	}
+
+	// le=0.001 bucket: 0.001 falls into it (≤), 0.003 doesn't.
+	bucket0p001 := findBucket(read.Buckets, 0.001)
+	if bucket0p001 != 1 {
+		t.Errorf("le=0.001 bucket count = %d, want 1", bucket0p001)
+	}
+	// le=0.005 bucket: 0.001 and 0.003 both fall in.
+	bucket0p005 := findBucket(read.Buckets, 0.005)
+	if bucket0p005 != 2 {
+		t.Errorf("le=0.005 bucket count = %d, want 2", bucket0p005)
+	}
+	// le=0.5 bucket: 0.001, 0.003, and 0.4 all fall in.
+	bucket0p5 := findBucket(read.Buckets, 0.5)
+	if bucket0p5 != 3 {
+		t.Errorf("le=0.5 bucket count = %d, want 3", bucket0p5)
+	}
+	// le=2.5 bucket: 5.0 doesn't fall in, so still 3.
+	bucket2p5 := findBucket(read.Buckets, 2.5)
+	if bucket2p5 != 3 {
+		t.Errorf("le=2.5 bucket count = %d, want 3", bucket2p5)
+	}
+}
+
+func findBucket(points []bucketPoint, le float64) uint64 {
+	for _, p := range points {
+		if p.UpperBound == le {
+			return p.Count
+		}
+	}
+	return 0
+}
+
+func TestQueryHistogram_NilSafe(t *testing.T) {
+	var h *queryHistogram
+	h.Observe("read", "ok", 0.1) // must not panic
+	if got := h.Snapshot(); got != nil {
+		t.Errorf("nil snapshot must be nil, got %v", got)
+	}
+}
+
+func TestQueryHistogram_ConcurrentObserve(t *testing.T) {
+	h := newQueryHistogram()
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				h.Observe("read", "ok", 0.001)
+			}
+		}()
+	}
+	wg.Wait()
+	snap := h.Snapshot()
+	if len(snap) != 1 || snap[0].Count != 5000 {
+		t.Errorf("expected count=5000, got %+v", snap)
+	}
+}
+
+func TestWriteQueryHistogramMetrics_EmitsAllSeries(t *testing.T) {
+	h := newQueryHistogram()
+	h.Observe("read", "ok", 0.0009) // ≤ 0.001 bucket
+	h.Observe("read", "ok", 1.5)    // ≤ 2.5 bucket
+
+	var buf bytes.Buffer
+	writeQueryHistogramMetrics(&buf, h.Snapshot())
+	out := buf.String()
+
+	mustContain := []string{
+		"# HELP loveliness_query_duration_seconds",
+		"# TYPE loveliness_query_duration_seconds histogram",
+		`loveliness_query_duration_seconds_bucket{query_type="read",status="ok",le="0.001"} 1`,
+		`loveliness_query_duration_seconds_bucket{query_type="read",status="ok",le="2.5"} 2`,
+		`loveliness_query_duration_seconds_bucket{query_type="read",status="ok",le="+Inf"} 2`,
+		`loveliness_query_duration_seconds_count{query_type="read",status="ok"} 2`,
+		`loveliness_query_duration_seconds_sum{query_type="read",status="ok"}`,
+	}
+	for _, s := range mustContain {
+		if !strings.Contains(out, s) {
+			t.Errorf("missing %q in:\n%s", s, out)
+		}
+	}
+}
+
 func TestCypher_RecordsQueryCounter(t *testing.T) {
 	srv := setupTestServer()
 


### PR DESCRIPTION
## Summary
- Adds `loveliness_query_duration_seconds{query_type, status}` Prometheus histogram, recorded on every `/cypher` outcome alongside the existing counter.
- Buckets per #12 spec (0.25 ms → 2.5 s) plus `+Inf` as required by the histogram contract.
- Same labels as `loveliness_query_total` — bounded ≤ 16 series total.
- Hand-rolled (no `client_golang` dep) to keep the exposition consistent with the rest of the metrics file.
- Duration covers body read → parse → dispatch → response write so dashboards see end-to-end client latency.

## Test plan
- [x] `go test ./pkg/api/... -run "Histogram"` — 4 new tests pass (Observe + Snapshot, nil-safe, concurrent, exposition format)
- [x] `go test ./...` — full suite green
- [x] `golangci-lint run ./...` — 0 issues

## Follow-ups (still on #12)
- `loveliness_shard_rss_bytes`, `loveliness_shard_vertex_count`, `loveliness_shard_edge_count`
- `loveliness_bulk_load_rows_total`
- Per-shard detail array on /health
- `deploy/grafana/loveliness-overview.json`
- Label budget docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)