### PR TITLE
feat(mcp): Arrow IPC stream negotiation for cypher tools (#27)

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -141,11 +141,52 @@ first non-comment keyword is `CREATE`, `MERGE`, `SET`, `DELETE`, `DROP`,
 
 Returns `{columns, rows, stats}`.
 
+#### Arrow output (`format: "arrow"`)
+
+Add `"format": "arrow"` to receive the result as an Apache Arrow IPC
+stream attached to the tool result as an embedded resource (MIME type
+`application/vnd.apache.arrow.stream`):
+
+```jsonc
+{
+  "query":  "MATCH (p:Person) RETURN p LIMIT 25000",
+  "format": "arrow"
+}
+```
+
+Tool result shape (abridged):
+
+```jsonc
+{
+  "content": [
+    { "type": "text", "text": "Arrow IPC stream attached (524288 bytes). MIME type application/vnd.apache.arrow.stream." },
+    { "type": "resource", "resource": {
+        "uri":      "loveliness:cypher-result.arrows",
+        "mimeType": "application/vnd.apache.arrow.stream",
+        "blob":     "<base64-encoded IPC stream>"
+    }}
+  ]
+}
+```
+
+Use this from MCP clients that can ingest Arrow directly
+(DuckDB-WASM `read_arrow`, pyarrow `ipc.open_stream`, polars
+`read_ipc_stream`, …) — it skips the JSON marshal/unmarshal
+round-trip and lands in the consumer's columnar memory layout
+without an intermediate parse step. The schema follows the
+[Cypher → Arrow type mapping](arrow-mapping.md). The default
+(`format` omitted or `"json"`) keeps the existing
+`{columns, rows, stats}` structured-content path that LLMs read
+directly.
+
 ### `cypher_write`
 
-Same input shape as `cypher_read`, no keyword gate. Registered only
-when `--readonly=false`. Clients that want per-tool gating (Claude
-Code's `/permissions`) can opt-in this tool specifically.
+Same input shape as `cypher_read`, including the `format` field, no
+keyword gate. Registered only when `--readonly=false`. Clients that
+want per-tool gating (Claude Code's `/permissions`) can opt-in this
+tool specifically. The Arrow path on `cypher_write` is mostly useful
+for write-then-`RETURN` queries where the returned rows feed an
+analytics consumer.
 
 ### `create_node_table` / `create_edge_table` / `drop_table`
 

--- a/pkg/mcp/client.go
+++ b/pkg/mcp/client.go
@@ -74,6 +74,35 @@ func (c *Client) Cypher(ctx context.Context, query string, params map[string]any
 	return &out, nil
 }
 
+// ArrowStreamMIME is the MIME type of an Arrow IPC stream payload.
+// Mirrors api.contentTypeArrowStream — duplicated here to avoid an
+// import cycle between pkg/mcp and pkg/api.
+const ArrowStreamMIME = "application/vnd.apache.arrow.stream"
+
+// CypherArrow executes the same Cypher statement as Cypher but
+// negotiates an Apache Arrow IPC stream response from /cypher. The
+// returned bytes are a complete IPC stream (schema + record batches +
+// EOS) — feed them to pyarrow.ipc.open_stream, DuckDB-WASM
+// `read_arrow`, polars.read_ipc_stream, or any other Arrow-aware
+// reader without a JSON decode step.
+//
+// Use this from MCP tooling when the consumer is itself
+// analytics-aware (e.g. a DuckDB-WASM cosmograph spike) so the tool
+// result skips the JSON marshal/unmarshal round-trip.
+func (c *Client) CypherArrow(ctx context.Context, query string, params map[string]any) ([]byte, error) {
+	expanded, err := inlineParams(query, params)
+	if err != nil {
+		return nil, err
+	}
+	body, err := c.post(ctx, "/cypher", "text/plain", strings.NewReader(expanded), map[string]string{
+		"Accept": ArrowStreamMIME,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return body, nil
+}
+
 // ClusterStatus is the shape returned by GET /cluster.
 type ClusterStatus struct {
 	Leader       string         `json:"leader"`

--- a/pkg/mcp/tools_cypher.go
+++ b/pkg/mcp/tools_cypher.go
@@ -12,14 +12,27 @@ import (
 type CypherInput struct {
 	Query  string         `json:"query" jsonschema:"Cypher statement to execute."`
 	Params map[string]any `json:"params,omitempty" jsonschema:"Optional parameter bindings (referenced as $name in the query)."`
+	// Format selects the response wire format. "json" (default) returns
+	// rows as structured output for the LLM to read directly. "arrow"
+	// returns an Apache Arrow IPC stream as an embedded resource on
+	// the tool result, paired with a brief text summary — use this
+	// when the downstream consumer (DuckDB-WASM, pyarrow, polars) can
+	// ingest Arrow bytes without a JSON parse step.
+	Format string `json:"format,omitempty" jsonschema:"Result format: 'json' (default) or 'arrow' (IPC stream attached as embedded resource)."`
 }
 
-// CypherOutput is the structured output.
+// CypherOutput is the structured output for the JSON path.
 type CypherOutput struct {
 	Columns []string         `json:"columns"`
 	Rows    []map[string]any `json:"rows"`
 	Stats   map[string]any   `json:"stats,omitempty"`
 }
+
+// arrowResourceURI is the URI we attach to embedded Arrow result
+// blobs. It is informational — clients identify the payload by MIME
+// type, not URI — but a stable scheme makes it easier to spot in
+// logs and traces.
+const arrowResourceURI = "loveliness:cypher-result.arrows"
 
 // writeKeywords are statements rejected by cypher_read.
 //
@@ -163,7 +176,7 @@ func registerCypherTools(s *mcp.Server, c *Client, readonly bool) {
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "cypher_read",
 		Title:       "Run a read-only Cypher query",
-		Description: "Execute a Cypher read query (MATCH/RETURN/CALL/...). Rejects write keywords (CREATE, MERGE, SET, DELETE, DROP, REMOVE, LOAD, COPY, ALTER, DETACH). Use $name placeholders with params for safe substitution.",
+		Description: "Execute a Cypher read query (MATCH/RETURN/CALL/...). Rejects write keywords (CREATE, MERGE, SET, DELETE, DROP, REMOVE, LOAD, COPY, ALTER, DETACH). Use $name placeholders with params for safe substitution. Set format='arrow' to receive an Apache Arrow IPC stream as an embedded resource (skip JSON parsing for analytics consumers).",
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, in CypherInput) (*mcp.CallToolResult, CypherOutput, error) {
 		if strings.TrimSpace(in.Query) == "" {
 			return toolError(fmt.Errorf("query is required")), CypherOutput{}, nil
@@ -171,11 +184,7 @@ func registerCypherTools(s *mcp.Server, c *Client, readonly bool) {
 		if isWrite(in.Query) {
 			return toolError(fmt.Errorf("cypher_read rejects write statements; use cypher_write for %s", firstKeyword(in.Query))), CypherOutput{}, nil
 		}
-		res, err := c.Cypher(ctx, in.Query, in.Params)
-		if err != nil {
-			return toolError(err), CypherOutput{}, nil
-		}
-		return nil, CypherOutput{Columns: res.Columns, Rows: res.Rows, Stats: res.Stats}, nil
+		return runCypher(ctx, c, in)
 	})
 
 	if readonly {
@@ -185,15 +194,57 @@ func registerCypherTools(s *mcp.Server, c *Client, readonly bool) {
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "cypher_write",
 		Title:       "Run a Cypher write query",
-		Description: "Execute a Cypher write statement (CREATE/MERGE/SET/DELETE/etc) or DDL. Not registered when --readonly is set.",
+		Description: "Execute a Cypher write statement (CREATE/MERGE/SET/DELETE/etc) or DDL. Not registered when --readonly is set. Set format='arrow' to receive an Apache Arrow IPC stream as an embedded resource (mostly useful for write-then-RETURN queries).",
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, in CypherInput) (*mcp.CallToolResult, CypherOutput, error) {
 		if strings.TrimSpace(in.Query) == "" {
 			return toolError(fmt.Errorf("query is required")), CypherOutput{}, nil
 		}
+		return runCypher(ctx, c, in)
+	})
+}
+
+// runCypher dispatches a Cypher request to the right code path based
+// on the requested response format. JSON is the default (LLM-friendly
+// structured output); Arrow attaches an IPC stream blob to the tool
+// result so analytics consumers can skip a JSON parse round-trip.
+func runCypher(ctx context.Context, c *Client, in CypherInput) (*mcp.CallToolResult, CypherOutput, error) {
+	switch strings.ToLower(strings.TrimSpace(in.Format)) {
+	case "", "json":
 		res, err := c.Cypher(ctx, in.Query, in.Params)
 		if err != nil {
 			return toolError(err), CypherOutput{}, nil
 		}
 		return nil, CypherOutput{Columns: res.Columns, Rows: res.Rows, Stats: res.Stats}, nil
-	})
+	case "arrow":
+		buf, err := c.CypherArrow(ctx, in.Query, in.Params)
+		if err != nil {
+			return toolError(err), CypherOutput{}, nil
+		}
+		return arrowResult(buf), CypherOutput{}, nil
+	default:
+		return toolError(fmt.Errorf("format must be 'json' or 'arrow', got %q", in.Format)), CypherOutput{}, nil
+	}
+}
+
+// arrowResult builds a CallToolResult that pairs a brief text
+// summary (for the LLM / human reader) with an embedded Arrow IPC
+// resource carrying the actual bytes. The text summary intentionally
+// stays terse — the whole point of the Arrow path is that the LLM
+// shouldn't need to read the full result; an analytics-aware client
+// reads the embedded resource instead.
+func arrowResult(buf []byte) *mcp.CallToolResult {
+	size := int64(len(buf))
+	summary := fmt.Sprintf("Arrow IPC stream attached (%d bytes). MIME type %s.", size, ArrowStreamMIME)
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{
+			&mcp.TextContent{Text: summary},
+			&mcp.EmbeddedResource{
+				Resource: &mcp.ResourceContents{
+					URI:      arrowResourceURI,
+					MIMEType: ArrowStreamMIME,
+					Blob:     buf,
+				},
+			},
+		},
+	}
 }

--- a/pkg/mcp/tools_cypher_arrow_test.go
+++ b/pkg/mcp/tools_cypher_arrow_test.go
@@ -1,0 +1,225 @@
+package mcp
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/ipc"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// fakeArrowCypherServer answers /cypher with either a JSON envelope
+// or an Arrow IPC stream depending on the Accept header — the same
+// content negotiation contract pkg/api enforces. The MCP integration
+// can be unit-tested against this without standing up a real
+// cluster.
+func fakeArrowCypherServer(t *testing.T) (*httptest.Server, []byte) {
+	t.Helper()
+	mem := memory.NewGoAllocator()
+	schema := arrow.NewSchema([]arrow.Field{
+		{Name: "n", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+	}, nil)
+	rb := array.NewRecordBuilder(mem, schema)
+	rb.Field(0).(*array.Int64Builder).AppendValues([]int64{1, 2, 3}, nil)
+	rec := rb.NewRecordBatch()
+	rb.Release()
+	defer rec.Release()
+
+	var arrowBuf bytes.Buffer
+	w := ipc.NewWriter(&arrowBuf, ipc.WithSchema(schema), ipc.WithAllocator(mem))
+	if err := w.Write(rec); err != nil {
+		t.Fatalf("write arrow: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close arrow: %v", err)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Header.Get("Accept") {
+		case ArrowStreamMIME:
+			w.Header().Set("Content-Type", ArrowStreamMIME)
+			_, _ = w.Write(arrowBuf.Bytes())
+		default:
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"columns":["n"],"rows":[{"n":1},{"n":2},{"n":3}],"stats":{"ms":1}}`))
+		}
+	}))
+	return srv, arrowBuf.Bytes()
+}
+
+func TestClientCypherArrow_AcceptHeaderAndBytes(t *testing.T) {
+	srv, want := fakeArrowCypherServer(t)
+	t.Cleanup(srv.Close)
+
+	c := NewClient(srv.URL, "", 2*time.Second)
+	got, err := c.CypherArrow(context.Background(), "MATCH (n) RETURN n", nil)
+	if err != nil {
+		t.Fatalf("CypherArrow: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("arrow bytes mismatch: got %d bytes, want %d", len(got), len(want))
+	}
+	// Verify the bytes are a parseable IPC stream — a cheap check that
+	// guards against the response-body machinery quietly mangling
+	// binary data.
+	r, err := ipc.NewReader(bytes.NewReader(got), ipc.WithAllocator(memory.NewGoAllocator()))
+	if err != nil {
+		t.Fatalf("ipc.NewReader: %v", err)
+	}
+	defer r.Release()
+	if !r.Next() {
+		t.Fatal("expected one record batch")
+	}
+}
+
+func TestRunCypher_JSONIsDefault(t *testing.T) {
+	srv, _ := fakeArrowCypherServer(t)
+	t.Cleanup(srv.Close)
+
+	c := NewClient(srv.URL, "", 2*time.Second)
+	res, out, err := runCypher(context.Background(), c, CypherInput{Query: "MATCH (n) RETURN n"})
+	if err != nil {
+		t.Fatalf("runCypher: %v", err)
+	}
+	if res != nil {
+		t.Fatalf("JSON path must return a nil CallToolResult so structured output auto-populates; got %+v", res)
+	}
+	if len(out.Rows) != 3 {
+		t.Errorf("rows = %d, want 3", len(out.Rows))
+	}
+}
+
+func TestRunCypher_ExplicitJSON(t *testing.T) {
+	srv, _ := fakeArrowCypherServer(t)
+	t.Cleanup(srv.Close)
+
+	c := NewClient(srv.URL, "", 2*time.Second)
+	res, out, err := runCypher(context.Background(), c, CypherInput{
+		Query:  "MATCH (n) RETURN n",
+		Format: "json",
+	})
+	if err != nil {
+		t.Fatalf("runCypher: %v", err)
+	}
+	if res != nil {
+		t.Fatalf("JSON path must return nil CallToolResult, got %+v", res)
+	}
+	if len(out.Rows) != 3 {
+		t.Errorf("rows = %d, want 3", len(out.Rows))
+	}
+}
+
+func TestRunCypher_ArrowReturnsEmbeddedResource(t *testing.T) {
+	srv, wantBytes := fakeArrowCypherServer(t)
+	t.Cleanup(srv.Close)
+
+	c := NewClient(srv.URL, "", 2*time.Second)
+	res, out, err := runCypher(context.Background(), c, CypherInput{
+		Query:  "MATCH (n) RETURN n",
+		Format: "arrow",
+	})
+	if err != nil {
+		t.Fatalf("runCypher: %v", err)
+	}
+	if res == nil {
+		t.Fatal("arrow path must return an explicit CallToolResult")
+	}
+	if len(out.Rows) != 0 {
+		t.Errorf("arrow path must skip JSON rows; got %d", len(out.Rows))
+	}
+	if len(res.Content) != 2 {
+		t.Fatalf("expected 2 content blocks (text summary + embedded resource), got %d", len(res.Content))
+	}
+
+	if _, ok := res.Content[0].(*mcp.TextContent); !ok {
+		t.Errorf("first content block must be TextContent, got %T", res.Content[0])
+	}
+	er, ok := res.Content[1].(*mcp.EmbeddedResource)
+	if !ok {
+		t.Fatalf("second content block must be EmbeddedResource, got %T", res.Content[1])
+	}
+	if er.Resource == nil {
+		t.Fatal("embedded resource has nil Resource")
+	}
+	if er.Resource.MIMEType != ArrowStreamMIME {
+		t.Errorf("MIME type = %q, want %q", er.Resource.MIMEType, ArrowStreamMIME)
+	}
+	if !bytes.Equal(er.Resource.Blob, wantBytes) {
+		t.Errorf("resource blob does not match the upstream Arrow bytes (got %d bytes, want %d)",
+			len(er.Resource.Blob), len(wantBytes))
+	}
+}
+
+func TestRunCypher_ArrowResourceBlobIsParseableIPCStream(t *testing.T) {
+	srv, _ := fakeArrowCypherServer(t)
+	t.Cleanup(srv.Close)
+
+	c := NewClient(srv.URL, "", 2*time.Second)
+	res, _, err := runCypher(context.Background(), c, CypherInput{
+		Query:  "MATCH (n) RETURN n",
+		Format: "arrow",
+	})
+	if err != nil {
+		t.Fatalf("runCypher: %v", err)
+	}
+	er := res.Content[1].(*mcp.EmbeddedResource)
+
+	r, err := ipc.NewReader(bytes.NewReader(er.Resource.Blob), ipc.WithAllocator(memory.NewGoAllocator()))
+	if err != nil {
+		t.Fatalf("ipc.NewReader on resource blob: %v", err)
+	}
+	defer r.Release()
+	if !r.Next() {
+		t.Fatal("expected one record batch in the embedded blob")
+	}
+	rec := r.RecordBatch()
+	if rec.NumRows() != 3 {
+		t.Errorf("rows in blob = %d, want 3", rec.NumRows())
+	}
+}
+
+func TestRunCypher_RejectsUnknownFormat(t *testing.T) {
+	srv, _ := fakeArrowCypherServer(t)
+	t.Cleanup(srv.Close)
+
+	c := NewClient(srv.URL, "", 2*time.Second)
+	res, _, err := runCypher(context.Background(), c, CypherInput{
+		Query:  "MATCH (n) RETURN n",
+		Format: "parquet",
+	})
+	if err != nil {
+		t.Fatalf("runCypher: %v", err)
+	}
+	if res == nil || !res.IsError {
+		t.Fatalf("expected IsError result for unknown format, got %+v", res)
+	}
+}
+
+func TestRunCypher_ArrowAcceptsJSONUppercase(t *testing.T) {
+	// Format strings should be case-insensitive — JSON, Arrow, ARROW
+	// all need to work, since LLMs often shout.
+	srv, _ := fakeArrowCypherServer(t)
+	t.Cleanup(srv.Close)
+
+	c := NewClient(srv.URL, "", 2*time.Second)
+	res, _, err := runCypher(context.Background(), c, CypherInput{
+		Query:  "MATCH (n) RETURN n",
+		Format: "ARROW",
+	})
+	if err != nil {
+		t.Fatalf("runCypher: %v", err)
+	}
+	if res == nil {
+		t.Fatal("expected CallToolResult for uppercase ARROW format")
+	}
+	if _, ok := res.Content[1].(*mcp.EmbeddedResource); !ok {
+		t.Errorf("expected EmbeddedResource for ARROW format")
+	}
+}


### PR DESCRIPTION
## Summary

- `cypher_read` / `cypher_write` accept `format: "arrow"` to receive Apache Arrow IPC stream bytes as an embedded resource on the tool result (MIME `application/vnd.apache.arrow.stream`)
- Default (`format` omitted or `"json"`) keeps the existing `{columns, rows, stats}` structured-output path; LLM-driven flows are unchanged
- New `Client.CypherArrow` forwards `Accept: application/vnd.apache.arrow.stream` to `/cypher` and returns the raw bytes
- Dispatch lives in a single `runCypher` helper shared by both tools
- Format strings are case-insensitive (`arrow` / `Arrow` / `ARROW` all work)

The point: analytics-aware MCP consumers (DuckDB-WASM `read_arrow`, pyarrow `ipc.open_stream`, polars `read_ipc_stream`) can ingest the result directly into their columnar memory without a JSON marshal/unmarshal round-trip. Same payload as the HTTP `/cypher` Arrow path, just delivered through the MCP wire.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./... -count=1` passes
- [x] `TestClientCypherArrow_AcceptHeaderAndBytes` — Accept header negotiation, bytes round-trip cleanly, parseable as IPC stream
- [x] `TestRunCypher_JSONIsDefault` / `*ExplicitJSON` — JSON path returns nil CallToolResult so structured output auto-populates
- [x] `TestRunCypher_ArrowReturnsEmbeddedResource` — Arrow path returns CallToolResult with TextContent + EmbeddedResource (MIME pinned to Arrow stream)
- [x] `TestRunCypher_ArrowResourceBlobIsParseableIPCStream` — embedded blob round-trips through ipc.NewReader
- [x] `TestRunCypher_RejectsUnknownFormat` — unknown format produces an IsError result
- [x] `TestRunCypher_ArrowAcceptsJSONUppercase` — case-insensitive format handling

Issue: #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)