### PR TITLE
feat(metrics): Go runtime gauges + GC counters (#12)

### DIFF
--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -66,6 +66,8 @@ type replicaLagPair struct {
 }
 
 func writeMetrics(w io.Writer, s *Server) {
+	writeRuntimeMetrics(w)
+
 	emitHelp(w, "loveliness_local_shards", "Number of shards opened on this node.", "gauge")
 	fprintf(w, "loveliness_local_shards %d\n", len(s.shards))
 

--- a/pkg/api/runtime_metrics.go
+++ b/pkg/api/runtime_metrics.go
@@ -1,0 +1,54 @@
+package api
+
+import (
+	"io"
+	"runtime"
+)
+
+// writeRuntimeMetrics emits a small, fixed set of Go runtime gauges and
+// counters. We deliberately don't pull in prometheus/client_golang's Go
+// collector — its surface area is broad, and operators only need a
+// handful of signals to spot memory or scheduler trouble. All series
+// have zero label cardinality.
+//
+// Series exposed:
+//
+//	loveliness_go_goroutines                gauge
+//	loveliness_go_memstats_alloc_bytes      gauge   (HeapAlloc)
+//	loveliness_go_memstats_sys_bytes        gauge   (Sys — total OS memory obtained)
+//	loveliness_go_memstats_heap_inuse_bytes gauge
+//	loveliness_go_memstats_heap_objects     gauge
+//	loveliness_go_gc_count_total            counter (NumGC)
+//	loveliness_go_gc_pause_seconds_total    counter (PauseTotalNs / 1e9)
+func writeRuntimeMetrics(w io.Writer) {
+	emitHelp(w, "loveliness_go_goroutines", "Number of goroutines currently running.", "gauge")
+	fprintf(w, "loveliness_go_goroutines %d\n", runtime.NumGoroutine())
+
+	var ms runtime.MemStats
+	runtime.ReadMemStats(&ms)
+
+	emitHelp(w, "loveliness_go_memstats_alloc_bytes",
+		"Bytes of heap objects currently allocated.", "gauge")
+	fprintf(w, "loveliness_go_memstats_alloc_bytes %d\n", ms.HeapAlloc)
+
+	emitHelp(w, "loveliness_go_memstats_sys_bytes",
+		"Total bytes of memory obtained from the OS by the Go runtime.", "gauge")
+	fprintf(w, "loveliness_go_memstats_sys_bytes %d\n", ms.Sys)
+
+	emitHelp(w, "loveliness_go_memstats_heap_inuse_bytes",
+		"Bytes in in-use heap spans.", "gauge")
+	fprintf(w, "loveliness_go_memstats_heap_inuse_bytes %d\n", ms.HeapInuse)
+
+	emitHelp(w, "loveliness_go_memstats_heap_objects",
+		"Number of allocated heap objects.", "gauge")
+	fprintf(w, "loveliness_go_memstats_heap_objects %d\n", ms.HeapObjects)
+
+	emitHelp(w, "loveliness_go_gc_count_total",
+		"Cumulative count of completed GC cycles.", "counter")
+	fprintf(w, "loveliness_go_gc_count_total %d\n", ms.NumGC)
+
+	emitHelp(w, "loveliness_go_gc_pause_seconds_total",
+		"Cumulative time the program has been paused for GC, in seconds.", "counter")
+	fprintf(w, "loveliness_go_gc_pause_seconds_total %s\n",
+		formatGaugeFloat(float64(ms.PauseTotalNs)/1e9))
+}

--- a/pkg/api/runtime_metrics_test.go
+++ b/pkg/api/runtime_metrics_test.go
@@ -1,0 +1,86 @@
+package api
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestWriteRuntimeMetrics_EmitsAllSeries(t *testing.T) {
+	var buf bytes.Buffer
+	writeRuntimeMetrics(&buf)
+	out := buf.String()
+
+	mustContain := []string{
+		"# HELP loveliness_go_goroutines",
+		"# TYPE loveliness_go_goroutines gauge",
+		"loveliness_go_goroutines ",
+
+		"# HELP loveliness_go_memstats_alloc_bytes",
+		"# TYPE loveliness_go_memstats_alloc_bytes gauge",
+		"loveliness_go_memstats_alloc_bytes ",
+
+		"# HELP loveliness_go_memstats_sys_bytes",
+		"# TYPE loveliness_go_memstats_sys_bytes gauge",
+		"loveliness_go_memstats_sys_bytes ",
+
+		"# HELP loveliness_go_memstats_heap_inuse_bytes",
+		"loveliness_go_memstats_heap_inuse_bytes ",
+
+		"# HELP loveliness_go_memstats_heap_objects",
+		"loveliness_go_memstats_heap_objects ",
+
+		"# HELP loveliness_go_gc_count_total",
+		"# TYPE loveliness_go_gc_count_total counter",
+		"loveliness_go_gc_count_total ",
+
+		"# HELP loveliness_go_gc_pause_seconds_total",
+		"# TYPE loveliness_go_gc_pause_seconds_total counter",
+		"loveliness_go_gc_pause_seconds_total ",
+	}
+	for _, s := range mustContain {
+		if !strings.Contains(out, s) {
+			t.Errorf("missing %q in:\n%s", s, out)
+		}
+	}
+}
+
+func TestWriteRuntimeMetrics_NonZeroValues(t *testing.T) {
+	var buf bytes.Buffer
+	writeRuntimeMetrics(&buf)
+	out := buf.String()
+
+	// At least one goroutine (the test runner) and some heap allocation
+	// must always be present in a live Go process — confirms we're
+	// reading actual values, not zeros.
+	if strings.Contains(out, "loveliness_go_goroutines 0\n") {
+		t.Errorf("goroutine count should be > 0:\n%s", out)
+	}
+	if strings.Contains(out, "loveliness_go_memstats_alloc_bytes 0\n") {
+		t.Errorf("heap alloc should be > 0:\n%s", out)
+	}
+}
+
+func TestRuntimeMetrics_ScrapedViaEndpoint(t *testing.T) {
+	srv := setupTestServer()
+	req := httptest.NewRequest("GET", "/metrics", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("metrics endpoint returned %d: %s", w.Code, w.Body.String())
+	}
+	body := w.Body.String()
+	mustContain := []string{
+		"loveliness_go_goroutines ",
+		"loveliness_go_memstats_alloc_bytes ",
+		"loveliness_go_gc_count_total ",
+	}
+	for _, s := range mustContain {
+		if !strings.Contains(body, s) {
+			t.Errorf("missing %q in /metrics body:\n%s", s, body)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Adds a hand-rolled set of process/runtime metrics — goroutines, heap alloc/sys/in-use, heap objects, GC count + cumulative pause time.
- Zero label cardinality across the new series; `ReadMemStats` is cheap enough to call per-scrape.
- Avoids `prometheus/client_golang` dependency, consistent with the rest of the metrics package.

## Test plan
- [x] `go test ./...` (full suite green)
- [x] `golangci-lint run ./pkg/api/...` (0 issues)
- [x] Unit tests for full series exposition + non-zero values
- [x] End-to-end `/metrics` scrape contains the new series

Slice of #12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)