### PR TITLE
feat(metrics): loveliness_uptime_seconds gauge (#12)

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -20,6 +20,7 @@ explicitly here, not by collector defaults.
 
 | Metric | Type | Labels | Cardinality bound |
 |---|---|---|---|
+| `loveliness_uptime_seconds` | gauge | — | 1 |
 | `loveliness_local_shards` | gauge | — | 1 |
 | `loveliness_shard_healthy` | gauge | `shard_id` | ≤ 256 |
 | `loveliness_raft_state` | gauge | `node_id`, `state` | 1 × 5 = **5** |

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -70,6 +70,11 @@ type replicaLagPair struct {
 func writeMetrics(w io.Writer, s *Server) {
 	writeRuntimeMetrics(w)
 
+	emitHelp(w, "loveliness_uptime_seconds",
+		"Seconds since this server process started.", "gauge")
+	fprintf(w, "loveliness_uptime_seconds %s\n",
+		formatGaugeFloat(time.Since(s.startTime).Seconds()))
+
 	emitHelp(w, "loveliness_local_shards", "Number of shards opened on this node.", "gauge")
 	fprintf(w, "loveliness_local_shards %d\n", len(s.shards))
 

--- a/pkg/api/metrics_test.go
+++ b/pkg/api/metrics_test.go
@@ -199,6 +199,36 @@ func TestRaftState_AlwaysEmitsAllStates(t *testing.T) {
 	}
 }
 
+func TestUptimeMetric_NonNegativeAndPresent(t *testing.T) {
+	srv := setupTestServer()
+	// Sleep so uptime is meaningfully > 0; mostly we want to confirm
+	// the series exists and is non-negative.
+	time.Sleep(2 * time.Millisecond)
+
+	req := httptest.NewRequest("GET", "/metrics", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("metrics endpoint returned %d: %s", w.Code, w.Body.String())
+	}
+	body := w.Body.String()
+	mustContain := []string{
+		"# HELP loveliness_uptime_seconds",
+		"# TYPE loveliness_uptime_seconds gauge",
+		"loveliness_uptime_seconds ",
+	}
+	for _, s := range mustContain {
+		if !strings.Contains(body, s) {
+			t.Errorf("missing %q in /metrics body:\n%s", s, body)
+		}
+	}
+	// loveliness_uptime_seconds 0 is the broken case (means we read
+	// startTime as zero).
+	if strings.Contains(body, "loveliness_uptime_seconds 0\n") {
+		t.Errorf("uptime should be > 0 after sleep, got body:\n%s", body)
+	}
+}
+
 func TestShardHealthMetric_AllHealthy(t *testing.T) {
 	srv := setupTestServer()
 	var buf bytes.Buffer


### PR DESCRIPTION
## Summary
- Single zero-cardinality gauge derived from the existing `startTime` field on `Server`.
- Useful as a "process started here" overlay on Grafana dashboards and for restart-detection alerts (`rate(loveliness_uptime_seconds[5m]) < 0` ⇒ a restart happened in the window).
- Adds the new series to `docs/metrics.md`.

## Test plan
- [x] `go test ./...` (full suite green)
- [x] `golangci-lint run ./pkg/api/...` (0 issues)
- [x] Unit test asserts `# HELP` / `# TYPE` lines and that the value is > 0 after a brief sleep

Slice of #12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)