### PR TITLE
feat(router): bounded scatter-gather concurrency (#6)

### DIFF
--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -79,6 +79,16 @@ type Router struct {
 	nodeID    string
 	remote    RemoteQuerier
 	placement PlacementResolver
+
+	// scatterConcurrency caps the number of in-flight per-shard
+	// dispatches in scatterGather. Without a cap, a deployment with
+	// hundreds of shards would spawn hundreds of goroutines per query
+	// and exhaust the connection pool / pin a CPU core under load. The
+	// cap is set at 0 (unbounded) by default for backwards compat;
+	// production callers that wire SetRemoteTransport should set this
+	// to max(8, 2*shardCount) per the #6 spec. SetScatterConcurrency
+	// is the configuration knob.
+	scatterConcurrency int
 }
 
 // DDLHook is called when a DDL statement registers or removes a table.
@@ -196,10 +206,42 @@ func (r *Router) SetDDLHook(h DDLHook) {
 }
 
 // SetRemoteTransport configures distributed query routing to remote shards.
+//
+// Wiring remote transport also installs a sensible scatter-concurrency
+// cap if the caller hasn't set one yet. The default — max(8,
+// 2*shardCount) — matches the #6 spec and keeps the fan-out finite when
+// a deployment has more shards than the connection pool can sustain.
+// Callers that want a different value can call SetScatterConcurrency
+// after this.
 func (r *Router) SetRemoteTransport(nodeID string, remote RemoteQuerier, placement PlacementResolver) {
 	r.nodeID = nodeID
 	r.remote = remote
 	r.placement = placement
+	if r.scatterConcurrency == 0 {
+		r.scatterConcurrency = defaultScatterConcurrency(r.shardCount)
+	}
+}
+
+// SetScatterConcurrency sets the upper bound on parallel per-shard
+// dispatches in scatterGather. n <= 0 disables the cap (every shard
+// gets its own goroutine; matches the pre-#6 behavior).
+func (r *Router) SetScatterConcurrency(n int) {
+	if n < 0 {
+		n = 0
+	}
+	r.scatterConcurrency = n
+}
+
+// defaultScatterConcurrency yields the cap recommended by the #6 spec:
+// max(8, 2*shardCount). The 2× factor lets one shard be scheduling its
+// next request while another is mid-RPC; the 8 floor keeps small
+// deployments from over-throttling.
+func defaultScatterConcurrency(shardCount int) int {
+	cap := 2 * shardCount
+	if cap < 8 {
+		cap = 8
+	}
+	return cap
 }
 
 // queryShardRaw queries a shard and returns the raw QueryResponse.
@@ -487,10 +529,22 @@ func (r *Router) scatterGather(ctx context.Context, parsed *ParsedQuery) (*Resul
 	var wg sync.WaitGroup
 	results := make(chan shardResult, r.shardCount)
 
+	// Bounded fan-out: a buffered channel acts as a semaphore. Each
+	// goroutine acquires before dispatching the per-shard query and
+	// releases on return. Cap == 0 disables the gate (legacy behavior).
+	var sem chan struct{}
+	if r.scatterConcurrency > 0 && r.scatterConcurrency < r.shardCount {
+		sem = make(chan struct{}, r.scatterConcurrency)
+	}
+
 	for i := 0; i < r.shardCount; i++ {
 		wg.Add(1)
 		go func(shardID int) {
 			defer wg.Done()
+			if sem != nil {
+				sem <- struct{}{}
+				defer func() { <-sem }()
+			}
 			resp, err := r.queryShardRaw(shardID, shardQuery)
 			results <- shardResult{shardID: shardID, resp: resp, err: err}
 		}(i)

--- a/pkg/router/scatter_concurrency_test.go
+++ b/pkg/router/scatter_concurrency_test.go
@@ -1,0 +1,154 @@
+package router
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/johnjansen/loveliness/pkg/shard"
+)
+
+// blockingRemote is a RemoteQuerier that records peak concurrency. It
+// blocks every call on a barrier so we can observe how many calls are
+// in flight simultaneously — that's how we prove the scatter cap is
+// being honored. Without the cap, peak concurrency equals shardCount;
+// with a cap of N, it must be ≤ N.
+type blockingRemote struct {
+	mu      sync.Mutex
+	inFlight int
+	peak    int32
+	gate    chan struct{}
+}
+
+func newBlockingRemote() *blockingRemote {
+	return &blockingRemote{gate: make(chan struct{})}
+}
+
+func (b *blockingRemote) QueryRemoteShard(_ string, shardID int, _ string) (*shard.QueryResponse, error) {
+	b.mu.Lock()
+	b.inFlight++
+	if int32(b.inFlight) > atomic.LoadInt32(&b.peak) {
+		atomic.StoreInt32(&b.peak, int32(b.inFlight))
+	}
+	b.mu.Unlock()
+
+	<-b.gate
+
+	b.mu.Lock()
+	b.inFlight--
+	b.mu.Unlock()
+	return &shard.QueryResponse{
+		Columns: []string{"x"},
+		Rows:    []map[string]any{{"x": shardID}},
+	}, nil
+}
+
+func (b *blockingRemote) Peak() int { return int(atomic.LoadInt32(&b.peak)) }
+func (b *blockingRemote) Release()  { close(b.gate) }
+
+type allRemotePlacement struct{}
+
+func (allRemotePlacement) PrimaryForShard(_ int) string { return "remote" }
+
+// TestScatterConcurrency_RespectsCap is the headline assertion: when
+// the scatter cap is set, no more than that many remote calls are
+// in flight at once. Without the cap (cap == 0), all shards dispatch
+// in parallel.
+func TestScatterConcurrency_RespectsCap(t *testing.T) {
+	const shardCount = 32
+	const cap = 4
+
+	// All shards nil → router treats every shard as remote.
+	shards := make([]*shard.Shard, shardCount)
+	r := NewRouter(shards, 5*time.Second)
+
+	br := newBlockingRemote()
+	r.SetRemoteTransport("local", br, allRemotePlacement{})
+	r.SetScatterConcurrency(cap)
+
+	// Release the gate after a beat so all in-flight goroutines have a
+	// chance to pile up against the semaphore. 50ms is comfortably
+	// longer than goroutine spin-up and short enough not to slow CI.
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		br.Release()
+	}()
+
+	res, err := r.Execute(context.Background(), "MATCH (n) RETURN n")
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if res == nil {
+		t.Fatal("Execute returned nil result")
+	}
+
+	peak := br.Peak()
+	if peak == 0 {
+		t.Fatalf("expected at least one in-flight call, got 0")
+	}
+	if peak > cap {
+		t.Errorf("scatter exceeded cap: peak=%d, cap=%d", peak, cap)
+	}
+}
+
+// TestScatterConcurrency_ZeroDisablesCap confirms backwards compat:
+// without an explicit cap or remote transport, scatterGather still
+// fans out to every shard concurrently.
+func TestScatterConcurrency_ZeroDisablesCap(t *testing.T) {
+	const shardCount = 16
+	shards := make([]*shard.Shard, shardCount)
+	r := NewRouter(shards, 5*time.Second)
+
+	br := newBlockingRemote()
+	// SetRemoteTransport would auto-set the default cap; bypass it by
+	// assigning the fields via the public setters in a way that keeps
+	// the cap at 0.
+	r.SetRemoteTransport("local", br, allRemotePlacement{})
+	r.SetScatterConcurrency(0) // explicit override back to unbounded
+
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		br.Release()
+	}()
+	if _, err := r.Execute(context.Background(), "MATCH (n) RETURN n"); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if br.Peak() < shardCount {
+		t.Errorf("expected unbounded fan-out (peak=%d) to reach shardCount=%d", br.Peak(), shardCount)
+	}
+}
+
+// TestSetRemoteTransport_DefaultsConcurrency pins the wiring side
+// effect: the default cap is installed automatically when remote
+// transport is configured, so production callers don't have to
+// remember to set it.
+func TestSetRemoteTransport_DefaultsConcurrency(t *testing.T) {
+	r := NewRouter(make([]*shard.Shard, 16), time.Second)
+	r.SetRemoteTransport("local", newBlockingRemote(), allRemotePlacement{})
+	got := r.scatterConcurrency
+	want := defaultScatterConcurrency(16)
+	if got != want {
+		t.Errorf("scatterConcurrency after SetRemoteTransport = %d, want %d", got, want)
+	}
+}
+
+func TestDefaultScatterConcurrency_Floor(t *testing.T) {
+	// max(8, 2*shardCount) — verify the floor at 8 for tiny shard counts.
+	for _, tc := range []struct {
+		shards int
+		want   int
+	}{
+		{shards: 1, want: 8},
+		{shards: 3, want: 8},
+		{shards: 4, want: 8},
+		{shards: 5, want: 10},
+		{shards: 16, want: 32},
+		{shards: 64, want: 128},
+	} {
+		if got := defaultScatterConcurrency(tc.shards); got != tc.want {
+			t.Errorf("defaultScatterConcurrency(%d) = %d, want %d", tc.shards, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Polish slice 1 of 5 for #6 — adds a configurable concurrency cap to `Router.scatterGather`. Previously the router spawned one goroutine per shard unconditionally; with distributed placement, a 100-shard deployment would burn 100 goroutines per query and saturate the connection pool.

- New \`Router.scatterConcurrency\` field + \`SetScatterConcurrency(n)\` setter
- Default of \`max(8, 2*shardCount)\` installed automatically when \`SetRemoteTransport\` is called (per #6 spec)
- Buffered-channel semaphore inside \`scatterGather\` enforces the cap; \`n=0\` keeps the legacy unbounded behavior for tests and single-node setups

## Test plan

- [x] \`TestScatterConcurrency_RespectsCap\` — 32 shards, cap=4, blocking remote, peak in-flight ≤ 4
- [x] \`TestScatterConcurrency_ZeroDisablesCap\` — explicit 0 keeps legacy fan-out to all shards
- [x] \`TestSetRemoteTransport_DefaultsConcurrency\` — wiring side-effect lands the spec default
- [x] \`TestDefaultScatterConcurrency_Floor\` — formula correct across shardCounts
- [x] \`go test -race ./pkg/router/\` clean
- [x] \`go test ./...\` clean

## Related

- Issue #6 (cross-node scatter-gather, polish slice 1 of 5)
- Spike #64 tracks the deferred transport-architecture review

🤖 Generated with [Claude Code](https://claude.com/claude-code)