### PR TITLE
feat(api): /health shards array with replication detail (#12)

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -9,7 +9,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
-	"strconv"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -334,14 +334,26 @@ func (s *Server) replicateSchemaDDL(cypher string) {
 // gate honest: ready returns 503 iff this snapshot says the node is
 // degraded or not-yet-ready, rather than re-deriving the same checks.
 type healthSnapshot struct {
-	Status         string            `json:"status"` // "ok" | "degraded"
-	NodeID         string            `json:"node_id,omitempty"`
-	Mode           string            `json:"mode,omitempty"` // "standalone" when no cluster
-	Role           string            `json:"role,omitempty"`
-	LeaderID       string            `json:"leader_id,omitempty"`
-	UptimeSeconds  float64           `json:"uptime_seconds"`
-	PlacementEpoch uint64            `json:"placement_epoch,omitempty"`
-	Shards         map[string]string `json:"shards,omitempty"`
+	Status         string        `json:"status"` // "ok" | "degraded"
+	NodeID         string        `json:"node_id,omitempty"`
+	Mode           string        `json:"mode,omitempty"` // "standalone" when no cluster
+	Role           string        `json:"role,omitempty"`
+	LeaderID       string        `json:"leader_id,omitempty"`
+	UptimeSeconds  float64       `json:"uptime_seconds"`
+	PlacementEpoch uint64        `json:"placement_epoch,omitempty"`
+	Shards         []shardStatus `json:"shards,omitempty"`
+}
+
+// shardStatus is the per-shard entry on /health. Sorted by ID so the
+// array is deterministic across scrapes — important for diffing health
+// JSON in incident reviews.
+type shardStatus struct {
+	ID                  int     `json:"id"`
+	Status              string  `json:"status"`           // "healthy" | "unhealthy"
+	Reason              string  `json:"reason,omitempty"` // populated when status != healthy
+	WALSequence         uint64  `json:"wal_sequence,omitempty"`
+	ReplicationLagSecs  float64 `json:"replication_lag_seconds,omitempty"`
+	ReplicationLagBytes int64   `json:"replication_lag_bytes,omitempty"`
 }
 
 // snapshotHealth gathers the current node's health into a structured form.
@@ -363,22 +375,66 @@ func (s *Server) snapshotHealth() healthSnapshot {
 	}
 
 	if len(s.shards) > 0 {
-		snap.Shards = make(map[string]string, len(s.shards))
+		snap.Shards = make([]shardStatus, 0, len(s.shards))
 		allHealthy := true
 		for _, sh := range s.shards {
-			if sh.IsHealthy() {
-				snap.Shards[strconv.Itoa(sh.ID)] = "healthy"
-			} else {
-				snap.Shards[strconv.Itoa(sh.ID)] = "unhealthy"
+			st := shardStatus{ID: sh.ID, Status: "healthy"}
+			if !sh.IsHealthy() {
+				st.Status = "unhealthy"
+				st.Reason = "shard_marked_unhealthy"
 				allHealthy = false
 			}
+			s.fillShardReplicationLag(&st)
+			snap.Shards = append(snap.Shards, st)
 		}
+		sort.Slice(snap.Shards, func(i, j int) bool {
+			return snap.Shards[i].ID < snap.Shards[j].ID
+		})
 		if !allHealthy {
 			snap.Status = "degraded"
 		}
 	}
 
 	return snap
+}
+
+// fillShardReplicationLag populates the WAL- and replica-derived fields
+// on a shardStatus entry. Quiet no-op when the node isn't running with
+// DR/replication enabled — keeps the JSON shape stable across single-node
+// and clustered deployments.
+func (s *Server) fillShardReplicationLag(st *shardStatus) {
+	if s.dr == nil || s.dr.WAL == nil {
+		return
+	}
+	st.WALSequence = s.dr.WAL.ShardSequence(st.ID)
+
+	if s.dr.ReplicaState == nil || s.cluster == nil {
+		return
+	}
+	sm := s.cluster.GetShardMap()
+	assignment, ok := sm.Assignments[st.ID]
+	if !ok {
+		return
+	}
+	headTS := s.dr.WAL.HeadTimestamp(st.ID)
+	var maxLagSecs float64
+	var maxLagBytes int64
+	for _, replica := range assignment.Replicas {
+		if replica == "" {
+			continue
+		}
+		pos := s.dr.ReplicaState.GetPosition(st.ID, replica)
+		applied := s.dr.ReplicaState.GetTimestamp(st.ID, replica)
+		secs := computeLagSeconds(headTS, applied, pos)
+		if secs > maxLagSecs {
+			maxLagSecs = secs
+		}
+		if b := s.dr.WAL.LagBytes(st.ID, pos); b > maxLagBytes {
+			maxLagBytes = b
+		}
+	}
+	st.ReplicationLagSecs = maxLagSecs
+	st.ReplicationLagBytes = maxLagBytes
 }
 
 // maxShardEpoch returns the highest per-shard placement epoch in the map,

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -126,16 +126,20 @@ func TestHealth_Standalone(t *testing.T) {
 	if resp["status"] != "ok" {
 		t.Errorf("expected status ok, got %v", resp["status"])
 	}
-	shards, ok := resp["shards"].(map[string]any)
+	shards, ok := resp["shards"].([]any)
 	if !ok {
-		t.Fatal("expected shards in health response")
+		t.Fatal("expected shards array in health response")
 	}
 	if len(shards) != 3 {
 		t.Errorf("expected 3 shards, got %d", len(shards))
 	}
-	for id, status := range shards {
-		if status != "healthy" {
-			t.Errorf("shard %s expected healthy, got %v", id, status)
+	for _, raw := range shards {
+		entry, ok := raw.(map[string]any)
+		if !ok {
+			t.Fatalf("expected shard entry to be object, got %T", raw)
+		}
+		if entry["status"] != "healthy" {
+			t.Errorf("shard %v expected healthy, got %v", entry["id"], entry["status"])
 		}
 	}
 }

--- a/pkg/api/health_endpoints_test.go
+++ b/pkg/api/health_endpoints_test.go
@@ -112,6 +112,64 @@ func TestHealth_StructuredFieldsPresent(t *testing.T) {
 	}
 }
 
+func TestHealth_ShardsArrayShape(t *testing.T) {
+	srv := setupTestServer() // 3 healthy shards
+	req := httptest.NewRequest("GET", "/health", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	shards, ok := resp["shards"].([]any)
+	if !ok {
+		t.Fatalf("expected shards to be an array, got %T", resp["shards"])
+	}
+	if len(shards) != 3 {
+		t.Fatalf("expected 3 shards, got %d", len(shards))
+	}
+	// Sorted by id ascending: 0, 1, 2.
+	for i, raw := range shards {
+		entry := raw.(map[string]any)
+		gotID := int(entry["id"].(float64))
+		if gotID != i {
+			t.Errorf("shards[%d].id = %d, want %d (must be sorted)", i, gotID, i)
+		}
+		if entry["status"] != "healthy" {
+			t.Errorf("shards[%d].status = %v, want healthy", i, entry["status"])
+		}
+	}
+}
+
+func TestHealth_ShardEntryIncludesReason_WhenUnhealthy(t *testing.T) {
+	shards := []*shard.Shard{
+		shard.NewShard(0, shard.NewMemoryStore(), 4),
+		shard.NewShard(1, &panicStore{}, 4),
+	}
+	shards[1].Query("MATCH (n) RETURN n") // mark unhealthy
+	r := router.NewRouter(shards, 5*time.Second)
+	srv := NewServer(r, nil, shards, nil, 5*time.Second)
+
+	req := httptest.NewRequest("GET", "/health", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	var resp map[string]any
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["status"] != "degraded" {
+		t.Errorf("expected status=degraded with one unhealthy shard, got %v", resp["status"])
+	}
+	arr := resp["shards"].([]any)
+	got := arr[1].(map[string]any)
+	if got["status"] != "unhealthy" {
+		t.Errorf("expected unhealthy on shard 1, got %v", got["status"])
+	}
+	if got["reason"] == "" || got["reason"] == nil {
+		t.Errorf("expected non-empty reason on unhealthy shard, got %v", got["reason"])
+	}
+}
+
 func TestHealth_UptimeIsNonNegative(t *testing.T) {
 	srv := setupTestServer()
 	// Sleep a tick so uptime is meaningfully > 0; we mostly want to


### PR DESCRIPTION
## Summary
- `/health` shards is now a sorted array of richer per-shard entries: `{id, status, reason?, wal_sequence?, replication_lag_seconds?, replication_lag_bytes?}`.
- WAL/replica fields populate only when DR is enabled — JSON shape stays stable across single-node and clustered deployments.
- Replication lag uses the worst case across that shard's replicas, mirroring the metrics emission.
- Sorted-by-id ordering makes health diffs deterministic across scrapes.

⚠️ Breaking change to `/health.shards` shape (was `map[string]string`, now `[]object`). No backwards-compat shim — internal endpoint, no documented external clients.

## Test plan
- [x] `go test ./...` (full suite green)
- [x] `golangci-lint run ./pkg/api/...` (0 issues)
- [x] Existing `/health` test updated for new array shape
- [x] New tests: array-shape with sorted IDs; reason field on unhealthy shard

Slice of #12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)