### PR TITLE
feat(api): mid-stream error trailer (#27)

### DIFF
--- a/docs/arrow-mapping.md
+++ b/docs/arrow-mapping.md
@@ -142,22 +142,32 @@ got rows back).
 
 The Arrow stream format flushes the schema message before the first
 record batch, so there is no way to return a 4xx/5xx HTTP status
-once a batch has been written. Errors discovered mid-stream are
-encoded as a final record batch with these schema-metadata flags:
+once a batch has been written. The Loveliness encoder surfaces
+errors as schema-level metadata so a single read of the schema
+metadata tells a client whether the result is authoritative:
 
 | Key | Value |
 |---|---|
 | `loveliness.error` | `"true"` |
-| `loveliness.error.code` | server error code (e.g. `SHARD_TIMEOUT`) |
-| `loveliness.error.message` | human-readable detail |
+| `loveliness.error.code` | `SHARD_ERROR` (one shard failed) or `SHARD_ERRORS` (multiple) |
+| `loveliness.error.message` | human-readable detail; for multi-shard cases prefixed with the failed-shard count |
 
-Clients **must** check for `loveliness.error == "true"` after the
-last batch and surface the error to the user — silent truncation
-would otherwise look like an empty result. This trailer mechanism is
-documented here so clients across languages have one contract; it
-does not exist in the file format because file payloads are always
-fully buffered before the response headers are sent (a regular HTTP
-500 covers that path).
+Clients **must** check for `loveliness.error == "true"` and surface
+the error to the user — silent truncation would otherwise look like
+an empty result. The structured per-shard list still rides along on
+`loveliness.errors` (JSON array) when clients want machine-readable
+detail; the flat keys above exist so a client can do one metadata
+lookup. The same keys are emitted on both the stream and file
+formats so client code can share the check.
+
+Today the encoder is fully buffered, so all errors are observed
+before any byte is written and the metadata lands on the initial
+schema message. A future truly-incremental encoder that flushes
+record batches as shards reply will need a sentinel terminal-batch
+mechanism (likely a zero-row batch with column-level metadata) to
+signal errors discovered after the schema is on the wire; the wire
+contract for clients does not change — they still check
+`loveliness.error` after the last batch.
 
 ## Versioning
 

--- a/pkg/api/arrow.go
+++ b/pkg/api/arrow.go
@@ -344,7 +344,12 @@ const arrowMappingVersion = "1"
 func schemaMetadataKeys(result *router.Result) []string {
 	keys := []string{"loveliness.arrow_mapping_version", "loveliness.partial"}
 	if len(result.Errors) > 0 {
-		keys = append(keys, "loveliness.errors")
+		keys = append(keys,
+			"loveliness.errors",
+			"loveliness.error",
+			"loveliness.error.code",
+			"loveliness.error.message",
+		)
 	}
 	return keys
 }
@@ -353,9 +358,33 @@ func schemaMetadataValues(result *router.Result) []string {
 	values := []string{arrowMappingVersion, boolStr(result.Partial)}
 	if len(result.Errors) > 0 {
 		errsJSON, _ := json.Marshal(result.Errors)
-		values = append(values, string(errsJSON))
+		code, msg := errorTrailer(result.Errors)
+		values = append(values, string(errsJSON), "true", code, msg)
 	}
 	return values
+}
+
+// errorTrailer derives the (code, message) pair attached to the
+// stream as the mid-stream error trailer documented in
+// docs/arrow-mapping.md. The full structured list still rides on
+// `loveliness.errors`; these flat keys exist so clients can perform
+// a single metadata lookup to decide whether to surface an error.
+//
+// Shape choice: pick the first shard error as the canonical
+// (code, message) — for a single failed shard this is exact; for
+// multiple, the message degrades to "N shards failed" so a client
+// that only reads the trailer doesn't quietly drop the count. The
+// structured list remains the source of truth.
+func errorTrailer(errs []router.ShardError) (code, message string) {
+	if len(errs) == 0 {
+		return "", ""
+	}
+	first := errs[0]
+	if len(errs) == 1 {
+		return "SHARD_ERROR", fmt.Sprintf("shard %d: %s", first.ShardID, first.Error)
+	}
+	return "SHARD_ERRORS", fmt.Sprintf("%d shards failed; first: shard %d: %s",
+		len(errs), first.ShardID, first.Error)
 }
 
 func boolStr(b bool) string {

--- a/pkg/api/arrow_trailer_test.go
+++ b/pkg/api/arrow_trailer_test.go
@@ -1,0 +1,190 @@
+package api
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/johnjansen/loveliness/pkg/router"
+)
+
+// The mid-stream error trailer is the contract documented in
+// docs/arrow-mapping.md under "Mid-stream errors". Three flat
+// metadata keys ride alongside the structured `loveliness.errors`
+// JSON array so a client that only reads schema metadata can detect
+// failure with one lookup. The structured array remains the source
+// of truth — these tests pin both surfaces so a client written
+// against either can't quietly miss errors.
+
+func TestArrowTrailer_NoErrorsLeavesTrailerKeysAbsent(t *testing.T) {
+	// A clean result must NOT carry trailer keys — their presence is
+	// itself the "errors happened" signal. Emitting them with empty
+	// values would force every client to disambiguate.
+	res := &router.Result{
+		Columns: []string{"x"},
+		Rows:    []map[string]any{{"x": "ok"}},
+	}
+
+	for _, tc := range []struct {
+		name   string
+		encode func(*router.Result) ([]byte, error)
+		read   func(*testing.T, []byte) (interface{ GetValue(string) (string, bool) }, error)
+	}{
+		{
+			name:   "stream",
+			encode: encodeResultAsArrowStream,
+			read: func(t *testing.T, buf []byte) (interface{ GetValue(string) (string, bool) }, error) {
+				schema, _ := readArrowStream(t, buf)
+				md := schema.Metadata()
+				return &md, nil
+			},
+		},
+		{
+			name:   "file",
+			encode: encodeResultAsArrow,
+			read: func(t *testing.T, buf []byte) (interface{ GetValue(string) (string, bool) }, error) {
+				schema, _ := readArrowFile(t, buf)
+				md := schema.Metadata()
+				return &md, nil
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			buf, err := tc.encode(res)
+			if err != nil {
+				t.Fatalf("encode: %v", err)
+			}
+			md, err := tc.read(t, buf)
+			if err != nil {
+				t.Fatalf("read: %v", err)
+			}
+			for _, key := range []string{
+				"loveliness.error",
+				"loveliness.error.code",
+				"loveliness.error.message",
+				"loveliness.errors",
+			} {
+				if _, ok := md.GetValue(key); ok {
+					t.Errorf("clean result must not carry %s metadata", key)
+				}
+			}
+		})
+	}
+}
+
+func TestArrowTrailer_SingleShardError(t *testing.T) {
+	res := &router.Result{
+		Columns: []string{"x"},
+		Rows:    []map[string]any{{"x": "ok"}},
+		Partial: true,
+		Errors: []router.ShardError{
+			{ShardID: 2, Error: "shard timeout"},
+		},
+	}
+
+	for _, tc := range []struct {
+		name   string
+		encode func(*router.Result) ([]byte, error)
+	}{
+		{"stream", encodeResultAsArrowStream},
+		{"file", encodeResultAsArrow},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			buf, err := tc.encode(res)
+			if err != nil {
+				t.Fatalf("encode: %v", err)
+			}
+			var md interface {
+				GetValue(string) (string, bool)
+			}
+			if tc.name == "stream" {
+				schema, _ := readArrowStream(t, buf)
+				m := schema.Metadata()
+				md = &m
+			} else {
+				schema, _ := readArrowFile(t, buf)
+				m := schema.Metadata()
+				md = &m
+			}
+
+			if got, ok := md.GetValue("loveliness.error"); !ok || got != "true" {
+				t.Errorf("loveliness.error = %q (ok=%v), want true", got, ok)
+			}
+			if got, ok := md.GetValue("loveliness.error.code"); !ok || got != "SHARD_ERROR" {
+				t.Errorf("loveliness.error.code = %q (ok=%v), want SHARD_ERROR", got, ok)
+			}
+			got, ok := md.GetValue("loveliness.error.message")
+			if !ok {
+				t.Fatal("loveliness.error.message missing")
+			}
+			if !strings.Contains(got, "shard 2") || !strings.Contains(got, "shard timeout") {
+				t.Errorf("loveliness.error.message = %q, want it to mention shard 2 and the underlying error", got)
+			}
+
+			// Structured list still rides along — clients that prefer
+			// it over the trailer keys must keep working.
+			raw, ok := md.GetValue("loveliness.errors")
+			if !ok {
+				t.Fatal("loveliness.errors missing alongside trailer")
+			}
+			var decoded []router.ShardError
+			if err := json.Unmarshal([]byte(raw), &decoded); err != nil {
+				t.Fatalf("loveliness.errors not parseable: %v", err)
+			}
+			if len(decoded) != 1 || decoded[0].ShardID != 2 {
+				t.Errorf("decoded loveliness.errors = %+v, want [{ShardID:2, ...}]", decoded)
+			}
+		})
+	}
+}
+
+func TestArrowTrailer_MultipleShardErrors(t *testing.T) {
+	res := &router.Result{
+		Columns: []string{"x"},
+		Rows:    []map[string]any{{"x": "ok"}},
+		Partial: true,
+		Errors: []router.ShardError{
+			{ShardID: 0, Error: "first boom"},
+			{ShardID: 3, Error: "second boom"},
+			{ShardID: 5, Error: "third boom"},
+		},
+	}
+
+	buf, err := encodeResultAsArrowStream(res)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	schema, _ := readArrowStream(t, buf)
+	md := schema.Metadata()
+
+	if got, ok := md.GetValue("loveliness.error"); !ok || got != "true" {
+		t.Errorf("loveliness.error = %q (ok=%v), want true", got, ok)
+	}
+	if got, ok := md.GetValue("loveliness.error.code"); !ok || got != "SHARD_ERRORS" {
+		t.Errorf("loveliness.error.code = %q (ok=%v), want SHARD_ERRORS for >1 errors", got, ok)
+	}
+	got, ok := md.GetValue("loveliness.error.message")
+	if !ok {
+		t.Fatal("loveliness.error.message missing")
+	}
+	if !strings.Contains(got, "3 shards") {
+		t.Errorf("loveliness.error.message = %q, want it to mention the shard count", got)
+	}
+	if !strings.Contains(got, "first boom") {
+		t.Errorf("loveliness.error.message = %q, want it to surface the first shard error", got)
+	}
+}
+
+func TestErrorTrailer_EmptyInput(t *testing.T) {
+	// Defensive: errorTrailer with no errors must return empty
+	// strings so callers that forget the len-check don't accidentally
+	// emit a trailer.
+	code, msg := errorTrailer(nil)
+	if code != "" || msg != "" {
+		t.Errorf("errorTrailer(nil) = (%q, %q), want empty", code, msg)
+	}
+	code, msg = errorTrailer([]router.ShardError{})
+	if code != "" || msg != "" {
+		t.Errorf("errorTrailer([]) = (%q, %q), want empty", code, msg)
+	}
+}


### PR DESCRIPTION
## Summary
- Emit flat `loveliness.error`, `loveliness.error.code`, `loveliness.error.message` schema metadata on both stream and file Arrow encodings when `result.Errors` is non-empty — clients now detect failure with one metadata lookup instead of parsing the JSON array.
- Code is `SHARD_ERROR` for a single failed shard or `SHARD_ERRORS` for multi-shard failures; message includes the shard count and the first underlying error so a client that only reads the trailer doesn't lose the count.
- Structured `loveliness.errors` JSON array still rides alongside the trailer keys, unchanged.
- Updates `docs/arrow-mapping.md` to describe the buffered-encoder reality (metadata at the schema message) and what a future incremental encoder would need.

Closes the "mid-stream error trailer" acceptance bullet on #27. Remaining: DuckDB-WASM smoke test.

## Test plan
- [x] `go test ./pkg/api/ -run Trailer -v` passes (4 tests, 8 subtests)
- [x] `go test ./pkg/api/` whole-package suite green
- [x] `go build ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)