### PR TITLE
feat(metrics): loveliness_bulk_load_rows_total counter (#12)

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -63,21 +63,26 @@ type Server struct {
 	// queryHistogram tracks /cypher latencies by (query_type, status)
 	// for the loveliness_query_duration_seconds metric.
 	queryHistogram *queryHistogram
+
+	// bulkLoadCounters tracks rows ingested via /bulk/* endpoints,
+	// labeled by table, for the loveliness_bulk_load_rows_total metric.
+	bulkLoadCounters *bulkLoadCounters
 }
 
 // NewServer creates a new API server.
 func NewServer(r *router.Router, c *cluster.Cluster, shards []*shard.Shard, reg *schema.Registry, timeout time.Duration) *Server {
 	return &Server{
-		router:         r,
-		cluster:        c,
-		shards:         shards,
-		schema:         reg,
-		timeout:        timeout,
-		refTracker:     make(map[int]map[string]bool),
-		joinTokens:     cluster.NewTokenStore(),
-		startTime:      time.Now(),
-		queryCounters:  newQueryCounters(),
-		queryHistogram: newQueryHistogram(),
+		router:           r,
+		cluster:          c,
+		shards:           shards,
+		schema:           reg,
+		timeout:          timeout,
+		refTracker:       make(map[int]map[string]bool),
+		joinTokens:       cluster.NewTokenStore(),
+		startTime:        time.Now(),
+		queryCounters:    newQueryCounters(),
+		queryHistogram:   newQueryHistogram(),
+		bulkLoadCounters: newBulkLoadCounters(),
 	}
 }
 

--- a/pkg/api/bulk.go
+++ b/pkg/api/bulk.go
@@ -99,6 +99,8 @@ func (s *Server) handleBulkNodes(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	}
+	s.bulkLoadCounters.Add(tableName, result.Loaded)
+
 	if len(result.Errors) > 0 {
 		writeJSON(w, http.StatusMultiStatus, result)
 	} else {
@@ -195,9 +197,14 @@ func (s *Server) handleBulkEdges(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if refsOnly {
+		loaded := int64(totalRefs - len(refErrors))
+		// Refs-only loads materialise nodes in the "to" table, not the
+		// rel table — count them under toTable so dashboards see them
+		// against the right entity.
+		s.bulkLoadCounters.Add(toTable, loaded)
 		writeJSON(w, http.StatusOK, bulkResult{
 			Table:  relTable,
-			Loaded: int64(totalRefs - len(refErrors)),
+			Loaded: loaded,
 			Errors: refErrors,
 		})
 		return
@@ -206,6 +213,8 @@ func (s *Server) handleBulkEdges(w http.ResponseWriter, r *http.Request) {
 	// COPY FROM edges per shard.
 	result := s.copyFromShards(relTable, headerLine, buckets)
 	result.Errors = append(refErrors, result.Errors...)
+
+	s.bulkLoadCounters.Add(relTable, result.Loaded)
 
 	if len(result.Errors) > 0 {
 		writeJSON(w, http.StatusMultiStatus, result)

--- a/pkg/api/bulk_stream.go
+++ b/pkg/api/bulk_stream.go
@@ -136,6 +136,7 @@ func (s *Server) handleBulkNodesStream(w http.ResponseWriter, r *http.Request) {
 		Loaded: totalLoaded.Load(),
 		Errors: allErrors,
 	}
+	s.bulkLoadCounters.Add(tableName, result.Loaded)
 	if len(result.Errors) > 0 {
 		writeJSON(w, http.StatusMultiStatus, result)
 	} else {
@@ -303,6 +304,7 @@ func (s *Server) handleBulkEdgesStream(w http.ResponseWriter, r *http.Request) {
 		Loaded: totalLoaded.Load(),
 		Errors: allErrors,
 	}
+	s.bulkLoadCounters.Add(relTable, result.Loaded)
 	if len(result.Errors) > 0 {
 		writeJSON(w, http.StatusMultiStatus, result)
 	} else {

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -81,6 +81,10 @@ func writeMetrics(w io.Writer, s *Server) {
 		writeQueryHistogramMetrics(w, s.queryHistogram.Snapshot())
 	}
 
+	if s.bulkLoadCounters != nil {
+		writeBulkLoadMetrics(w, s.bulkLoadCounters.Snapshot())
+	}
+
 	if s.dr == nil || s.dr.WAL == nil {
 		return
 	}
@@ -140,6 +144,20 @@ func formatBucketBound(v float64) string {
 		return "+Inf"
 	}
 	return formatGaugeFloat(v)
+}
+
+// writeBulkLoadMetrics emits loveliness_bulk_load_rows_total{table} from
+// a deterministic snapshot. Empty snapshots emit nothing — a series only
+// appears once a /bulk/* request has loaded at least one row for the table.
+func writeBulkLoadMetrics(w io.Writer, samples []bulkLoadSample) {
+	if len(samples) == 0 {
+		return
+	}
+	emitHelp(w, "loveliness_bulk_load_rows_total",
+		"Cumulative rows loaded via /bulk/* endpoints, by table.", "counter")
+	for _, s := range samples {
+		fprintf(w, "loveliness_bulk_load_rows_total{table=%q} %d\n", s.Table, s.Count)
+	}
 }
 
 // writeQueryCounterMetrics emits loveliness_query_total{query_type, status}

--- a/pkg/api/query_metrics.go
+++ b/pkg/api/query_metrics.go
@@ -199,6 +199,51 @@ func (h *queryHistogram) Snapshot() []histogramSnapshot {
 	return out
 }
 
+// bulkLoadCounters tracks total rows loaded by /bulk/* endpoints,
+// labeled by table. Cardinality is bounded by the number of tables in
+// the cluster (≤ ~hundreds in production); we deliberately don't add
+// a status label here — partial loads still count rows actually
+// applied, and total errors are surfaced via loveliness_query_total.
+type bulkLoadCounters struct {
+	mu     sync.Mutex
+	counts map[string]uint64 // table → cumulative row count
+}
+
+func newBulkLoadCounters() *bulkLoadCounters {
+	return &bulkLoadCounters{counts: make(map[string]uint64)}
+}
+
+// Add records `rows` rows loaded into `table`. Negative or zero rows
+// are dropped — empty bulk requests should not bump the counter.
+func (b *bulkLoadCounters) Add(table string, rows int64) {
+	if b == nil || rows <= 0 || table == "" {
+		return
+	}
+	b.mu.Lock()
+	b.counts[table] += uint64(rows)
+	b.mu.Unlock()
+}
+
+type bulkLoadSample struct {
+	Table string
+	Count uint64
+}
+
+// Snapshot returns a stable, alphabetically-sorted dump for emission.
+func (b *bulkLoadCounters) Snapshot() []bulkLoadSample {
+	if b == nil {
+		return nil
+	}
+	b.mu.Lock()
+	out := make([]bulkLoadSample, 0, len(b.counts))
+	for t, c := range b.counts {
+		out = append(out, bulkLoadSample{Table: t, Count: c})
+	}
+	b.mu.Unlock()
+	sort.Slice(out, func(i, j int) bool { return out[i].Table < out[j].Table })
+	return out
+}
+
 // statusBucket collapses an HTTP status into the three buckets exposed
 // as the `status` label: "ok" (2xx), "client_error" (4xx),
 // "server_error" (5xx). Keeps cardinality bounded — the spec forbids

--- a/pkg/api/query_metrics_test.go
+++ b/pkg/api/query_metrics_test.go
@@ -287,6 +287,113 @@ func TestWriteQueryHistogramMetrics_EmitsAllSeries(t *testing.T) {
 	}
 }
 
+func TestBulkLoadCounters_AddAndSnapshot(t *testing.T) {
+	b := newBulkLoadCounters()
+	b.Add("Person", 100)
+	b.Add("Person", 50)
+	b.Add("Movie", 7)
+
+	snap := b.Snapshot()
+	if len(snap) != 2 {
+		t.Fatalf("expected 2 series, got %d", len(snap))
+	}
+	// Sorted alphabetically: Movie, Person.
+	if snap[0].Table != "Movie" || snap[0].Count != 7 {
+		t.Errorf("snap[0] = %+v, want {Movie 7}", snap[0])
+	}
+	if snap[1].Table != "Person" || snap[1].Count != 150 {
+		t.Errorf("snap[1] = %+v, want {Person 150}", snap[1])
+	}
+}
+
+func TestBulkLoadCounters_DropsZeroAndNegative(t *testing.T) {
+	b := newBulkLoadCounters()
+	b.Add("Person", 0)
+	b.Add("Person", -5)
+	b.Add("", 10)
+	if got := b.Snapshot(); len(got) != 0 {
+		t.Errorf("expected no samples, got %+v", got)
+	}
+}
+
+func TestBulkLoadCounters_NilSafe(t *testing.T) {
+	var b *bulkLoadCounters
+	b.Add("Person", 5) // must not panic
+	if got := b.Snapshot(); got != nil {
+		t.Errorf("nil snapshot must be nil, got %v", got)
+	}
+}
+
+func TestBulkLoadCounters_ConcurrentAdd(t *testing.T) {
+	b := newBulkLoadCounters()
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				b.Add("Person", 1)
+			}
+		}()
+	}
+	wg.Wait()
+	snap := b.Snapshot()
+	if len(snap) != 1 || snap[0].Count != 5000 {
+		t.Errorf("expected 1 series with count=5000, got %+v", snap)
+	}
+}
+
+func TestWriteBulkLoadMetrics_EmptyEmitsNothing(t *testing.T) {
+	var buf bytes.Buffer
+	writeBulkLoadMetrics(&buf, nil)
+	if buf.Len() != 0 {
+		t.Errorf("empty samples must emit nothing, got:\n%s", buf.String())
+	}
+}
+
+func TestWriteBulkLoadMetrics_Format(t *testing.T) {
+	var buf bytes.Buffer
+	writeBulkLoadMetrics(&buf, []bulkLoadSample{
+		{Table: "Movie", Count: 7},
+		{Table: "Person", Count: 150},
+	})
+	out := buf.String()
+	mustContain := []string{
+		"# HELP loveliness_bulk_load_rows_total",
+		"# TYPE loveliness_bulk_load_rows_total counter",
+		`loveliness_bulk_load_rows_total{table="Movie"} 7`,
+		`loveliness_bulk_load_rows_total{table="Person"} 150`,
+	}
+	for _, s := range mustContain {
+		if !strings.Contains(out, s) {
+			t.Errorf("missing %q in:\n%s", s, out)
+		}
+	}
+}
+
+func TestBulkNodes_RecordsBulkLoadCounter(t *testing.T) {
+	srv := setupTestServerWithSchema()
+	body := "name,age,city\nAlice,30,Auckland\nBob,25,Wellington\nCharlie,28,Hamilton\n"
+	req := httptest.NewRequest("POST", "/bulk/nodes", bytes.NewBufferString(body))
+	req.Header.Set("X-Table", "Person")
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("bulk/nodes returned %d: %s", w.Code, w.Body.String())
+	}
+
+	mreq := httptest.NewRequest("GET", "/metrics", nil)
+	mw := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(mw, mreq)
+	if mw.Code != http.StatusOK {
+		t.Fatalf("metrics endpoint returned %d: %s", mw.Code, mw.Body.String())
+	}
+	body2 := mw.Body.String()
+	if !strings.Contains(body2, `loveliness_bulk_load_rows_total{table="Person"} 3`) {
+		t.Errorf("expected Person counter at 3 in /metrics:\n%s", body2)
+	}
+}
+
 func TestCypher_RecordsQueryCounter(t *testing.T) {
 	srv := setupTestServer()
 


### PR DESCRIPTION
## Summary
- New `loveliness_bulk_load_rows_total{table}` counter exposed via `/metrics`, recording rows ingested by `/bulk/nodes` and `/bulk/edges` (buffered + streaming).
- Refs-only edge loads count under the *to-table* (where nodes materialise); rel-table counter only bumps for actual edge rows.
- Bounded cardinality (one series per table) and lazy creation matching the rest of the metrics package.

## Test plan
- [x] `go test ./...` (full suite green)
- [x] `golangci-lint run ./pkg/api/...` (0 issues)
- [x] New unit tests: Add/Snapshot, drops zero/negative, nil-safe, concurrent Add, sorted-output, format
- [x] End-to-end: POST `/bulk/nodes` then GET `/metrics` shows `table="Person"` at the expected count

Slice of #12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)