### PR TITLE
feat(metrics): loveliness_shard_healthy{shard_id} gauge (#12)

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -21,6 +21,7 @@ explicitly here, not by collector defaults.
 | Metric | Type | Labels | Cardinality bound |
 |---|---|---|---|
 | `loveliness_local_shards` | gauge | — | 1 |
+| `loveliness_shard_healthy` | gauge | `shard_id` | ≤ 256 |
 | `loveliness_raft_state` | gauge | `node_id`, `state` | 1 × 5 = **5** |
 | `loveliness_query_total` | counter | `query_type`, `status` | 4 × 4 = **16** |
 | `loveliness_query_duration_seconds` | histogram | `query_type`, `status` | 4 × 4 × (13 buckets + `_sum` + `_count` + `+Inf`) ≈ **256** |

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -8,6 +8,8 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/johnjansen/loveliness/pkg/shard"
 )
 
 // handleMetrics serves Prometheus text-format metrics. We hand-roll the
@@ -70,6 +72,8 @@ func writeMetrics(w io.Writer, s *Server) {
 
 	emitHelp(w, "loveliness_local_shards", "Number of shards opened on this node.", "gauge")
 	fprintf(w, "loveliness_local_shards %d\n", len(s.shards))
+
+	writeShardHealthMetric(w, s)
 
 	if s.cluster != nil {
 		writeRaftStateMetric(w, s.cluster)
@@ -175,6 +179,29 @@ func writeQueryCounterMetrics(w io.Writer, samples []queryCounterSample) {
 	for _, s := range samples {
 		fprintf(w, "loveliness_query_total{query_type=%q,status=%q} %d\n",
 			s.QueryType, s.Status, s.Count)
+	}
+}
+
+// writeShardHealthMetric emits loveliness_shard_healthy{shard_id} as a
+// 0/1 gauge per local shard. Lets dashboards and alerts surface a single
+// shard going unhealthy (CGo panic, marked offline) without scraping
+// /health and parsing JSON.
+func writeShardHealthMetric(w io.Writer, s *Server) {
+	if len(s.shards) == 0 {
+		return
+	}
+	emitHelp(w, "loveliness_shard_healthy",
+		"Per-shard health on this node: 1 healthy, 0 unhealthy.", "gauge")
+	sortedShards := append([]*shard.Shard(nil), s.shards...)
+	sort.Slice(sortedShards, func(i, j int) bool {
+		return sortedShards[i].ID < sortedShards[j].ID
+	})
+	for _, sh := range sortedShards {
+		v := 0
+		if sh.IsHealthy() {
+			v = 1
+		}
+		fprintf(w, "loveliness_shard_healthy{shard_id=\"%d\"} %d\n", sh.ID, v)
 	}
 }
 

--- a/pkg/api/metrics_test.go
+++ b/pkg/api/metrics_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"bytes"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -196,6 +197,70 @@ func TestRaftState_AlwaysEmitsAllStates(t *testing.T) {
 			t.Errorf("missing series for state=%q in:\n%s", st, out)
 		}
 	}
+}
+
+func TestShardHealthMetric_AllHealthy(t *testing.T) {
+	srv := setupTestServer()
+	var buf bytes.Buffer
+	writeShardHealthMetric(&buf, srv)
+	out := buf.String()
+
+	mustContain := []string{
+		"# HELP loveliness_shard_healthy",
+		"# TYPE loveliness_shard_healthy gauge",
+	}
+	for _, s := range mustContain {
+		if !strings.Contains(out, s) {
+			t.Errorf("missing %q in:\n%s", s, out)
+		}
+	}
+	for _, sh := range srv.shards {
+		want := `loveliness_shard_healthy{shard_id="` + itoa(sh.ID) + `"} 1`
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+func TestShardHealthMetric_SortedByShardID(t *testing.T) {
+	srv := setupTestServer()
+	var buf bytes.Buffer
+	writeShardHealthMetric(&buf, srv)
+	out := buf.String()
+	idx0 := strings.Index(out, `loveliness_shard_healthy{shard_id="0"}`)
+	idx1 := strings.Index(out, `loveliness_shard_healthy{shard_id="1"}`)
+	if idx0 < 0 || idx1 < 0 || idx0 >= idx1 {
+		t.Errorf("expected shard 0 before shard 1; got idx0=%d idx1=%d", idx0, idx1)
+	}
+}
+
+func TestShardHealthMetric_ScrapedViaEndpoint(t *testing.T) {
+	srv := setupTestServer()
+	req := httptest.NewRequest("GET", "/metrics", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("metrics endpoint returned %d: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "loveliness_shard_healthy{shard_id=") {
+		t.Errorf("missing loveliness_shard_healthy series in /metrics:\n%s", w.Body.String())
+	}
+}
+
+func TestShardHealthMetric_NoShardsEmitsNothing(t *testing.T) {
+	// A Server with no shards (degenerate case) must not emit the
+	// help/type headers either — empty exposition is what Prometheus
+	// expects for a metric with no series.
+	srv := &Server{}
+	var buf bytes.Buffer
+	writeShardHealthMetric(&buf, srv)
+	if buf.Len() != 0 {
+		t.Errorf("expected no output for empty shards, got:\n%s", buf.String())
+	}
+}
+
+func itoa(n int) string {
+	return fmt.Sprintf("%d", n)
 }
 
 func TestComputeLagSeconds(t *testing.T) {


### PR DESCRIPTION
## Summary
- Per-shard `0/1` health gauge derived from `Shard.IsHealthy()`.
- Lets dashboards/alerts surface a single shard going unhealthy (CGo panic, marked offline) without scraping `/health` and parsing JSON.
- Stable `shard_id` ordering matches the existing `loveliness_wal_head_sequence` emission.
- Updates `docs/metrics.md` catalogue with the new series.

## Test plan
- [x] `go test ./...` (full suite green)
- [x] `golangci-lint run ./pkg/api/...` (0 issues)
- [x] Unit tests: all-healthy, sorted-by-shard-id, end-to-end scrape, no-shards-emits-nothing

Slice of #12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)