### PR TITLE
feat(analytics): promote plugin system from spike to pkg/

### DIFF
--- a/pkg/analytics/analytics.go
+++ b/pkg/analytics/analytics.go
@@ -6,6 +6,7 @@ package analytics
 import (
 	"context"
 	"fmt"
+	"sort"
 	"sync"
 
 	"github.com/johnjansen/loveliness/pkg/router"
@@ -58,6 +59,9 @@ func (r *Registry) Lookup(name string) (Plugin, bool) {
 	return p, ok
 }
 
+// Names returns the registered plugin names in lexical order. Sorted so
+// /analytics responses are deterministic across calls — clients can diff
+// or cache without surprise from map iteration order.
 func (r *Registry) Names() []string {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
@@ -65,16 +69,27 @@ func (r *Registry) Names() []string {
 	for n := range r.plugins {
 		out = append(out, n)
 	}
+	sort.Strings(out)
 	return out
 }
 
 // Run executes a slice of plugin requests against a result. Errors are
 // collected per-plugin so a single misbehaving plugin doesn't kill the
-// whole response.
+// whole response. Duplicate plugin names in a single request are
+// rejected on the second occurrence — otherwise the second silently
+// overwrites the first in the result map and the client can't tell why.
+// It also caps amplification: a request can't make the same expensive
+// plugin run N times under one body limit.
 func (r *Registry) Run(ctx context.Context, result *router.Result, reqs []Request) (map[string]any, map[string]string) {
 	out := map[string]any{}
 	errs := map[string]string{}
+	seen := map[string]bool{}
 	for _, req := range reqs {
+		if seen[req.Name] {
+			errs[req.Name] = "duplicate plugin in request"
+			continue
+		}
+		seen[req.Name] = true
 		p, ok := r.Lookup(req.Name)
 		if !ok {
 			errs[req.Name] = "unknown plugin"

--- a/pkg/analytics/analytics.go
+++ b/pkg/analytics/analytics.go
@@ -1,0 +1,91 @@
+// Package analytics defines the plugin contract for opt-in,
+// post-execution computations on a Cypher Result. Plugins are registered
+// once at server boot and selected per-request via the JSON query envelope.
+package analytics
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/johnjansen/loveliness/pkg/router"
+)
+
+// Plugin is a named, side-effect-free computation that runs against a
+// completed *router.Result and produces an opaque value the client gets
+// back under response.analytics[Name].
+//
+// Implementations MUST treat the result as read-only. Mutating Rows or
+// Columns will corrupt the response that's about to be serialised.
+type Plugin interface {
+	Name() string
+	Compute(ctx context.Context, result *router.Result, params map[string]any) (any, error)
+}
+
+// Request describes a single plugin invocation pulled from the query envelope.
+type Request struct {
+	Name   string         `json:"name"`
+	Params map[string]any `json:"params,omitempty"`
+}
+
+// Registry holds the set of plugins known to a server. Concurrent-safe
+// for reads; registration is expected to happen once at boot.
+type Registry struct {
+	mu      sync.RWMutex
+	plugins map[string]Plugin
+}
+
+func NewRegistry() *Registry { return &Registry{plugins: map[string]Plugin{}} }
+
+func (r *Registry) Register(p Plugin) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	name := p.Name()
+	if name == "" {
+		return fmt.Errorf("analytics: plugin has empty Name()")
+	}
+	if _, dup := r.plugins[name]; dup {
+		return fmt.Errorf("analytics: plugin %q already registered", name)
+	}
+	r.plugins[name] = p
+	return nil
+}
+
+func (r *Registry) Lookup(name string) (Plugin, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	p, ok := r.plugins[name]
+	return p, ok
+}
+
+func (r *Registry) Names() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]string, 0, len(r.plugins))
+	for n := range r.plugins {
+		out = append(out, n)
+	}
+	return out
+}
+
+// Run executes a slice of plugin requests against a result. Errors are
+// collected per-plugin so a single misbehaving plugin doesn't kill the
+// whole response.
+func (r *Registry) Run(ctx context.Context, result *router.Result, reqs []Request) (map[string]any, map[string]string) {
+	out := map[string]any{}
+	errs := map[string]string{}
+	for _, req := range reqs {
+		p, ok := r.Lookup(req.Name)
+		if !ok {
+			errs[req.Name] = "unknown plugin"
+			continue
+		}
+		v, err := p.Compute(ctx, result, req.Params)
+		if err != nil {
+			errs[req.Name] = err.Error()
+			continue
+		}
+		out[req.Name] = v
+	}
+	return out, errs
+}

--- a/pkg/analytics/analytics_test.go
+++ b/pkg/analytics/analytics_test.go
@@ -1,0 +1,76 @@
+package analytics
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/johnjansen/loveliness/pkg/router"
+)
+
+type stubPlugin struct {
+	name string
+	out  any
+	err  error
+}
+
+func (s stubPlugin) Name() string { return s.name }
+func (s stubPlugin) Compute(_ context.Context, _ *router.Result, _ map[string]any) (any, error) {
+	return s.out, s.err
+}
+
+func TestRegistry_RegisterDuplicate(t *testing.T) {
+	r := NewRegistry()
+	if err := r.Register(stubPlugin{name: "x"}); err != nil {
+		t.Fatalf("first register: %v", err)
+	}
+	if err := r.Register(stubPlugin{name: "x"}); err == nil {
+		t.Fatal("expected duplicate registration to fail")
+	}
+}
+
+func TestRegistry_RegisterEmptyName(t *testing.T) {
+	if err := NewRegistry().Register(stubPlugin{name: ""}); err == nil {
+		t.Fatal("expected empty Name() to be rejected")
+	}
+}
+
+func TestRegistry_RunUnknownPlugin(t *testing.T) {
+	r := NewRegistry()
+	out, errs := r.Run(context.Background(), &router.Result{}, []Request{{Name: "missing"}})
+	if len(out) != 0 {
+		t.Errorf("expected empty out, got %v", out)
+	}
+	if errs["missing"] != "unknown plugin" {
+		t.Errorf("expected 'unknown plugin', got %q", errs["missing"])
+	}
+}
+
+func TestRegistry_RunErrorIsolation(t *testing.T) {
+	r := NewRegistry()
+	_ = r.Register(stubPlugin{name: "good", out: 42})
+	_ = r.Register(stubPlugin{name: "bad", err: errors.New("kaboom")})
+
+	out, errs := r.Run(context.Background(), &router.Result{}, []Request{
+		{Name: "good"}, {Name: "bad"},
+	})
+	if out["good"] != 42 {
+		t.Errorf("good: %v", out["good"])
+	}
+	if _, ok := out["bad"]; ok {
+		t.Errorf("bad should not appear in out")
+	}
+	if errs["bad"] != "kaboom" {
+		t.Errorf("bad err: %q", errs["bad"])
+	}
+}
+
+func TestRegistry_Names(t *testing.T) {
+	r := NewRegistry()
+	_ = r.Register(stubPlugin{name: "a"})
+	_ = r.Register(stubPlugin{name: "b"})
+	got := r.Names()
+	if len(got) != 2 {
+		t.Errorf("names: %v", got)
+	}
+}

--- a/pkg/analytics/analytics_test.go
+++ b/pkg/analytics/analytics_test.go
@@ -67,10 +67,45 @@ func TestRegistry_RunErrorIsolation(t *testing.T) {
 
 func TestRegistry_Names(t *testing.T) {
 	r := NewRegistry()
-	_ = r.Register(stubPlugin{name: "a"})
 	_ = r.Register(stubPlugin{name: "b"})
+	_ = r.Register(stubPlugin{name: "a"})
 	got := r.Names()
 	if len(got) != 2 {
-		t.Errorf("names: %v", got)
+		t.Fatalf("names: %v", got)
 	}
+	// Sorted lexically for deterministic /analytics responses.
+	if got[0] != "a" || got[1] != "b" {
+		t.Errorf("expected sorted names, got %v", got)
+	}
+}
+
+func TestRegistry_RunDuplicateRejected(t *testing.T) {
+	r := NewRegistry()
+	calls := 0
+	_ = r.Register(stubPluginFunc{name: "p", fn: func() (any, error) {
+		calls++
+		return calls, nil
+	}})
+	out, errs := r.Run(context.Background(), &router.Result{}, []Request{
+		{Name: "p"}, {Name: "p"},
+	})
+	if calls != 1 {
+		t.Errorf("expected exactly 1 invocation, got %d (amplification!)", calls)
+	}
+	if out["p"] == nil {
+		t.Errorf("first occurrence should still produce a value")
+	}
+	if errs["p"] != "duplicate plugin in request" {
+		t.Errorf("expected duplicate error, got %q", errs["p"])
+	}
+}
+
+type stubPluginFunc struct {
+	name string
+	fn   func() (any, error)
+}
+
+func (s stubPluginFunc) Name() string { return s.name }
+func (s stubPluginFunc) Compute(_ context.Context, _ *router.Result, _ map[string]any) (any, error) {
+	return s.fn()
 }

--- a/pkg/analytics/plugins/connected_components.go
+++ b/pkg/analytics/plugins/connected_components.go
@@ -1,0 +1,120 @@
+package plugins
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/johnjansen/loveliness/pkg/router"
+)
+
+// ConnectedComponents treats the result as an edge list and computes
+// weakly-connected components via union-find. It is the structural
+// stand-in for a future Leiden plugin — same contract, simpler maths.
+//
+// Params:
+//
+//	src (string, default "src") — column name holding the source node id
+//	dst (string, default "dst") — column name holding the destination node id
+type ConnectedComponents struct{}
+
+func (ConnectedComponents) Name() string { return "connected_components" }
+
+func (ConnectedComponents) Compute(_ context.Context, result *router.Result, params map[string]any) (any, error) {
+	srcCol := stringOr(params, "src", "src")
+	dstCol := stringOr(params, "dst", "dst")
+	if !columnExists(result.Columns, srcCol) {
+		return nil, fmt.Errorf("connected_components: src column %q not in result", srcCol)
+	}
+	if !columnExists(result.Columns, dstCol) {
+		return nil, fmt.Errorf("connected_components: dst column %q not in result", dstCol)
+	}
+
+	uf := newUnionFind()
+	for _, row := range result.Rows {
+		s := keyOf(row[srcCol])
+		d := keyOf(row[dstCol])
+		uf.union(s, d)
+	}
+
+	groups := uf.groups()
+	sizes := make([]int, 0, len(groups))
+	for _, members := range groups {
+		sizes = append(sizes, len(members))
+	}
+	sort.Sort(sort.Reverse(sort.IntSlice(sizes)))
+
+	return map[string]any{
+		"num_components": len(groups),
+		"num_nodes":      uf.nodeCount(),
+		"largest":        firstOr(sizes, 0),
+		"size_histogram": sizes,
+	}, nil
+}
+
+func stringOr(m map[string]any, k, def string) string {
+	if m == nil {
+		return def
+	}
+	if v, ok := m[k].(string); ok && v != "" {
+		return v
+	}
+	return def
+}
+
+func firstOr(xs []int, def int) int {
+	if len(xs) == 0 {
+		return def
+	}
+	return xs[0]
+}
+
+func keyOf(v any) string { return fmt.Sprintf("%v", v) }
+
+type unionFind struct {
+	parent map[string]string
+	rank   map[string]int
+}
+
+func newUnionFind() *unionFind {
+	return &unionFind{parent: map[string]string{}, rank: map[string]int{}}
+}
+
+func (u *unionFind) find(x string) string {
+	if _, seen := u.parent[x]; !seen {
+		u.parent[x] = x
+		u.rank[x] = 0
+		return x
+	}
+	if u.parent[x] != x {
+		u.parent[x] = u.find(u.parent[x])
+	}
+	return u.parent[x]
+}
+
+func (u *unionFind) union(a, b string) {
+	ra, rb := u.find(a), u.find(b)
+	if ra == rb {
+		return
+	}
+	switch {
+	case u.rank[ra] < u.rank[rb]:
+		u.parent[ra] = rb
+	case u.rank[ra] > u.rank[rb]:
+		u.parent[rb] = ra
+	default:
+		u.parent[rb] = ra
+		u.rank[ra]++
+	}
+}
+
+func (u *unionFind) groups() map[string][]string {
+	out := map[string][]string{}
+	for node := range u.parent {
+		root := u.find(node)
+		out[root] = append(out[root], node)
+	}
+	return out
+}
+
+func (u *unionFind) nodeCount() int { return len(u.parent) }

--- a/pkg/analytics/plugins/count_by_label.go
+++ b/pkg/analytics/plugins/count_by_label.go
@@ -1,0 +1,42 @@
+// Package plugins houses the analytics plugins shipped with the loveliness
+// server. Each file is a single Plugin implementation; new plugins drop
+// in here and get wired up once at server boot.
+package plugins
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/johnjansen/loveliness/pkg/router"
+)
+
+// CountByLabel groups rows by the value of one column and counts each group.
+// Param: column (string, required).
+type CountByLabel struct{}
+
+func (CountByLabel) Name() string { return "count_by_label" }
+
+func (CountByLabel) Compute(_ context.Context, result *router.Result, params map[string]any) (any, error) {
+	col, _ := params["column"].(string)
+	if col == "" {
+		return nil, fmt.Errorf("count_by_label: missing required param 'column'")
+	}
+	if !columnExists(result.Columns, col) {
+		return nil, fmt.Errorf("count_by_label: column %q not in result (have %v)", col, result.Columns)
+	}
+	counts := map[string]int{}
+	for _, row := range result.Rows {
+		key := fmt.Sprintf("%v", row[col])
+		counts[key]++
+	}
+	return map[string]any{"counts": counts, "total": len(result.Rows)}, nil
+}
+
+func columnExists(cols []string, want string) bool {
+	for _, c := range cols {
+		if c == want {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/analytics/plugins/plugins_test.go
+++ b/pkg/analytics/plugins/plugins_test.go
@@ -1,0 +1,95 @@
+package plugins
+
+import (
+	"context"
+	"testing"
+
+	"github.com/johnjansen/loveliness/pkg/router"
+)
+
+func TestCountByLabel_Compute(t *testing.T) {
+	r := &router.Result{
+		Columns: []string{"label"},
+		Rows: []map[string]any{
+			{"label": "User"}, {"label": "User"}, {"label": "User"},
+			{"label": "Post"}, {"label": "Post"},
+			{"label": "Tag"},
+		},
+	}
+	out, err := CountByLabel{}.Compute(context.Background(), r, map[string]any{"column": "label"})
+	if err != nil {
+		t.Fatalf("compute: %v", err)
+	}
+	got := out.(map[string]any)
+	counts := got["counts"].(map[string]int)
+	if counts["User"] != 3 || counts["Post"] != 2 || counts["Tag"] != 1 {
+		t.Errorf("counts: %+v", counts)
+	}
+	if got["total"].(int) != 6 {
+		t.Errorf("total: %v", got["total"])
+	}
+}
+
+func TestCountByLabel_MissingParam(t *testing.T) {
+	r := &router.Result{Columns: []string{"x"}, Rows: []map[string]any{{"x": 1}}}
+	if _, err := (CountByLabel{}).Compute(context.Background(), r, nil); err == nil {
+		t.Fatal("expected error on missing column param")
+	}
+}
+
+func TestCountByLabel_UnknownColumn(t *testing.T) {
+	r := &router.Result{Columns: []string{"label"}, Rows: []map[string]any{{"label": "x"}}}
+	if _, err := (CountByLabel{}).Compute(context.Background(), r, map[string]any{"column": "nope"}); err == nil {
+		t.Fatal("expected error on unknown column")
+	}
+}
+
+func TestConnectedComponents_TwoTriangles(t *testing.T) {
+	rows := []map[string]any{
+		{"src": "a", "dst": "b"}, {"src": "b", "dst": "c"}, {"src": "c", "dst": "a"},
+		{"src": "x", "dst": "y"}, {"src": "y", "dst": "z"}, {"src": "z", "dst": "x"},
+	}
+	r := &router.Result{Columns: []string{"src", "dst"}, Rows: rows}
+	out, err := ConnectedComponents{}.Compute(context.Background(), r, nil)
+	if err != nil {
+		t.Fatalf("compute: %v", err)
+	}
+	got := out.(map[string]any)
+	if got["num_components"].(int) != 2 {
+		t.Errorf("num_components: %v", got["num_components"])
+	}
+	if got["num_nodes"].(int) != 6 {
+		t.Errorf("num_nodes: %v", got["num_nodes"])
+	}
+	if got["largest"].(int) != 3 {
+		t.Errorf("largest: %v", got["largest"])
+	}
+}
+
+func TestConnectedComponents_CustomColumns(t *testing.T) {
+	rows := []map[string]any{
+		{"from": 1, "to": 2}, {"from": 2, "to": 3},
+	}
+	r := &router.Result{Columns: []string{"from", "to"}, Rows: rows}
+	out, err := ConnectedComponents{}.Compute(
+		context.Background(), r,
+		map[string]any{"src": "from", "dst": "to"},
+	)
+	if err != nil {
+		t.Fatalf("compute: %v", err)
+	}
+	got := out.(map[string]any)
+	if got["num_components"].(int) != 1 {
+		t.Errorf("num_components: want 1, got %v", got["num_components"])
+	}
+	if got["num_nodes"].(int) != 3 {
+		t.Errorf("num_nodes: want 3, got %v", got["num_nodes"])
+	}
+}
+
+func TestConnectedComponents_MissingColumn(t *testing.T) {
+	r := &router.Result{Columns: []string{"a"}, Rows: []map[string]any{{"a": 1}}}
+	if _, err := (ConnectedComponents{}).Compute(context.Background(), r, nil); err == nil {
+		t.Fatal("expected error when src column missing")
+	}
+}

--- a/pkg/api/analytics_test.go
+++ b/pkg/api/analytics_test.go
@@ -126,26 +126,71 @@ func TestQuery_MultiplePluginsAtOnce(t *testing.T) {
 	}
 }
 
-func TestQuery_PreservesPartialAndStats(t *testing.T) {
-	// queryResponse must be a strict superset of router.Result. We can't
-	// easily induce a partial result in a unit test, but we can at least
-	// assert the embedded fields are reachable on the decoded response,
-	// proving the wire shape carries them.
+func TestQuery_WireFormatCarriesPartialAndErrors(t *testing.T) {
+	// Direct marshalling test: queryResponse must round-trip Partial,
+	// Errors, and Stats from router.Result so the new endpoint is a
+	// strict superset of /db/{name}/cypher. We can't easily induce a
+	// real partial scatter-gather in a unit test, so we construct the
+	// state we want to see and assert it survives the wire.
+	resp := queryResponse{
+		Result: &router.Result{
+			Columns: []string{"n"},
+			Rows:    []map[string]any{{"n": 1}},
+			Partial: true,
+			Errors: []router.ShardError{
+				{ShardID: 7, Error: "shard unavailable"},
+			},
+		},
+		Analytics: map[string]any{"x": 1},
+	}
+	raw, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got["partial"] != true {
+		t.Errorf("partial dropped: %s", raw)
+	}
+	gotErrs, ok := got["errors"].([]any)
+	if !ok || len(gotErrs) != 1 {
+		t.Fatalf("errors dropped: %s", raw)
+	}
+	first := gotErrs[0].(map[string]any)
+	if first["shard_id"].(float64) != 7 || first["error"] != "shard unavailable" {
+		t.Errorf("errors content corrupted: %+v", first)
+	}
+	if _, ok := got["analytics"]; !ok {
+		t.Errorf("analytics block missing: %s", raw)
+	}
+}
+
+func TestQuery_DuplicatePluginRejected(t *testing.T) {
+	// Duplicate plugin names in one request must surface as an error,
+	// not silently last-write-wins. Otherwise a client can't tell why
+	// only one result came back, and a malicious client can amplify
+	// expensive plugin runs under one body limit.
 	srv := setupAnalyticsServer(t)
-	w, resp := postQuery(t, srv, `{"cypher":"MATCH (n) RETURN n"}`)
+	body := `{
+		"cypher": "MATCH (n) RETURN n",
+		"analytics": [
+			{"name": "count_by_label", "params": {"column": "label"}},
+			{"name": "count_by_label", "params": {"column": "name"}}
+		]
+	}`
+	w, resp := postQuery(t, srv, body)
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", w.Code)
 	}
-	if resp.Result == nil {
-		t.Fatalf("expected embedded *router.Result on response")
+	if resp.AnalyticsErrors["count_by_label"] != "duplicate plugin in request" {
+		t.Errorf("expected duplicate error, got %q", resp.AnalyticsErrors["count_by_label"])
 	}
-	if len(resp.Columns) == 0 {
-		t.Errorf("expected promoted Columns from embedded Result")
+	// The first occurrence still ran successfully.
+	if _, ok := resp.Analytics["count_by_label"]; !ok {
+		t.Errorf("first occurrence should still be in analytics: %+v", resp.Analytics)
 	}
-	// Partial/Errors are omitempty zero values; the field is reachable
-	// even when absent from the wire.
-	_ = resp.Partial
-	_ = resp.Errors
 }
 
 func TestQuery_UnknownPluginIsolated(t *testing.T) {

--- a/pkg/api/analytics_test.go
+++ b/pkg/api/analytics_test.go
@@ -1,0 +1,170 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/johnjansen/loveliness/pkg/catalog"
+	"github.com/johnjansen/loveliness/pkg/router"
+	"github.com/johnjansen/loveliness/pkg/shard"
+)
+
+// setupAnalyticsServer wires a multi-database router with a single
+// "main" database, seeded with rows that have a `name` shard-key column
+// so MATCH (n) RETURN n returns deterministic data across shards.
+func setupAnalyticsServer(t *testing.T) *Server {
+	t.Helper()
+	cat := catalog.NewCatalog()
+	db, err := cat.CreateDatabase("main", 2)
+	if err != nil {
+		t.Fatalf("create db: %v", err)
+	}
+
+	shards := make([]*shard.Shard, len(db.ShardIDs))
+	for i, id := range db.ShardIDs {
+		store := shard.NewMemoryStore()
+		store.PutNode("alice", map[string]any{"name": "alice", "label": "User"})
+		store.PutNode("bob", map[string]any{"name": "bob", "label": "User"})
+		store.PutNode("post", map[string]any{"name": "post", "label": "Post"})
+		shards[i] = shard.NewShard(id, store, 4)
+	}
+
+	dr := router.NewDatabaseRouter(cat, 5*time.Second)
+	dr.RegisterDatabase("main", shards)
+
+	r := router.NewRouter(shards, 5*time.Second)
+	srv := NewServer(r, nil, shards, nil, 5*time.Second)
+	srv.SetDatabaseRouter(dr)
+	return srv
+}
+
+func postQuery(t *testing.T, srv *Server, body string) (*httptest.ResponseRecorder, queryResponse) {
+	t.Helper()
+	req := httptest.NewRequest("POST", "/db/main/query", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+	var resp queryResponse
+	if w.Code == http.StatusOK {
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("decode: %v\nbody=%s", err, w.Body.String())
+		}
+	}
+	return w, resp
+}
+
+func TestQuery_NoAnalyticsIsCypherSuperset(t *testing.T) {
+	srv := setupAnalyticsServer(t)
+	w, resp := postQuery(t, srv, `{"cypher":"MATCH (n) RETURN n"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if resp.Analytics != nil || resp.AnalyticsErrors != nil {
+		t.Errorf("did not request analytics, got analytics=%v errors=%v",
+			resp.Analytics, resp.AnalyticsErrors)
+	}
+	if len(resp.Rows) == 0 {
+		t.Errorf("expected rows from underlying cypher")
+	}
+}
+
+func TestQuery_UnknownPluginIsolated(t *testing.T) {
+	srv := setupAnalyticsServer(t)
+	body := `{"cypher":"MATCH (n) RETURN n","analytics":[{"name":"nope"}]}`
+	w, resp := postQuery(t, srv, body)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 (unknown plugin shouldn't kill request), got %d: %s",
+			w.Code, w.Body.String())
+	}
+	if resp.AnalyticsErrors["nope"] != "unknown plugin" {
+		t.Errorf("expected unknown plugin error, got %q", resp.AnalyticsErrors["nope"])
+	}
+}
+
+func TestQuery_PluginErrorIsolation(t *testing.T) {
+	srv := setupAnalyticsServer(t)
+	// missing 'column' param → count_by_label fails, request still 200.
+	body := `{"cypher":"MATCH (n) RETURN n","analytics":[{"name":"count_by_label"}]}`
+	w, resp := postQuery(t, srv, body)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if _, ok := resp.AnalyticsErrors["count_by_label"]; !ok {
+		t.Errorf("expected count_by_label to surface in analytics_errors, got %v",
+			resp.AnalyticsErrors)
+	}
+	if resp.Analytics["count_by_label"] != nil {
+		t.Errorf("failed plugin should not appear in analytics")
+	}
+}
+
+func TestQuery_BadJSON(t *testing.T) {
+	srv := setupAnalyticsServer(t)
+	w, _ := postQuery(t, srv, `{not json}`)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestQuery_MissingCypher(t *testing.T) {
+	srv := setupAnalyticsServer(t)
+	w, _ := postQuery(t, srv, `{"analytics":[]}`)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestQuery_AdminCommandRejected(t *testing.T) {
+	srv := setupAnalyticsServer(t)
+	w, _ := postQuery(t, srv, `{"cypher":"CREATE DATABASE foo"}`)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for admin command on /db/{name}/query, got %d", w.Code)
+	}
+}
+
+func TestQuery_WithoutDBRouter(t *testing.T) {
+	// No SetDatabaseRouter — should report NO_MULTI_DB.
+	cat := catalog.NewCatalog()
+	_, _ = cat.CreateDatabase("main", 1)
+	shards := []*shard.Shard{shard.NewShard(0, shard.NewMemoryStore(), 4)}
+	r := router.NewRouter(shards, 5*time.Second)
+	srv := NewServer(r, nil, shards, nil, 5*time.Second)
+
+	req := httptest.NewRequest("POST", "/db/main/query",
+		bytes.NewBufferString(`{"cypher":"MATCH (n) RETURN n"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected 503, got %d", w.Code)
+	}
+}
+
+func TestAnalyticsList(t *testing.T) {
+	srv := setupAnalyticsServer(t)
+	req := httptest.NewRequest("GET", "/analytics", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var got map[string][]string
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	plugins := got["plugins"]
+	if len(plugins) != 2 {
+		t.Errorf("expected 2 built-in plugins, got %v", plugins)
+	}
+	have := map[string]bool{}
+	for _, n := range plugins {
+		have[n] = true
+	}
+	if !have["count_by_label"] || !have["connected_components"] {
+		t.Errorf("missing built-in plugin: %v", plugins)
+	}
+}

--- a/pkg/api/analytics_test.go
+++ b/pkg/api/analytics_test.go
@@ -72,6 +72,82 @@ func TestQuery_NoAnalyticsIsCypherSuperset(t *testing.T) {
 	}
 }
 
+func TestQuery_CountByLabelHappyPath(t *testing.T) {
+	srv := setupAnalyticsServer(t)
+	body := `{
+		"cypher": "MATCH (n) RETURN n",
+		"analytics": [{"name": "count_by_label", "params": {"column": "label"}}]
+	}`
+	w, resp := postQuery(t, srv, body)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if len(resp.AnalyticsErrors) != 0 {
+		t.Fatalf("unexpected analytics errors: %v", resp.AnalyticsErrors)
+	}
+	got, ok := resp.Analytics["count_by_label"].(map[string]any)
+	if !ok {
+		t.Fatalf("missing count_by_label in analytics: %+v", resp.Analytics)
+	}
+	counts, _ := got["counts"].(map[string]any)
+	// Two shards each seed 2 Users + 1 Post → 4 Users, 2 Posts.
+	if counts["User"].(float64) != 4 {
+		t.Errorf("User count: want 4, got %v", counts["User"])
+	}
+	if counts["Post"].(float64) != 2 {
+		t.Errorf("Post count: want 2, got %v", counts["Post"])
+	}
+	if got["total"].(float64) != 6 {
+		t.Errorf("total: want 6, got %v", got["total"])
+	}
+}
+
+func TestQuery_MultiplePluginsAtOnce(t *testing.T) {
+	// Both plugins requested; only count_by_label can run on this shape.
+	// connected_components needs src/dst columns it won't find — should
+	// surface in analytics_errors while count_by_label still succeeds.
+	srv := setupAnalyticsServer(t)
+	body := `{
+		"cypher": "MATCH (n) RETURN n",
+		"analytics": [
+			{"name": "count_by_label", "params": {"column": "label"}},
+			{"name": "connected_components"}
+		]
+	}`
+	w, resp := postQuery(t, srv, body)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if _, ok := resp.Analytics["count_by_label"]; !ok {
+		t.Errorf("count_by_label should have succeeded: %+v", resp.Analytics)
+	}
+	if _, ok := resp.AnalyticsErrors["connected_components"]; !ok {
+		t.Errorf("connected_components should have failed (no src column): %+v", resp.AnalyticsErrors)
+	}
+}
+
+func TestQuery_PreservesPartialAndStats(t *testing.T) {
+	// queryResponse must be a strict superset of router.Result. We can't
+	// easily induce a partial result in a unit test, but we can at least
+	// assert the embedded fields are reachable on the decoded response,
+	// proving the wire shape carries them.
+	srv := setupAnalyticsServer(t)
+	w, resp := postQuery(t, srv, `{"cypher":"MATCH (n) RETURN n"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if resp.Result == nil {
+		t.Fatalf("expected embedded *router.Result on response")
+	}
+	if len(resp.Columns) == 0 {
+		t.Errorf("expected promoted Columns from embedded Result")
+	}
+	// Partial/Errors are omitempty zero values; the field is reachable
+	// even when absent from the wire.
+	_ = resp.Partial
+	_ = resp.Errors
+}
+
 func TestQuery_UnknownPluginIsolated(t *testing.T) {
 	srv := setupAnalyticsServer(t)
 	body := `{"cypher":"MATCH (n) RETURN n","analytics":[{"name":"nope"}]}`

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -110,9 +110,11 @@ func defaultAnalyticsRegistry() *analytics.Registry {
 	return reg
 }
 
-// RegisterAnalyticsPlugin registers an additional plugin at runtime.
-// Intended for cmd/server wire-up of out-of-tree plugins (e.g. a real
-// Leiden binding) before Handler() is called. Returns an error on
+// RegisterAnalyticsPlugin registers an additional plugin. The registry
+// is concurrency-safe so this is technically callable at any time, but
+// callers should register before the server begins accepting requests
+// — otherwise there is a window in which clients can hit /analytics or
+// POST /db/{name}/query and not see the plugin. Returns an error on
 // duplicate Name().
 func (s *Server) RegisterAnalyticsPlugin(p analytics.Plugin) error {
 	return s.analytics.Register(p)

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -720,12 +720,15 @@ type queryRequest struct {
 	Analytics []analytics.Request `json:"analytics,omitempty"`
 }
 
-// queryResponse mirrors the cypher result, with an extra analytics block.
-// `analytics_errors` is per-plugin so one bad plugin can't poison the
-// rest of the response — clients should always consult both maps.
+// queryResponse embeds the full cypher result (columns, rows, partial,
+// errors, stats — see router.Result) and adds the analytics block on
+// top. analytics_errors is per-plugin so one bad plugin can't poison
+// the rest of the response — clients should always consult both maps.
+//
+// Embedding *router.Result keeps this endpoint a strict superset of
+// /db/{name}/cypher: nothing the cypher endpoint returns is dropped here.
 type queryResponse struct {
-	Columns         []string          `json:"columns"`
-	Rows            []map[string]any  `json:"rows"`
+	*router.Result
 	Analytics       map[string]any    `json:"analytics,omitempty"`
 	AnalyticsErrors map[string]string `json:"analytics_errors,omitempty"`
 }
@@ -790,7 +793,7 @@ func (s *Server) handleQuery(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	resp := queryResponse{Columns: result.Columns, Rows: result.Rows}
+	resp := queryResponse{Result: result}
 	if len(req.Analytics) > 0 {
 		out, errs := s.analytics.Run(ctx, result, req.Analytics)
 		if len(out) > 0 {

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -14,6 +14,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/johnjansen/loveliness/pkg/analytics"
+	"github.com/johnjansen/loveliness/pkg/analytics/plugins"
 	"github.com/johnjansen/loveliness/pkg/auth"
 	"github.com/johnjansen/loveliness/pkg/cluster"
 	"github.com/johnjansen/loveliness/pkg/ingest"
@@ -67,6 +69,11 @@ type Server struct {
 	// bulkLoadCounters tracks rows ingested via /bulk/* endpoints,
 	// labeled by table, for the loveliness_bulk_load_rows_total metric.
 	bulkLoadCounters *bulkLoadCounters
+
+	// analytics is the registry of opt-in, post-execution plugins that run
+	// against a Cypher Result when the client hits POST /db/{name}/query
+	// with an analytics[] selector. Plugins register at boot.
+	analytics *analytics.Registry
 }
 
 // NewServer creates a new API server.
@@ -83,7 +90,32 @@ func NewServer(r *router.Router, c *cluster.Cluster, shards []*shard.Shard, reg 
 		queryCounters:    newQueryCounters(),
 		queryHistogram:   newQueryHistogram(),
 		bulkLoadCounters: newBulkLoadCounters(),
+		analytics:        defaultAnalyticsRegistry(),
 	}
+}
+
+// defaultAnalyticsRegistry returns the registry the server boots with —
+// the built-in plugins shipped in pkg/analytics/plugins. Registration is
+// fail-fast: a duplicate Name() at this layer is a programming error.
+func defaultAnalyticsRegistry() *analytics.Registry {
+	reg := analytics.NewRegistry()
+	for _, p := range []analytics.Plugin{
+		plugins.CountByLabel{},
+		plugins.ConnectedComponents{},
+	} {
+		if err := reg.Register(p); err != nil {
+			panic(fmt.Sprintf("analytics: register %q: %v", p.Name(), err))
+		}
+	}
+	return reg
+}
+
+// RegisterAnalyticsPlugin registers an additional plugin at runtime.
+// Intended for cmd/server wire-up of out-of-tree plugins (e.g. a real
+// Leiden binding) before Handler() is called. Returns an error on
+// duplicate Name().
+func (s *Server) RegisterAnalyticsPlugin(p analytics.Plugin) error {
+	return s.analytics.Register(p)
 }
 
 type contextKey string
@@ -120,6 +152,11 @@ func (s *Server) Handler() http.Handler {
 	protected.HandleFunc("POST /db/{name}/cypher", s.handleCypherScoped)
 	protected.HandleFunc("POST /db/{name}/bulk/nodes", s.handleBulkNodesScoped)
 	protected.HandleFunc("POST /db/{name}/bulk/edges", s.handleBulkEdgesScoped)
+
+	// Analytics: cypher + opt-in post-execution plugins, JSON envelope.
+	// Strict superset of POST /db/{name}/cypher — analytics[] is optional.
+	protected.HandleFunc("POST /db/{name}/query", s.handleQuery)
+	protected.HandleFunc("GET /analytics", s.handleAnalyticsList)
 
 	// Admin endpoint (not db-scoped) for CREATE/STOP/START/DROP DATABASE, SHOW DATABASES.
 	protected.HandleFunc("POST /admin/cypher", s.handleAdminCypher)
@@ -673,6 +710,103 @@ func (s *Server) handleCypherScoped(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, result)
+}
+
+// queryRequest is the JSON envelope for POST /db/{name}/query.
+// `cypher` is required; `analytics` is optional. Empty `analytics`
+// makes this endpoint a strict superset of /db/{name}/cypher.
+type queryRequest struct {
+	Cypher    string              `json:"cypher"`
+	Analytics []analytics.Request `json:"analytics,omitempty"`
+}
+
+// queryResponse mirrors the cypher result, with an extra analytics block.
+// `analytics_errors` is per-plugin so one bad plugin can't poison the
+// rest of the response — clients should always consult both maps.
+type queryResponse struct {
+	Columns         []string          `json:"columns"`
+	Rows            []map[string]any  `json:"rows"`
+	Analytics       map[string]any    `json:"analytics,omitempty"`
+	AnalyticsErrors map[string]string `json:"analytics_errors,omitempty"`
+}
+
+// handleQuery is the JSON-envelope sibling of handleCypherScoped: cypher
+// runs through the same dbRouter, then any requested analytics plugins
+// post-process the Result. The wire format is the design coming out of
+// spike/analytics-plugin-poc; see issue #62 for the promotion checklist.
+func (s *Server) handleQuery(w http.ResponseWriter, r *http.Request) {
+	dbName := r.PathValue("name")
+	if dbName == "" {
+		writeError(w, http.StatusBadRequest, "BAD_REQUEST", "database name required in path", 0)
+		return
+	}
+	if s.dbRouter == nil {
+		writeError(w, http.StatusServiceUnavailable, "NO_MULTI_DB", "multi-database not enabled", 0)
+		return
+	}
+
+	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "BAD_REQUEST", "cannot read body: "+err.Error(), 0)
+		return
+	}
+	var req queryRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		writeError(w, http.StatusBadRequest, "BAD_JSON", err.Error(), 0)
+		return
+	}
+	cypher := strings.TrimSpace(req.Cypher)
+	if cypher == "" {
+		writeError(w, http.StatusBadRequest, "BAD_REQUEST", "missing cypher", 0)
+		return
+	}
+	if router.IsAdminCommand(cypher) {
+		writeError(w, http.StatusBadRequest, "BAD_REQUEST",
+			"admin commands must use POST /admin/cypher", 0)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), s.timeout)
+	defer cancel()
+
+	result, err := s.dbRouter.Execute(ctx, dbName, cypher)
+	if err != nil {
+		if qe, ok := err.(*router.QueryError); ok {
+			status := http.StatusInternalServerError
+			switch qe.Code {
+			case "CYPHER_PARSE_ERROR", "MISSING_SHARD_KEY":
+				status = http.StatusBadRequest
+			case "DATABASE_ERROR":
+				status = http.StatusNotFound
+			case "SHARD_UNAVAILABLE":
+				status = http.StatusServiceUnavailable
+			case "QUERY_TIMEOUT":
+				status = http.StatusGatewayTimeout
+			}
+			writeError(w, status, qe.Code, qe.Message, qe.ShardID)
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", err.Error(), 0)
+		return
+	}
+
+	resp := queryResponse{Columns: result.Columns, Rows: result.Rows}
+	if len(req.Analytics) > 0 {
+		out, errs := s.analytics.Run(ctx, result, req.Analytics)
+		if len(out) > 0 {
+			resp.Analytics = out
+		}
+		if len(errs) > 0 {
+			resp.AnalyticsErrors = errs
+		}
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// handleAnalyticsList returns the names of registered analytics plugins.
+// Useful as a discovery endpoint for clients building UI around them.
+func (s *Server) handleAnalyticsList(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusOK, map[string]any{"plugins": s.analytics.Names()})
 }
 
 // handleBulkNodesScoped routes bulk node loading to a specific database.

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -158,7 +158,6 @@ func (s *Server) Handler() http.Handler {
 	// Analytics: cypher + opt-in post-execution plugins, JSON envelope.
 	// Strict superset of POST /db/{name}/cypher — analytics[] is optional.
 	protected.HandleFunc("POST /db/{name}/query", s.handleQuery)
-	protected.HandleFunc("GET /analytics", s.handleAnalyticsList)
 
 	// Admin endpoint (not db-scoped) for CREATE/STOP/START/DROP DATABASE, SHOW DATABASES.
 	protected.HandleFunc("POST /admin/cypher", s.handleAdminCypher)
@@ -170,6 +169,9 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("GET /health/ready", s.handleHealthReady)
 	mux.HandleFunc("GET /discovery", s.handleDiscovery)
 	mux.HandleFunc("GET /metrics", s.handleMetrics)
+	// Plugin directory is a discovery endpoint — public, like /discovery.
+	// Returns only plugin names (no graph data, no auth context).
+	mux.HandleFunc("GET /analytics", s.handleAnalyticsList)
 	if s.auth != nil && s.auth.Enabled() {
 		mux.Handle("/", s.auth.Middleware(protected))
 	} else {


### PR DESCRIPTION
## Summary

Promotes the analytics plugin system out of `spike/analytics-plugin-poc/` and into production. Adds two new routes alongside the existing cypher routes — no changes to `/cypher` or `/db/{name}/cypher`.

- `POST /db/{name}/query` — cypher with opt-in post-execution plugins, JSON envelope
- `GET /analytics` — plugin directory

Two built-ins ship registered: `count_by_label` (trivial) and `connected_components` (graph-shape, Leiden stand-in). Out-of-tree plugins (e.g. a real Leiden binding later) can register via `Server.RegisterAnalyticsPlugin` before `Handler()` is called.

Closes the move-and-wire steps of the promotion checklist on #62. Leiden plugin, lifecycle decision, and metrics are still open as separate follow-ups.

## What's where

| | |
|---|---|
| `pkg/analytics/analytics.go` | `Plugin` interface + `Registry` (thread-safe) |
| `pkg/analytics/plugins/` | `count_by_label`, `connected_components` |
| `pkg/api/api.go` | new routes, handlers, `defaultAnalyticsRegistry` boot wire |
| `pkg/api/analytics_test.go` | handler-level integration with real `DatabaseRouter` |
| `pkg/analytics/*_test.go` | unit tests for registry + plugins |

The spike directory (`spike/analytics-plugin-poc/`) is left in place as historical record — README/RESEARCH/FINDINGS still capture the decision trail. A follow-up can remove it once this lands.

## Test plan

- [x] \`go build ./...\` — clean
- [x] \`go vet ./...\` — clean
- [x] \`go test ./...\` — full suite green (no regressions on existing tests)
- [x] New tests cover: cypher-only superset behaviour, unknown-plugin isolation, per-plugin error isolation, bad JSON, missing cypher, admin-command rejection, missing dbRouter, plugin directory

## Wire format (unchanged from spike)

\`\`\`http
POST /db/main/query
{
  "cypher": "MATCH (s)-[:KNOWS]->(d) RETURN s.id AS src, d.id AS dst",
  "analytics": [
    {"name": "connected_components"},
    {"name": "count_by_label", "params": {"column": "src"}}
  ]
}
\`\`\`

\`\`\`json
{
  "columns": ["src", "dst"],
  "rows": [...],
  "analytics": {
    "connected_components": {...},
    "count_by_label": {...}
  },
  "analytics_errors": {}
}
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)