### PR TITLE
docs(arrow): formalize Cypher→Arrow type mapping (#27)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -57,6 +57,10 @@ skip the JSON encode/decode round-trip and stay zero-copy across the
 network and pandas / polars / DuckDB on the consumer side, which is a
 material throughput win on result sets above ~10k rows.
 
+The full Cypher→Arrow type mapping is documented in
+[`arrow-mapping.md`](arrow-mapping.md) — that doc is the contract for
+schema metadata, mid-stream error handling, and version negotiation.
+
 | Accept value | Response Content-Type | Format |
 |---|---|---|
 | `application/json` *(default)* | `application/json` | JSON |

--- a/docs/arrow-mapping.md
+++ b/docs/arrow-mapping.md
@@ -1,0 +1,136 @@
+# Cypher → Arrow type mapping
+
+This document is the contract between the `/cypher` server and any
+Arrow-aware client (DuckDB-WASM, pyarrow, polars, Cosmograph, MCP
+clients). It pins down how every Cypher value type lands in the Arrow
+schema so client code can declare exactly what it expects to read
+back.
+
+The mapping is the same for both IPC variants — `application/vnd.apache.arrow.stream`
+and `application/vnd.apache.arrow.file`. They differ only in the
+container, not in the schema.
+
+> Status — the **current encoder** implements scalar types and the
+> JSON-fallback row in the table below. NODE / RELATIONSHIP / LIST /
+> MAP / PATH are part of issue [#27](https://github.com/dreamware-nz/loveliness/issues/27)
+> and ship as separate slices; until they land, those values arrive
+> as JSON-encoded `utf8` so clients still receive a parseable result.
+> The "Status" column flags which rows are live today vs. landing
+> later — the schema contract itself does not change when those
+> slices ship; clients can rely on the documented Arrow type from
+> the moment they target a release that lists the row as live.
+
+## Scalar types
+
+| Cypher value | Arrow type | Status |
+|---|---|---|
+| `BOOLEAN` | `bool` | live |
+| `INTEGER` (any width) | `int64` | live |
+| `FLOAT` | `float64` | live |
+| `STRING` | `utf8` | live |
+| `NULL` | null bitmap on the column | live |
+| `BYTES` | `binary` | follow-up |
+| `DATE` | `date32` (days since epoch) | follow-up |
+| `LOCAL_TIME` | `time64[ns]` | follow-up |
+| `LOCAL_DATETIME` | `timestamp[ns]` (no tz) | follow-up |
+| `DATETIME` (zoned) | `timestamp[ns, UTC]` | follow-up |
+| `DURATION` | `struct{months: int32, days: int32, nanos: int64}` | follow-up |
+
+Numeric promotion within a single column: if a column produces a mix
+of integers and floats across rows, the column is encoded as
+`float64` for the entire batch. Boolean mixed with anything else
+falls into the JSON fallback row below — booleans are not silently
+coerced to 0/1.
+
+## Composite types
+
+| Cypher value | Arrow type | Status |
+|---|---|---|
+| `LIST<T>` | `list<T'>` where `T'` is `T`'s row above | follow-up |
+| `MAP<utf8, V>` | `map<utf8, V'>` (keys always `utf8`, sorted) | follow-up |
+| `NODE` | `struct{ id: int64, labels: list<dictionary<utf8>>, properties: map<utf8, utf8> }` | follow-up |
+| `RELATIONSHIP` | `struct{ id: int64, start_id: int64, end_id: int64, type: dictionary<utf8>, properties: map<utf8, utf8> }` | follow-up |
+| `PATH` | `struct{ nodes: list<NODE>, relationships: list<RELATIONSHIP>, length: int64 }` | follow-up |
+| any other / heterogeneous column | `utf8` (JSON-encoded value per cell) | live |
+
+`properties` lands as `map<utf8, utf8>` with property values
+JSON-encoded inside the string value slot. That keeps the schema flat
+and stable across rows that have different property sets — every node
+in a graph has its own property bag, and trying to express that as a
+strongly-typed struct would mean either schema-per-row (which Arrow
+forbids inside a single batch) or a sparse schema with one column
+per property name (which explodes on real graphs). The follow-up to
+strongly-type properties for a single label is tracked on #27 itself.
+
+## Heterogeneous columns
+
+When a single column produces values of multiple Cypher kinds across
+rows that are not numerically compatible (`INTEGER`+`FLOAT` is
+compatible, everything else is not), the encoder falls back to
+`utf8` and writes each cell as a JSON-encoded string. Schema
+metadata records the decision so clients can warn users that a
+column degraded:
+
+```
+loveliness.column.<name>.fallback = "json"
+```
+
+This rule is conservative — Arrow `union` types would express the
+mix more precisely but every downstream consumer (DuckDB-WASM,
+Cosmograph, polars on its current release) parses unions
+inconsistently or not at all. The fallback is also what JSON
+already does (a JSON column can hold mixed types), so the contract
+across the JSON and Arrow paths stays equivalent.
+
+## Schema metadata
+
+Every Arrow payload carries schema-level metadata that mirrors the
+JSON envelope's top-level fields:
+
+| Key | Value | Meaning |
+|---|---|---|
+| `loveliness.partial` | `"true"` / `"false"` | At least one shard returned an error; rows present are partial |
+| `loveliness.errors` | JSON array | Per-shard errors when `partial=true` |
+| `loveliness.column.<name>.fallback` | `"json"` | Column degraded to JSON-encoded `utf8` |
+
+Clients should **always** check `loveliness.partial` before treating
+the result as authoritative. The wire format does not surface
+partial-ness any other way (HTTP status stays 200 because the user
+got rows back).
+
+## Mid-stream errors
+
+The Arrow stream format flushes the schema message before the first
+record batch, so there is no way to return a 4xx/5xx HTTP status
+once a batch has been written. Errors discovered mid-stream are
+encoded as a final record batch with these schema-metadata flags:
+
+| Key | Value |
+|---|---|
+| `loveliness.error` | `"true"` |
+| `loveliness.error.code` | server error code (e.g. `SHARD_TIMEOUT`) |
+| `loveliness.error.message` | human-readable detail |
+
+Clients **must** check for `loveliness.error == "true"` after the
+last batch and surface the error to the user — silent truncation
+would otherwise look like an empty result. This trailer mechanism is
+documented here so clients across languages have one contract; it
+does not exist in the file format because file payloads are always
+fully buffered before the response headers are sent (a regular HTTP
+500 covers that path).
+
+## Versioning
+
+The mapping is versioned via the schema metadata key
+`loveliness.arrow_mapping_version` (string, currently `"1"`). Bumping
+this is reserved for a breaking change to a row above — adding a new
+row (e.g. when `DURATION` lands) keeps the version unchanged. Clients
+that need to be conservative can refuse to parse a payload whose
+version is higher than they were built against.
+
+## Reference
+
+- Arrow IPC format: <https://arrow.apache.org/docs/format/Columnar.html#format-ipc>
+- HTTP API content negotiation: [`docs/api.md`](api.md#apache-arrow-output)
+- Server encoder: `pkg/api/arrow.go`
+- Issue tracking remaining slices: [#27](https://github.com/dreamware-nz/loveliness/issues/27)

--- a/pkg/api/arrow.go
+++ b/pkg/api/arrow.go
@@ -188,8 +188,13 @@ func encodeResultAsArrowStream(result *router.Result) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
+// arrowMappingVersion is the version of the Cypher→Arrow type
+// mapping documented in docs/arrow-mapping.md. Bumped on a breaking
+// change to a documented row; new rows alone don't bump it.
+const arrowMappingVersion = "1"
+
 func schemaMetadataKeys(result *router.Result) []string {
-	keys := []string{"loveliness.partial"}
+	keys := []string{"loveliness.arrow_mapping_version", "loveliness.partial"}
 	if len(result.Errors) > 0 {
 		keys = append(keys, "loveliness.errors")
 	}
@@ -197,7 +202,7 @@ func schemaMetadataKeys(result *router.Result) []string {
 }
 
 func schemaMetadataValues(result *router.Result) []string {
-	values := []string{boolStr(result.Partial)}
+	values := []string{arrowMappingVersion, boolStr(result.Partial)}
 	if len(result.Errors) > 0 {
 		errsJSON, _ := json.Marshal(result.Errors)
 		values = append(values, string(errsJSON))

--- a/pkg/api/arrow_test.go
+++ b/pkg/api/arrow_test.go
@@ -147,6 +147,26 @@ func TestArrow_ComplexValueFallsBackToJSON(t *testing.T) {
 	}
 }
 
+func TestArrow_MappingVersionMetadataAlwaysPresent(t *testing.T) {
+	// Every Arrow payload must carry the mapping version so clients
+	// can refuse a payload that is newer than they were built for —
+	// the contract is documented in docs/arrow-mapping.md.
+	res := &router.Result{
+		Columns: []string{"x"},
+		Rows:    []map[string]any{{"x": "ok"}},
+	}
+	buf, err := encodeResultAsArrow(res)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	schema, _ := readArrowFile(t, buf)
+	got, ok := schema.Metadata().GetValue("loveliness.arrow_mapping_version")
+	if !ok || got != arrowMappingVersion {
+		t.Errorf("loveliness.arrow_mapping_version = %q (ok=%v), want %q",
+			got, ok, arrowMappingVersion)
+	}
+}
+
 func TestArrow_EmptyResultStillValid(t *testing.T) {
 	res := &router.Result{Columns: []string{"x"}, Rows: nil}
 	buf, err := encodeResultAsArrow(res)


### PR DESCRIPTION
## Summary

Pins down the Cypher→Arrow type mapping that the upcoming
NODE/RELATIONSHIP/LIST/MAP encoder slices implement against. Without
a published contract every client has to reverse-engineer schema
metadata from a running server, and we can't ship a breaking change
without breaking every consumer in lockstep.

`docs/arrow-mapping.md` covers:
- Scalar types (live: bool/int/float/string/null; follow-up: date/time/duration/bytes)
- Composite types (follow-up: list/map/node/rel/path; live: JSON-encoded `utf8` fallback covers all of them today)
- Heterogeneous-column rule (Arrow `union` exists but no downstream consumer parses it consistently — fall back to JSON, same shape as the JSON path)
- Schema metadata catalogue (`loveliness.partial`, `loveliness.errors`, `loveliness.column.<name>.fallback`)
- Mid-stream error trailer mechanism for the stream variant (set `loveliness.error=true` on the final batch's schema metadata)
- Versioning rule: bump `loveliness.arrow_mapping_version` only on a breaking change to a documented row, not on adding a new row

Encoder side:
- New constant `arrowMappingVersion = "1"` and metadata key `loveliness.arrow_mapping_version` written into every payload — clients can refuse a payload newer than they were built against
- Test pins the version metadata is always present

`api.md` gets a one-line link to the new doc so a reader who lands on the negotiation table can find the mapping without searching.

## Test plan

- [x] `go test ./pkg/api/ -run Arrow` — green (existing + new version-metadata test)
- [x] `golangci-lint run ./pkg/api/` — 0 issues
- [x] Doc renders cleanly (status column flags live vs follow-up rows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)