### PR TITLE
feat(grafana): operational overview dashboard (#12)

### DIFF
--- a/deploy/grafana/README.md
+++ b/deploy/grafana/README.md
@@ -1,0 +1,64 @@
+# Grafana dashboards
+
+`loveliness-overview.json` is the operational overview dashboard for a
+Loveliness cluster. It panels:
+
+- Raft state (one-hot per node)
+- Per-shard health (0/1)
+- Query QPS by `query_type`
+- Query error rate by `status` (everything except `ok`)
+- Query latency p50/p95/p99 from the duration histogram
+- Replication lag in seconds and entries, per shard × replica
+- Bulk-load rows/sec by table
+- Go runtime memory (alloc / in-use / sys)
+- Goroutines and GC pause/sec
+
+## Importing
+
+1. In Grafana, **Dashboards → New → Import**, then upload
+   `loveliness-overview.json` (or paste its contents).
+2. When prompted, point the `DS_PROMETHEUS` variable at the Prometheus
+   datasource scraping the cluster.
+3. The `node` template variable is populated from
+   `label_values(loveliness_local_shards, node_id)`. Note that
+   `loveliness_local_shards` is currently emitted without a `node_id`
+   label; the variable will fall back to `All` until a per-node label
+   is added at the scrape config (e.g. via `relabel_configs` /
+   `external_labels`).
+
+## Prometheus scrape config (example)
+
+```yaml
+scrape_configs:
+  - job_name: loveliness
+    metrics_path: /metrics
+    static_configs:
+      - targets:
+          - loveliness-0.example.internal:8080
+          - loveliness-1.example.internal:8080
+          - loveliness-2.example.internal:8080
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: node_id
+        regex: '([^.]+)\..*'
+        replacement: '$1'
+```
+
+## Schema
+
+- Targets Grafana **schemaVersion 39** (Grafana 10.0+). It will import
+  cleanly into newer versions; older versions may need a re-save to
+  fill in defaults.
+- All series referenced by panels are defined in
+  [`docs/metrics.md`](../../docs/metrics.md). Adding a new series
+  doesn't require dashboard changes; adding a new *panel* does — keep
+  the catalogue in `docs/metrics.md` and the panels here in lock-step.
+
+## Validation
+
+`pkg/api/grafana_dashboard_test.go` does two things on every CI run:
+
+1. Parses the JSON to ensure it stays well-formed.
+2. Asserts every metric name listed in `expectedMetrics` appears in at
+   least one panel's `expr`. That catches accidental renames or panels
+   pointing at metrics we no longer emit.

--- a/deploy/grafana/loveliness-overview.json
+++ b/deploy/grafana/loveliness-overview.json
@@ -1,0 +1,447 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Operational overview for a Loveliness cluster — query latency, Raft state, replication lag, per-shard health, bulk-load rate, and Go runtime signals.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "description": "Current Raft role for this node (one-hot encoded). 1 = active.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [
+            { "options": { "0": { "text": "—", "color": "text" } }, "type": "value" },
+            { "options": { "1": { "text": "ACTIVE", "color": "green" } }, "type": "value" }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "text", "value": null },
+              { "color": "green", "value": 1 }
+            ]
+          }
+        }
+      },
+      "gridPos": { "h": 5, "w": 12, "x": 0, "y": 0 },
+      "id": 1,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "value_and_name"
+      },
+      "pluginVersion": "10.4.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "max by (state) (max_over_time(loveliness_raft_state{node_id=~\"$node\"}[1m]))",
+          "legendFormat": "{{state}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Raft state",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "description": "Per-shard 0/1 health gauge — anything below 1 means a shard panicked or was marked offline.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [
+            { "options": { "0": { "text": "DOWN", "color": "red" } }, "type": "value" },
+            { "options": { "1": { "text": "OK", "color": "green" } }, "type": "value" }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "green", "value": 1 }
+            ]
+          }
+        }
+      },
+      "gridPos": { "h": 5, "w": 12, "x": 12, "y": 0 },
+      "id": 2,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "value_and_name"
+      },
+      "pluginVersion": "10.4.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "loveliness_shard_healthy",
+          "legendFormat": "shard {{shard_id}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Shard health",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "description": "Per-second /cypher request rate, broken out by query type. Sustained spikes on `unknown` usually mean a client is sending malformed Cypher.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "lineWidth": 2,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": { "mode": "none" }
+          },
+          "unit": "reqps"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 5 },
+      "id": 3,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum by (query_type) (rate(loveliness_query_total[$__rate_interval]))",
+          "legendFormat": "{{query_type}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Query QPS by type",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "description": "Per-second rate of non-2xx /cypher responses. A sustained server_error rate is the page-the-operator signal.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "lineWidth": 2,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": { "mode": "none" }
+          },
+          "unit": "reqps"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 5 },
+      "id": 4,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum by (status) (rate(loveliness_query_total{status!=\"ok\"}[$__rate_interval]))",
+          "legendFormat": "{{status}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Query error rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "description": "p50 / p95 / p99 /cypher latency per query_type, computed from the loveliness_query_duration_seconds histogram.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "unit": "s"
+        }
+      },
+      "gridPos": { "h": 9, "w": 24, "x": 0, "y": 13 },
+      "id": 5,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "histogram_quantile(0.50, sum by (le, query_type) (rate(loveliness_query_duration_seconds_bucket[$__rate_interval])))",
+          "legendFormat": "p50 {{query_type}}",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "histogram_quantile(0.95, sum by (le, query_type) (rate(loveliness_query_duration_seconds_bucket[$__rate_interval])))",
+          "legendFormat": "p95 {{query_type}}",
+          "refId": "B"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "histogram_quantile(0.99, sum by (le, query_type) (rate(loveliness_query_duration_seconds_bucket[$__rate_interval])))",
+          "legendFormat": "p99 {{query_type}}",
+          "refId": "C"
+        }
+      ],
+      "title": "Query latency (p50/p95/p99)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "description": "Replica lag in seconds (WAL head timestamp − applied timestamp). Use this to alert on persistent lag > a few seconds.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "unit": "s"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 22 },
+      "id": 6,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "loveliness_replication_lag_seconds",
+          "legendFormat": "shard {{shard_id}} → {{replica_id}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Replication lag (seconds)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "description": "Replica lag in WAL entries (head_seq − applied_seq). Useful when timestamps drift between nodes.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 22 },
+      "id": 7,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "loveliness_replication_lag_entries",
+          "legendFormat": "shard {{shard_id}} → {{replica_id}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Replication lag (entries)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "description": "Rows ingested per second through /bulk/* endpoints, by table. Use this to confirm an ingestion job is making progress.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "lineWidth": 2,
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "unit": "rowsps"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 30 },
+      "id": 8,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum by (table) (rate(loveliness_bulk_load_rows_total[$__rate_interval]))",
+          "legendFormat": "{{table}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Bulk load rows/sec",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "description": "Go runtime memory: heap allocated vs. in-use vs. total OS-reserved.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "unit": "bytes"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 30 },
+      "id": 9,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "loveliness_go_memstats_alloc_bytes",
+          "legendFormat": "alloc",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "loveliness_go_memstats_heap_inuse_bytes",
+          "legendFormat": "heap in-use",
+          "refId": "B"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "loveliness_go_memstats_sys_bytes",
+          "legendFormat": "sys",
+          "refId": "C"
+        }
+      ],
+      "title": "Go memory",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "description": "Goroutine count and per-second GC pause time. Goroutine count climbing without bound is a leak signal.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "showPoints": "never",
+            "spanNulls": true
+          }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "gc pause/s" },
+            "properties": [{ "id": "unit", "value": "s" }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "goroutines" },
+            "properties": [{ "id": "unit", "value": "short" }]
+          }
+        ]
+      },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 38 },
+      "id": 10,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "loveliness_go_goroutines",
+          "legendFormat": "goroutines",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "rate(loveliness_go_gc_pause_seconds_total[$__rate_interval])",
+          "legendFormat": "gc pause/s",
+          "refId": "B"
+        }
+      ],
+      "title": "Goroutines & GC",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["loveliness", "graph-database", "observability"],
+  "templating": {
+    "list": [
+      {
+        "current": { "selected": false, "text": "Prometheus", "value": "Prometheus" },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": { "selected": false, "text": "All", "value": "$__all" },
+        "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+        "definition": "label_values(loveliness_local_shards, node_id)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Node",
+        "multi": true,
+        "name": "node",
+        "options": [],
+        "query": { "query": "label_values(loveliness_local_shards, node_id)", "refId": "StandardVariableQuery" },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Loveliness — Overview",
+  "uid": "loveliness-overview",
+  "version": 1,
+  "weekStart": ""
+}

--- a/pkg/api/grafana_dashboard_test.go
+++ b/pkg/api/grafana_dashboard_test.go
@@ -1,0 +1,113 @@
+package api
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestGrafanaOverviewDashboard_ParsesAndCoversCoreMetrics validates the
+// shipped Grafana JSON. The point isn't to lint Grafana's full schema —
+// that's Grafana's job at import time. The point is to catch drift:
+// when a metric name changes, this test fails until the dashboard is
+// updated (or vice-versa).
+func TestGrafanaOverviewDashboard_ParsesAndCoversCoreMetrics(t *testing.T) {
+	path := filepath.Join("..", "..", "deploy", "grafana", "loveliness-overview.json")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("cannot read %s: %v", path, err)
+	}
+
+	var dash struct {
+		Title  string `json:"title"`
+		UID    string `json:"uid"`
+		Panels []struct {
+			Title   string `json:"title"`
+			Type    string `json:"type"`
+			Targets []struct {
+				Expr string `json:"expr"`
+			} `json:"targets"`
+		} `json:"panels"`
+		Templating struct {
+			List []struct {
+				Name string `json:"name"`
+			} `json:"list"`
+		} `json:"templating"`
+	}
+	if err := json.Unmarshal(raw, &dash); err != nil {
+		t.Fatalf("invalid JSON in dashboard: %v", err)
+	}
+
+	if dash.Title == "" {
+		t.Error("dashboard must have a title")
+	}
+	if dash.UID == "" {
+		t.Error("dashboard must have a uid (so re-imports overwrite the same dashboard)")
+	}
+	if len(dash.Panels) == 0 {
+		t.Fatal("dashboard has no panels")
+	}
+
+	hasDS := false
+	for _, v := range dash.Templating.List {
+		if v.Name == "DS_PROMETHEUS" {
+			hasDS = true
+			break
+		}
+	}
+	if !hasDS {
+		t.Error("dashboard must define a DS_PROMETHEUS templating variable")
+	}
+
+	// Every panel must have at least one target with a non-empty expr.
+	for i, p := range dash.Panels {
+		if len(p.Targets) == 0 {
+			t.Errorf("panel %d (%q) has no targets", i, p.Title)
+			continue
+		}
+		anyExpr := false
+		for _, tgt := range p.Targets {
+			if strings.TrimSpace(tgt.Expr) != "" {
+				anyExpr = true
+				break
+			}
+		}
+		if !anyExpr {
+			t.Errorf("panel %d (%q) has no non-empty expr", i, p.Title)
+		}
+	}
+
+	// Every metric we emit and consider operationally important must
+	// appear in at least one panel expr. Adding a series here forces
+	// the dashboard to display it, or the test fails.
+	expectedMetrics := []string{
+		"loveliness_raft_state",
+		"loveliness_shard_healthy",
+		"loveliness_query_total",
+		"loveliness_query_duration_seconds_bucket",
+		"loveliness_replication_lag_seconds",
+		"loveliness_replication_lag_entries",
+		"loveliness_bulk_load_rows_total",
+		"loveliness_go_goroutines",
+		"loveliness_go_memstats_alloc_bytes",
+		"loveliness_go_memstats_heap_inuse_bytes",
+		"loveliness_go_memstats_sys_bytes",
+		"loveliness_go_gc_pause_seconds_total",
+	}
+
+	allExprs := make([]string, 0)
+	for _, p := range dash.Panels {
+		for _, tgt := range p.Targets {
+			allExprs = append(allExprs, tgt.Expr)
+		}
+	}
+	joined := strings.Join(allExprs, "\n")
+
+	for _, m := range expectedMetrics {
+		if !strings.Contains(joined, m) {
+			t.Errorf("metric %q is not referenced by any panel — dashboard out of date with emitted series", m)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- New `deploy/grafana/loveliness-overview.json` — 10-panel Grafana dashboard covering every metric currently exposed at `/metrics`.
- Panels: Raft state, shard health, query QPS / error rate / latency p50-p99, replication lag (seconds + entries), bulk-load rows/sec, Go memory, goroutines / GC pause.
- Targets schemaVersion 39 (Grafana 10+); `DS_PROMETHEUS` datasource variable, `node` template populated from `label_values(loveliness_local_shards, node_id)`.
- `deploy/grafana/README.md` documents import flow + example Prometheus `relabel_configs` for `node_id`.
- `pkg/api/grafana_dashboard_test.go` parses the JSON and asserts every metric in an allow-list is referenced by at least one panel — catches drift between emitted series and dashboard.

## Test plan
- [x] `go test ./...` (full suite green)
- [x] `golangci-lint run ./pkg/api/...` (0 issues)
- [x] Dashboard JSON parses cleanly; every expected metric is referenced

Slice of #12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)