### PR TITLE
feat(api): NODE/RELATIONSHIP Arrow struct types (#27)

### DIFF
--- a/docs/arrow-mapping.md
+++ b/docs/arrow-mapping.md
@@ -48,19 +48,28 @@ coerced to 0/1.
 |---|---|---|
 | `LIST<T>` | `list<T'>` where `T'` is `T`'s row above | follow-up |
 | `MAP<utf8, V>` | `map<utf8, V'>` (keys always `utf8`, sorted) | follow-up |
-| `NODE` | `struct{ id: int64, labels: list<dictionary<utf8>>, properties: map<utf8, utf8> }` | follow-up |
-| `RELATIONSHIP` | `struct{ id: int64, start_id: int64, end_id: int64, type: dictionary<utf8>, properties: map<utf8, utf8> }` | follow-up |
+| `NODE` | `struct{ id: internal_id, labels: list<utf8>, properties: utf8 (JSON) }` | live |
+| `RELATIONSHIP` | `struct{ id: internal_id, start_id: internal_id, end_id: internal_id, label: utf8, properties: utf8 (JSON) }` | live |
 | `PATH` | `struct{ nodes: list<NODE>, relationships: list<RELATIONSHIP>, length: int64 }` | follow-up |
 | any other / heterogeneous column | `utf8` (JSON-encoded value per cell) | live |
 
-`properties` lands as `map<utf8, utf8>` with property values
-JSON-encoded inside the string value slot. That keeps the schema flat
-and stable across rows that have different property sets — every node
-in a graph has its own property bag, and trying to express that as a
-strongly-typed struct would mean either schema-per-row (which Arrow
-forbids inside a single batch) or a sparse schema with one column
-per property name (which explodes on real graphs). The follow-up to
-strongly-type properties for a single label is tracked on #27 itself.
+`internal_id` is the Arrow struct `struct{ table_id: int64, offset:
+int64 }`. It is a faithful representation of the LadybugDB 128-bit
+internal identifier, which would not fit in a single `int64` if a
+deployment ever allocated IDs near the upper end of the range. Two
+int64s round-trip every legal value losslessly today and stay in
+range for ID schemes other backends might adopt.
+
+`properties` lands as `utf8` with the property bag JSON-encoded into
+the string value. This keeps the schema flat and stable across rows
+that have different property sets — every node in a graph has its
+own property bag, and trying to express that as a strongly-typed
+struct would mean either schema-per-row (which Arrow forbids inside
+a single batch) or a sparse schema with one column per property name
+(which explodes on real graphs). A follow-up slice promotes
+`properties` to `map<utf8, utf8>` (keys utf8, values still
+JSON-encoded utf8 strings); the `loveliness.arrow_mapping_version`
+metadata key bumps when that lands so clients can detect the change.
 
 ## Heterogeneous columns
 

--- a/pkg/api/arrow.go
+++ b/pkg/api/arrow.go
@@ -13,10 +13,10 @@ import (
 )
 
 // arrowColumnKind classifies a column's effective Arrow type after
-// inspecting every row. Heterogeneous columns and complex types
-// (lists, maps, nodes) fall back to JSON-encoded utf8 — that keeps
-// the wire format honest while we ship the simple cases first;
-// proper struct/list types are a follow-up slice.
+// inspecting every row. NODE and RELATIONSHIP get strongly-typed
+// Arrow structs (see arrow_node.go); LIST / MAP currently fall
+// through to the JSON-encoded utf8 fallback while their dedicated
+// encoder slices land.
 type arrowColumnKind int
 
 const (
@@ -25,6 +25,8 @@ const (
 	arrowKindInt64
 	arrowKindFloat64
 	arrowKindString
+	arrowKindNode
+	arrowKindRelationship
 	arrowKindJSON
 )
 
@@ -38,6 +40,10 @@ func (k arrowColumnKind) arrowType() arrow.DataType {
 		return arrow.PrimitiveTypes.Float64
 	case arrowKindString, arrowKindJSON:
 		return arrow.BinaryTypes.String
+	case arrowKindNode:
+		return arrowNodeType
+	case arrowKindRelationship:
+		return arrowRelationshipType
 	default:
 		return arrow.Null
 	}
@@ -72,9 +78,14 @@ func kindOf(v any) arrowColumnKind {
 		return arrowKindFloat64
 	case string:
 		return arrowKindString
-	default:
-		return arrowKindJSON
 	}
+	if _, ok := extractNode(v); ok {
+		return arrowKindNode
+	}
+	if _, ok := extractRelationship(v); ok {
+		return arrowKindRelationship
+	}
+	return arrowKindJSON
 }
 
 func mergeKinds(a, b arrowColumnKind) arrowColumnKind {
@@ -253,6 +264,20 @@ func appendCell(b array.Builder, kind arrowColumnKind, v any) error {
 			return nil
 		}
 		b.(*array.StringBuilder).Append(s)
+	case arrowKindNode:
+		n, ok := extractNode(v)
+		if !ok {
+			b.AppendNull()
+			return nil
+		}
+		appendNode(b.(*array.StructBuilder), n)
+	case arrowKindRelationship:
+		r, ok := extractRelationship(v)
+		if !ok {
+			b.AppendNull()
+			return nil
+		}
+		appendRelationship(b.(*array.StructBuilder), r)
 	case arrowKindJSON:
 		// Heterogeneous / complex values: serialize each cell as JSON
 		// so clients can still read them. This is documented as the

--- a/pkg/api/arrow_node.go
+++ b/pkg/api/arrow_node.go
@@ -1,0 +1,227 @@
+package api
+
+import (
+	"encoding/json"
+	"reflect"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+)
+
+// Node and Relationship values flow through router.Result.Rows as the
+// concrete structs the underlying store binding produces — today
+// `lbug.Node` and `lbug.Relationship` from the LadybugDB Go binding,
+// tomorrow potentially others. We deliberately do not import the
+// binding here; instead, we duck-type by reflection on the structs'
+// exported field set. This keeps pkg/api decoupled from the CGo
+// binding for unit testing and future store backends.
+//
+// Node shape: ID (struct{TableID, Offset uint64}), Label string, Properties map[string]any
+// Rel shape:  ID + SourceID + DestinationID (same struct), Label string, Properties map[string]any
+
+// internalIDValue is the flattened ID we land in Arrow. Two int64s
+// faithfully represent the LadybugDB 128-bit identifier.
+type internalIDValue struct {
+	tableID int64
+	offset  int64
+}
+
+// nodeValue is the duck-typed projection of a node from any store.
+type nodeValue struct {
+	id        internalIDValue
+	labels    []string
+	propsJSON string
+}
+
+// relationshipValue is the duck-typed projection of a relationship.
+type relationshipValue struct {
+	id        internalIDValue
+	startID   internalIDValue
+	endID     internalIDValue
+	label     string
+	propsJSON string
+}
+
+// extractInternalID accepts anything that exposes uint TableID and
+// Offset fields (lbug.InternalID's shape) and returns the int64
+// pair. We accept both signed and unsigned underlying integer kinds
+// so the helper also works for fixtures that use int64.
+func extractInternalID(v any) (internalIDValue, bool) {
+	rv := reflect.ValueOf(v)
+	if rv.Kind() == reflect.Pointer {
+		rv = rv.Elem()
+	}
+	if rv.Kind() != reflect.Struct {
+		return internalIDValue{}, false
+	}
+	tID := rv.FieldByName("TableID")
+	off := rv.FieldByName("Offset")
+	if !tID.IsValid() || !off.IsValid() {
+		return internalIDValue{}, false
+	}
+	t, tOk := readIntField(tID)
+	o, oOk := readIntField(off)
+	if !tOk || !oOk {
+		return internalIDValue{}, false
+	}
+	return internalIDValue{tableID: t, offset: o}, true
+}
+
+func readIntField(v reflect.Value) (int64, bool) {
+	switch v.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return v.Int(), true
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		// Cast to int64. Kuzu IDs in practice never overflow int64;
+		// if a deployment ever produces uint64 > 2^63 we would silently
+		// alias — accepted because LadybugDB does not currently allocate
+		// IDs in that range and a wrap-around is the visible signal.
+		return int64(v.Uint()), true
+	}
+	return 0, false
+}
+
+// extractNode duck-types a value as a node. A struct with ID, Label,
+// and Properties matching the expected kinds qualifies — but not if
+// SourceID / DestinationID are also present, which marks it as a
+// Relationship instead.
+func extractNode(v any) (nodeValue, bool) {
+	rv := reflect.ValueOf(v)
+	if rv.Kind() == reflect.Pointer {
+		rv = rv.Elem()
+	}
+	if rv.Kind() != reflect.Struct {
+		return nodeValue{}, false
+	}
+	if rv.FieldByName("SourceID").IsValid() && rv.FieldByName("DestinationID").IsValid() {
+		return nodeValue{}, false
+	}
+	fID := rv.FieldByName("ID")
+	fLabel := rv.FieldByName("Label")
+	fProps := rv.FieldByName("Properties")
+	if !fID.IsValid() || !fLabel.IsValid() || !fProps.IsValid() {
+		return nodeValue{}, false
+	}
+	if fLabel.Kind() != reflect.String {
+		return nodeValue{}, false
+	}
+	id, ok := extractInternalID(fID.Interface())
+	if !ok {
+		return nodeValue{}, false
+	}
+	props, ok := fProps.Interface().(map[string]any)
+	if !ok {
+		return nodeValue{}, false
+	}
+	pj, err := json.Marshal(props)
+	if err != nil {
+		return nodeValue{}, false
+	}
+	var labels []string
+	if lab := fLabel.String(); lab != "" {
+		labels = []string{lab}
+	}
+	return nodeValue{id: id, labels: labels, propsJSON: string(pj)}, true
+}
+
+// extractRelationship duck-types a value as a relationship.
+func extractRelationship(v any) (relationshipValue, bool) {
+	rv := reflect.ValueOf(v)
+	if rv.Kind() == reflect.Pointer {
+		rv = rv.Elem()
+	}
+	if rv.Kind() != reflect.Struct {
+		return relationshipValue{}, false
+	}
+	fID := rv.FieldByName("ID")
+	fSrc := rv.FieldByName("SourceID")
+	fDst := rv.FieldByName("DestinationID")
+	fLabel := rv.FieldByName("Label")
+	fProps := rv.FieldByName("Properties")
+	if !fID.IsValid() || !fSrc.IsValid() || !fDst.IsValid() ||
+		!fLabel.IsValid() || !fProps.IsValid() {
+		return relationshipValue{}, false
+	}
+	if fLabel.Kind() != reflect.String {
+		return relationshipValue{}, false
+	}
+	id, idOk := extractInternalID(fID.Interface())
+	src, srcOk := extractInternalID(fSrc.Interface())
+	dst, dstOk := extractInternalID(fDst.Interface())
+	if !idOk || !srcOk || !dstOk {
+		return relationshipValue{}, false
+	}
+	props, ok := fProps.Interface().(map[string]any)
+	if !ok {
+		return relationshipValue{}, false
+	}
+	pj, err := json.Marshal(props)
+	if err != nil {
+		return relationshipValue{}, false
+	}
+	return relationshipValue{
+		id: id, startID: src, endID: dst,
+		label:     fLabel.String(),
+		propsJSON: string(pj),
+	}, true
+}
+
+// arrowInternalIDType is the struct type used wherever a Kuzu-style
+// 128-bit ID lands in Arrow. Two int64s faithfully represent the
+// (TableID, Offset) pair without lossy compression to a single int64.
+var arrowInternalIDType = arrow.StructOf(
+	arrow.Field{Name: "table_id", Type: arrow.PrimitiveTypes.Int64},
+	arrow.Field{Name: "offset", Type: arrow.PrimitiveTypes.Int64},
+)
+
+var arrowNodeType = arrow.StructOf(
+	arrow.Field{Name: "id", Type: arrowInternalIDType},
+	arrow.Field{Name: "labels", Type: arrow.ListOf(arrow.BinaryTypes.String)},
+	// properties is JSON-encoded utf8 for v1 of the mapping. A
+	// follow-up slice promotes this to map<utf8, utf8>; clients can
+	// detect the upgrade by checking loveliness.arrow_mapping_version.
+	arrow.Field{Name: "properties", Type: arrow.BinaryTypes.String},
+)
+
+var arrowRelationshipType = arrow.StructOf(
+	arrow.Field{Name: "id", Type: arrowInternalIDType},
+	arrow.Field{Name: "start_id", Type: arrowInternalIDType},
+	arrow.Field{Name: "end_id", Type: arrowInternalIDType},
+	arrow.Field{Name: "label", Type: arrow.BinaryTypes.String},
+	arrow.Field{Name: "properties", Type: arrow.BinaryTypes.String},
+)
+
+// appendInternalID writes one (table_id, offset) pair into the given
+// StructBuilder. The caller must have already called Append(true)
+// on the parent (or this builder, when used at the top level).
+func appendInternalID(b *array.StructBuilder, id internalIDValue) {
+	b.Append(true)
+	b.FieldBuilder(0).(*array.Int64Builder).Append(id.tableID)
+	b.FieldBuilder(1).(*array.Int64Builder).Append(id.offset)
+}
+
+// appendNode writes one node into the StructBuilder for arrowNodeType.
+func appendNode(b *array.StructBuilder, n nodeValue) {
+	b.Append(true)
+	appendInternalID(b.FieldBuilder(0).(*array.StructBuilder), n.id)
+
+	labelsB := b.FieldBuilder(1).(*array.ListBuilder)
+	labelsB.Append(true)
+	valB := labelsB.ValueBuilder().(*array.StringBuilder)
+	for _, lab := range n.labels {
+		valB.Append(lab)
+	}
+
+	b.FieldBuilder(2).(*array.StringBuilder).Append(n.propsJSON)
+}
+
+// appendRelationship writes one relationship into the StructBuilder
+// for arrowRelationshipType.
+func appendRelationship(b *array.StructBuilder, r relationshipValue) {
+	b.Append(true)
+	appendInternalID(b.FieldBuilder(0).(*array.StructBuilder), r.id)
+	appendInternalID(b.FieldBuilder(1).(*array.StructBuilder), r.startID)
+	appendInternalID(b.FieldBuilder(2).(*array.StructBuilder), r.endID)
+	b.FieldBuilder(3).(*array.StringBuilder).Append(r.label)
+	b.FieldBuilder(4).(*array.StringBuilder).Append(r.propsJSON)
+}

--- a/pkg/api/arrow_node_test.go
+++ b/pkg/api/arrow_node_test.go
@@ -1,0 +1,274 @@
+package api
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/ipc"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/johnjansen/loveliness/pkg/router"
+)
+
+// fakeInternalID matches lbug.InternalID's exported field set so the
+// reflection-based extractor sees both shapes equivalently. We keep
+// this as a local fixture rather than importing the lbug binding so
+// the encoder stays decoupled from any specific store backend.
+type fakeInternalID struct {
+	TableID uint64
+	Offset  uint64
+}
+
+type fakeNode struct {
+	ID         fakeInternalID
+	Label      string
+	Properties map[string]any
+}
+
+type fakeRelationship struct {
+	ID            fakeInternalID
+	SourceID      fakeInternalID
+	DestinationID fakeInternalID
+	Label         string
+	Properties    map[string]any
+}
+
+func TestExtractNode_PicksUpFakeShape(t *testing.T) {
+	v := fakeNode{
+		ID:         fakeInternalID{TableID: 1, Offset: 42},
+		Label:      "Person",
+		Properties: map[string]any{"name": "Alice"},
+	}
+	got, ok := extractNode(v)
+	if !ok {
+		t.Fatal("expected node shape to be detected")
+	}
+	if got.id.tableID != 1 || got.id.offset != 42 {
+		t.Errorf("id = %+v, want {1, 42}", got.id)
+	}
+	if len(got.labels) != 1 || got.labels[0] != "Person" {
+		t.Errorf("labels = %v, want [Person]", got.labels)
+	}
+	if got.propsJSON == "" {
+		t.Errorf("propsJSON is empty")
+	}
+}
+
+func TestExtractNode_RejectsRelationshipShape(t *testing.T) {
+	rel := fakeRelationship{
+		ID:            fakeInternalID{TableID: 1, Offset: 1},
+		SourceID:      fakeInternalID{TableID: 1, Offset: 1},
+		DestinationID: fakeInternalID{TableID: 1, Offset: 2},
+		Label:         "KNOWS",
+		Properties:    map[string]any{},
+	}
+	if _, ok := extractNode(rel); ok {
+		t.Error("relationship struct must not be detected as a node")
+	}
+}
+
+func TestExtractRelationship_PicksUpFakeShape(t *testing.T) {
+	v := fakeRelationship{
+		ID:            fakeInternalID{TableID: 2, Offset: 7},
+		SourceID:      fakeInternalID{TableID: 1, Offset: 1},
+		DestinationID: fakeInternalID{TableID: 1, Offset: 2},
+		Label:         "KNOWS",
+		Properties:    map[string]any{"since": int64(2020)},
+	}
+	got, ok := extractRelationship(v)
+	if !ok {
+		t.Fatal("expected relationship shape to be detected")
+	}
+	if got.label != "KNOWS" {
+		t.Errorf("label = %q, want KNOWS", got.label)
+	}
+	if got.startID.offset != 1 || got.endID.offset != 2 {
+		t.Errorf("start/end ids = %+v / %+v", got.startID, got.endID)
+	}
+}
+
+func TestArrow_NodeColumnHasStructSchema(t *testing.T) {
+	res := &router.Result{
+		Columns: []string{"p"},
+		Rows: []map[string]any{
+			{"p": fakeNode{
+				ID:         fakeInternalID{TableID: 1, Offset: 10},
+				Label:      "Person",
+				Properties: map[string]any{"name": "Alice", "age": int64(30)},
+			}},
+			{"p": fakeNode{
+				ID:         fakeInternalID{TableID: 1, Offset: 11},
+				Label:      "Person",
+				Properties: map[string]any{"name": "Bob"},
+			}},
+		},
+	}
+	buf, err := encodeResultAsArrow(res)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	r, err := ipc.NewFileReader(bytes.NewReader(buf), ipc.WithAllocator(memory.NewGoAllocator()))
+	if err != nil {
+		t.Fatalf("read arrow: %v", err)
+	}
+	defer r.Close()
+
+	if r.Schema().NumFields() != 1 {
+		t.Fatalf("want 1 field, got %d", r.Schema().NumFields())
+	}
+	got := r.Schema().Field(0).Type
+	if got.ID() != arrow.STRUCT {
+		t.Fatalf("p must be STRUCT, got %v", got)
+	}
+	st := got.(*arrow.StructType)
+	if st.NumFields() != 3 {
+		t.Errorf("node struct must have 3 fields (id, labels, properties), got %d", st.NumFields())
+	}
+	if st.Field(0).Name != "id" || st.Field(0).Type.ID() != arrow.STRUCT {
+		t.Errorf("field[0] = %v %v, want id STRUCT", st.Field(0).Name, st.Field(0).Type)
+	}
+	if st.Field(1).Name != "labels" || st.Field(1).Type.ID() != arrow.LIST {
+		t.Errorf("field[1] = %v %v, want labels LIST", st.Field(1).Name, st.Field(1).Type)
+	}
+	if st.Field(2).Name != "properties" || st.Field(2).Type.ID() != arrow.STRING {
+		t.Errorf("field[2] = %v %v, want properties STRING", st.Field(2).Name, st.Field(2).Type)
+	}
+}
+
+func TestArrow_NodeColumnRoundTripsValues(t *testing.T) {
+	res := &router.Result{
+		Columns: []string{"p"},
+		Rows: []map[string]any{
+			{"p": fakeNode{
+				ID:         fakeInternalID{TableID: 1, Offset: 10},
+				Label:      "Person",
+				Properties: map[string]any{"name": "Alice"},
+			}},
+		},
+	}
+	buf, err := encodeResultAsArrow(res)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	r, err := ipc.NewFileReader(bytes.NewReader(buf), ipc.WithAllocator(memory.NewGoAllocator()))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	defer r.Close()
+	rec, err := r.RecordBatch(0)
+	if err != nil {
+		t.Fatalf("record: %v", err)
+	}
+	if rec.NumRows() != 1 {
+		t.Fatalf("expected 1 row, got %d", rec.NumRows())
+	}
+	// Inspect via the typed array APIs — GetOneForMarshal returns
+	// pre-marshaled JSON tokens for nested types, which is the
+	// shape consumers see but a pain to assert on. Reach through
+	// the StructArray's children instead.
+	st := rec.Column(0).(*array.Struct)
+	idCol := st.Field(0).(*array.Struct)
+	tableID := idCol.Field(0).(*array.Int64).Value(0)
+	offset := idCol.Field(1).(*array.Int64).Value(0)
+	if tableID != 1 || offset != 10 {
+		t.Errorf("id = (%d, %d), want (1, 10)", tableID, offset)
+	}
+
+	labelsCol := st.Field(1).(*array.List)
+	labelValues := labelsCol.ListValues().(*array.String)
+	start, end := labelsCol.ValueOffsets(0)
+	if end-start != 1 {
+		t.Errorf("labels list length = %d, want 1", end-start)
+	}
+	if got := labelValues.Value(int(start)); got != "Person" {
+		t.Errorf("label = %q, want Person", got)
+	}
+
+	propsCol := st.Field(2).(*array.String)
+	props := propsCol.Value(0)
+	if props == "" {
+		t.Errorf("properties JSON is empty")
+	}
+	if want := `"name":"Alice"`; !bytes.Contains([]byte(props), []byte(want)) {
+		t.Errorf("properties JSON %q does not contain %q", props, want)
+	}
+}
+
+func TestArrow_RelationshipColumnHasStructSchema(t *testing.T) {
+	res := &router.Result{
+		Columns: []string{"r"},
+		Rows: []map[string]any{
+			{"r": fakeRelationship{
+				ID:            fakeInternalID{TableID: 2, Offset: 7},
+				SourceID:      fakeInternalID{TableID: 1, Offset: 1},
+				DestinationID: fakeInternalID{TableID: 1, Offset: 2},
+				Label:         "KNOWS",
+				Properties:    map[string]any{"since": int64(2020)},
+			}},
+		},
+	}
+	buf, err := encodeResultAsArrow(res)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	r, err := ipc.NewFileReader(bytes.NewReader(buf), ipc.WithAllocator(memory.NewGoAllocator()))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	defer r.Close()
+
+	got := r.Schema().Field(0).Type
+	if got.ID() != arrow.STRUCT {
+		t.Fatalf("r must be STRUCT, got %v", got)
+	}
+	st := got.(*arrow.StructType)
+	wantFields := []struct {
+		name string
+		id   arrow.Type
+	}{
+		{"id", arrow.STRUCT},
+		{"start_id", arrow.STRUCT},
+		{"end_id", arrow.STRUCT},
+		{"label", arrow.STRING},
+		{"properties", arrow.STRING},
+	}
+	if st.NumFields() != len(wantFields) {
+		t.Fatalf("relationship struct fields = %d, want %d", st.NumFields(), len(wantFields))
+	}
+	for i, want := range wantFields {
+		if st.Field(i).Name != want.name || st.Field(i).Type.ID() != want.id {
+			t.Errorf("field[%d] = %s %v, want %s %v",
+				i, st.Field(i).Name, st.Field(i).Type, want.name, want.id)
+		}
+	}
+}
+
+// Mixing a node value with a scalar in the same column is still the
+// JSON fallback — proves the heterogeneous-column rule still kicks
+// in even with the new strongly-typed kinds.
+func TestArrow_HeterogeneousNodeAndScalarFallsBackToJSON(t *testing.T) {
+	res := &router.Result{
+		Columns: []string{"x"},
+		Rows: []map[string]any{
+			{"x": fakeNode{
+				ID:         fakeInternalID{TableID: 1, Offset: 1},
+				Label:      "Person",
+				Properties: map[string]any{},
+			}},
+			{"x": "scalar string"},
+		},
+	}
+	buf, err := encodeResultAsArrow(res)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	r, err := ipc.NewFileReader(bytes.NewReader(buf), ipc.WithAllocator(memory.NewGoAllocator()))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	defer r.Close()
+	if got := r.Schema().Field(0).Type.ID(); got != arrow.STRING {
+		t.Errorf("heterogeneous column must fall back to STRING (JSON), got %v", got)
+	}
+}


### PR DESCRIPTION
## Summary

NODE and RELATIONSHIP values from `/cypher` now land as strongly-typed Arrow structs rather than JSON-encoded utf8 strings — moving two more rows on [docs/arrow-mapping.md](../blob/main/docs/arrow-mapping.md) from \"follow-up\" to \"live\".

```
NODE
  struct{
    id:         struct{ table_id: int64, offset: int64 },
    labels:     list<utf8>,
    properties: utf8 (JSON-encoded),
  }

RELATIONSHIP
  struct{
    id:         struct{ table_id: int64, offset: int64 },
    start_id:   struct{ table_id: int64, offset: int64 },
    end_id:     struct{ table_id: int64, offset: int64 },
    label:      utf8,
    properties: utf8 (JSON-encoded),
  }
```

### Design notes

- **ID is two int64s, not one.** LadybugDB's `InternalID` is 128-bit; a single int64 would either truncate or alias. The struct representation is faithful and stays in range for whatever ID scheme other backends might adopt. Doc updated to match.
- **`pkg/api` never imports the `lbug` binding directly.** Detection is reflection-based on the exported field set (ID/Label/Properties for nodes; +SourceID/DestinationID for relationships). That decouples the encoder from the CGo backend so unit tests construct fixtures without a live database.
- **`properties` is utf8 (JSON-encoded) for v1.** A follow-up slice promotes it to `map<utf8, utf8>`; clients can detect the bump via `loveliness.arrow_mapping_version`. Mapping doc updated.
- **Heterogeneous columns** (NODE + scalar in the same column across rows) still degrade to JSON utf8 — pinned by a regression test.
- **Contract version stays at \"1\"** — no consumers exist yet, so loosening the published shape before adoption is fair game.

## Test plan

- [x] `go test ./...` — full suite green
- [x] `golangci-lint run ./...` — 0 issues
- [x] `TestExtractNode_PicksUpFakeShape` / `TestExtractRelationship_PicksUpFakeShape` — duck-typed detection works on a non-lbug fixture
- [x] `TestExtractNode_RejectsRelationshipShape` — relationships are not misclassified as nodes
- [x] `TestArrow_NodeColumnHasStructSchema` / `TestArrow_RelationshipColumnHasStructSchema` — schema shape pinned
- [x] `TestArrow_NodeColumnRoundTripsValues` — id, labels, and properties round-trip through the Arrow file format
- [x] `TestArrow_HeterogeneousNodeAndScalarFallsBackToJSON` — mixed-kind column still degrades to JSON utf8

🤖 Generated with [Claude Code](https://claude.com/claude-code)