### PR TITLE
feat(api): true Arrow IPC stream output for /cypher (#27)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -60,10 +60,14 @@ material throughput win on result sets above ~10k rows.
 | Accept value | Response Content-Type | Format |
 |---|---|---|
 | `application/json` *(default)* | `application/json` | JSON |
-| `application/vnd.apache.arrow.stream` | `application/vnd.apache.arrow.stream` | Arrow IPC stream |
-| `application/vnd.apache.arrow.file` | `application/vnd.apache.arrow.file` | Arrow IPC file |
+| `application/vnd.apache.arrow.stream` | `application/vnd.apache.arrow.stream` | Arrow IPC stream (schema → batches → EOS) |
+| `application/vnd.apache.arrow.file` | `application/vnd.apache.arrow.file` | Arrow IPC file (random-access, `ARROW1` magic) |
 | `*/*` or `application/*` | `application/json` | JSON (fallback) |
 | anything else (concrete) | — | `406 Not Acceptable` |
+
+Stream and file are **not** byte-interchangeable. Use `pyarrow.ipc.open_stream` /
+`ipc.NewReader` / DuckDB-WASM `read_arrow` for the stream variant, and
+`pyarrow.ipc.open_file` / `ipc.NewFileReader` for the file variant.
 
 Quality values (`q=0.9`) are honored; ties broken by header order.
 

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -264,15 +264,14 @@ func (s *Server) handleCypher(w http.ResponseWriter, r *http.Request) {
 
 // writeNegotiated picks the response format based on the request's
 // Accept header. JSON stays the canonical default; clients can opt
-// into Arrow with `Accept: application/vnd.apache.arrow.file` (the
-// streaming variant is a follow-up). When the client explicitly
-// asks for an unsupported type we honor the contract and return
-// 406 instead of silently downgrading.
+// into Arrow IPC stream or file via the documented content types.
+// When the client explicitly asks for an unsupported type we honor
+// the contract and return 406 instead of silently downgrading.
 func writeNegotiated(w http.ResponseWriter, r *http.Request, result *router.Result) {
 	chosen, unacceptable := negotiateResponse(r.Header.Get("Accept"))
 	if unacceptable {
 		writeError(w, http.StatusNotAcceptable, "NOT_ACCEPTABLE",
-			"server can produce application/json or application/vnd.apache.arrow.file", 0)
+			"server can produce application/json, application/vnd.apache.arrow.stream, or application/vnd.apache.arrow.file", 0)
 		return
 	}
 	switch chosen {
@@ -286,12 +285,7 @@ func writeNegotiated(w http.ResponseWriter, r *http.Request, result *router.Resu
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write(buf)
 	case contentTypeArrowStream:
-		// Streaming Arrow is a follow-up slice; for now route stream
-		// requests to the buffered file writer so DuckDB-WASM and the
-		// other Arrow consumers still get a valid IPC payload. The
-		// content-type stays "stream" so clients that switched on it
-		// can read back without code changes once true streaming lands.
-		buf, err := encodeResultAsArrow(result)
+		buf, err := encodeResultAsArrowStream(result)
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "ARROW_ENCODE_ERROR", err.Error(), 0)
 			return

--- a/pkg/api/arrow.go
+++ b/pkg/api/arrow.go
@@ -94,15 +94,10 @@ func mergeKinds(a, b arrowColumnKind) arrowColumnKind {
 	return arrowKindJSON
 }
 
-// encodeResultAsArrow serializes a router.Result as an Arrow IPC
-// "file" payload (random-access, length-prefixed). This is the
-// buffered variant from the spec — streaming is a follow-up.
-//
-// Errors and Partial flags ride along as schema-level metadata so
-// clients can surface them without needing a separate channel.
-func encodeResultAsArrow(result *router.Result) ([]byte, error) {
-	mem := memory.NewGoAllocator()
-
+// buildArrowRecord turns the router.Result into a schema and a single
+// record batch, shared by the file and stream encoders. Caller owns
+// the returned record and must Release() it.
+func buildArrowRecord(result *router.Result, mem memory.Allocator) (*arrow.Schema, arrow.RecordBatch, error) {
 	cols := result.Columns
 	rows := result.Rows
 
@@ -129,12 +124,27 @@ func encodeResultAsArrow(result *router.Result) ([]byte, error) {
 	for _, row := range rows {
 		for i, c := range cols {
 			if err := appendCell(b.Field(i), kinds[i], row[c]); err != nil {
-				return nil, fmt.Errorf("column %q: %w", c, err)
+				return nil, nil, fmt.Errorf("column %q: %w", c, err)
 			}
 		}
 	}
 
-	rec := b.NewRecordBatch()
+	return schema, b.NewRecordBatch(), nil
+}
+
+// encodeResultAsArrow serializes a router.Result as an Arrow IPC
+// "file" payload (random-access, length-prefixed) — the buffered
+// variant. Use this for `application/vnd.apache.arrow.file`.
+//
+// Errors and Partial flags ride along as schema-level metadata so
+// clients can surface them without needing a separate channel.
+func encodeResultAsArrow(result *router.Result) ([]byte, error) {
+	mem := memory.NewGoAllocator()
+
+	schema, rec, err := buildArrowRecord(result, mem)
+	if err != nil {
+		return nil, err
+	}
 	defer rec.Release()
 
 	var buf bytes.Buffer
@@ -148,6 +158,32 @@ func encodeResultAsArrow(result *router.Result) ([]byte, error) {
 	}
 	if err := w.Close(); err != nil {
 		return nil, fmt.Errorf("arrow close: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
+// encodeResultAsArrowStream serializes a router.Result as an Arrow
+// IPC "stream" payload — schema message + record batches +
+// end-of-stream marker, no random-access footer. Use this for
+// `application/vnd.apache.arrow.stream`. Stream format is what
+// DuckDB-WASM's `read_arrow` and pyarrow's `open_stream` expect.
+func encodeResultAsArrowStream(result *router.Result) ([]byte, error) {
+	mem := memory.NewGoAllocator()
+
+	schema, rec, err := buildArrowRecord(result, mem)
+	if err != nil {
+		return nil, err
+	}
+	defer rec.Release()
+
+	var buf bytes.Buffer
+	w := ipc.NewWriter(&buf, ipc.WithSchema(schema), ipc.WithAllocator(mem))
+	if err := w.Write(rec); err != nil {
+		_ = w.Close()
+		return nil, fmt.Errorf("arrow stream write: %w", err)
+	}
+	if err := w.Close(); err != nil {
+		return nil, fmt.Errorf("arrow stream close: %w", err)
 	}
 	return buf.Bytes(), nil
 }

--- a/pkg/api/arrow_stream_test.go
+++ b/pkg/api/arrow_stream_test.go
@@ -1,0 +1,134 @@
+package api
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/ipc"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/johnjansen/loveliness/pkg/router"
+)
+
+// readArrowStream reads an Arrow IPC *stream* (not file) and flattens
+// every record batch into a row slice. It is the symmetric helper to
+// readArrowFile in arrow_test.go; the distinction matters because
+// stream and file formats are not interchangeable.
+func readArrowStream(t *testing.T, buf []byte) (*arrow.Schema, [][]any) {
+	t.Helper()
+	r, err := ipc.NewReader(bytes.NewReader(buf), ipc.WithAllocator(memory.NewGoAllocator()))
+	if err != nil {
+		t.Fatalf("read arrow stream: %v", err)
+	}
+	defer r.Release()
+
+	out := [][]any{}
+	for r.Next() {
+		rec := r.RecordBatch()
+		for row := int64(0); row < rec.NumRows(); row++ {
+			rowOut := make([]any, rec.NumCols())
+			for c := int64(0); c < rec.NumCols(); c++ {
+				col := rec.Column(int(c))
+				if col.IsNull(int(row)) {
+					rowOut[c] = nil
+					continue
+				}
+				rowOut[c] = col.GetOneForMarshal(int(row))
+			}
+			out = append(out, rowOut)
+		}
+	}
+	if err := r.Err(); err != nil {
+		t.Fatalf("stream reader err: %v", err)
+	}
+	return r.Schema(), out
+}
+
+func TestArrowStream_RoundTrip(t *testing.T) {
+	res := &router.Result{
+		Columns: []string{"name", "age", "score", "active"},
+		Rows: []map[string]any{
+			{"name": "Alice", "age": int64(30), "score": 1.5, "active": true},
+			{"name": "Bob", "age": int64(25), "score": 2.0, "active": false},
+		},
+	}
+	buf, err := encodeResultAsArrowStream(res)
+	if err != nil {
+		t.Fatalf("encode stream: %v", err)
+	}
+	if len(buf) == 0 {
+		t.Fatal("encoded buffer is empty")
+	}
+
+	schema, rows := readArrowStream(t, buf)
+	if schema.NumFields() != 4 {
+		t.Errorf("expected 4 fields, got %d", schema.NumFields())
+	}
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 rows, got %d", len(rows))
+	}
+	if rows[0][0] != "Alice" {
+		t.Errorf("row[0][name]=%v, want Alice", rows[0][0])
+	}
+}
+
+// The stream and file formats are NOT interchangeable. If the
+// dispatch ever regresses to writing the file format under the
+// stream content-type, this assertion will catch it: a file payload
+// always starts with the magic "ARROW1" header, a stream never
+// does.
+func TestArrowStream_NotFileFormat(t *testing.T) {
+	res := &router.Result{Columns: []string{"x"}, Rows: []map[string]any{{"x": int64(1)}}}
+	buf, err := encodeResultAsArrowStream(res)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	if bytes.HasPrefix(buf, []byte("ARROW1")) {
+		t.Fatal("stream encoder leaked the file-format magic header")
+	}
+	// Conversely, the file encoder MUST start with that magic — proves
+	// the two encoders produce genuinely different bytes.
+	fileBuf, err := encodeResultAsArrow(res)
+	if err != nil {
+		t.Fatalf("encode file: %v", err)
+	}
+	if !bytes.HasPrefix(fileBuf, []byte("ARROW1")) {
+		t.Fatal("file encoder did not produce the ARROW1 magic header")
+	}
+}
+
+func TestArrowStream_EmptyResultStillValid(t *testing.T) {
+	res := &router.Result{Columns: []string{"x"}, Rows: nil}
+	buf, err := encodeResultAsArrowStream(res)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	schema, rows := readArrowStream(t, buf)
+	if schema.NumFields() != 1 {
+		t.Errorf("expected 1 field, got %d", schema.NumFields())
+	}
+	if len(rows) != 0 {
+		t.Errorf("expected 0 rows, got %d", len(rows))
+	}
+}
+
+func TestArrowStream_MetadataPreserved(t *testing.T) {
+	res := &router.Result{
+		Columns: []string{"x"},
+		Rows:    []map[string]any{{"x": "ok"}},
+		Partial: true,
+		Errors:  []router.ShardError{{ShardID: 1, Error: "boom"}},
+	}
+	buf, err := encodeResultAsArrowStream(res)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	schema, _ := readArrowStream(t, buf)
+	md := schema.Metadata()
+	if got, ok := md.GetValue("loveliness.partial"); !ok || got != "true" {
+		t.Errorf("loveliness.partial metadata missing/wrong: %q (ok=%v)", got, ok)
+	}
+	if got, ok := md.GetValue("loveliness.errors"); !ok || got == "" {
+		t.Errorf("loveliness.errors metadata missing/empty: %q (ok=%v)", got, ok)
+	}
+}

--- a/pkg/api/cypher_arrow_test.go
+++ b/pkg/api/cypher_arrow_test.go
@@ -33,6 +33,35 @@ func TestCypher_AcceptArrowFile_ReturnsArrowBuffer(t *testing.T) {
 	r.Close()
 }
 
+func TestCypher_AcceptArrowStream_ReturnsStreamBuffer(t *testing.T) {
+	srv := setupTestServer()
+	req := httptest.NewRequest("POST", "/cypher",
+		bytes.NewBufferString("MATCH (p:Person) RETURN p"))
+	req.Header.Set("Accept", contentTypeArrowStream)
+	w := httptest.NewRecorder()
+
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if got := w.Header().Get("Content-Type"); got != contentTypeArrowStream {
+		t.Errorf("expected Content-Type %q, got %q", contentTypeArrowStream, got)
+	}
+	// Stream payload must NOT carry the "ARROW1" file-format magic;
+	// guards against the dispatch silently downgrading to the file
+	// encoder under the stream content type.
+	if bytes.HasPrefix(w.Body.Bytes(), []byte("ARROW1")) {
+		t.Fatal("stream Accept returned file-format payload (ARROW1 magic present)")
+	}
+	r, err := ipc.NewReader(bytes.NewReader(w.Body.Bytes()),
+		ipc.WithAllocator(memory.NewGoAllocator()))
+	if err != nil {
+		t.Fatalf("response is not a valid Arrow stream: %v", err)
+	}
+	r.Release()
+}
+
 func TestCypher_AcceptJSON_StaysJSON(t *testing.T) {
 	srv := setupTestServer()
 	req := httptest.NewRequest("POST", "/cypher",


### PR DESCRIPTION
## Summary

The `/cypher` endpoint negotiates `application/vnd.apache.arrow.stream` and `application/vnd.apache.arrow.file` as separate content types — but until now both were served by the same buffered **file** encoder. The stream content type was honest in its header and lying in its bytes, which means DuckDB-WASM's `read_arrow` and pyarrow's `open_stream` both reject the response. This wires up a true Arrow IPC stream encoder so the negotiation contract delivers what it advertises.

- `encodeResultAsArrowStream` uses `ipc.NewWriter` (the stream writer, not `NewFileWriter`)
- `buildArrowRecord` is the shared helper that produces `(schema, record)` for both encoders so type classification and `loveliness.partial` / `loveliness.errors` metadata stay consistent
- `writeNegotiated` routes `contentTypeArrowStream` → stream encoder, `contentTypeArrowFile` → file encoder
- Stream and file payloads are no longer byte-interchangeable, and tests pin that down

Drives one of the open ACs on #27 — true streaming format for the streaming Accept value. Subsequent slices: NODE/RELATIONSHIP struct types, list/map types, MCP negotiation, benchmarks, `docs/arrow-mapping.md`.

## Test plan

- [x] `go test ./...` — full suite green
- [x] `golangci-lint run ./...` — 0 issues
- [x] `TestArrowStream_RoundTrip` — stream payload parses via `ipc.NewReader`
- [x] `TestArrowStream_NotFileFormat` — stream bytes do **not** start with `ARROW1`; file bytes always do (catches future regressions where the dispatch silently falls back)
- [x] `TestCypher_AcceptArrowStream_ReturnsStreamBuffer` — HTTP-level test asserts the negotiated stream content type returns stream-formatted bytes
- [x] `TestArrowStream_MetadataPreserved` — `loveliness.partial` / `loveliness.errors` schema metadata round-trip
- [x] `TestArrowStream_EmptyResultStillValid` — empty result emits schema + zero batches + EOS
- [x] Existing file-format tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)