### PR TITLE
feat(router): retry transient remote errors with jittered backoff (#6)

### DIFF
--- a/pkg/router/retry.go
+++ b/pkg/router/retry.go
@@ -1,0 +1,149 @@
+package router
+
+import (
+	"context"
+	"errors"
+	"io"
+	"math/rand"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/johnjansen/loveliness/pkg/shard"
+)
+
+// Retry policy for remote shard RPCs.
+//
+// The router treats only transient transport-layer faults as
+// retryable: a peer that's restarting, a TCP frame interrupted
+// mid-flight, a connection refused while a node finishes booting.
+// Anything that looks like a protocol error or a query error is
+// surfaced immediately — retrying those would just multiply the
+// blast radius of a deterministic failure.
+//
+// The cap is small on purpose: 2 retries with jittered backoff is
+// enough to ride out a single restart or a brief network blip and
+// short enough that a sustained outage still surfaces in the
+// per-shard error within the scatter timeout. A user that needs
+// stronger SLAs can raise it via SetRemoteRetries.
+
+// defaultRemoteRetries is the spec-stated cap from #6.
+const defaultRemoteRetries = 2
+
+// defaultRemoteRetryBackoff is the base delay between retries. The
+// real delay is jittered to avoid thundering-herd patterns when many
+// shards on the same peer all retry at once.
+const defaultRemoteRetryBackoff = 25 * time.Millisecond
+
+// isRetryableRemoteError reports whether err describes a transient
+// transport fault that's worth retrying. The check is structural —
+// errors.Is / errors.As / type assertions on the unwrap chain — so
+// it survives the transport layer wrapping errors with fmt.Errorf
+// %w. We deliberately do not match on substrings: error messages
+// drift between Go versions, but the underlying types do not.
+func isRetryableRemoteError(err error) bool {
+	if err == nil {
+		return false
+	}
+	// Context cancel is a caller signal, not a transport fault — never
+	// retry it.
+	if errors.Is(err, context.Canceled) {
+		return false
+	}
+	// Deadline exceeded on a per-call basis is a hint that the peer is
+	// slow; one retry can ride out a brief stall.
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	// Mid-frame EOFs and unexpected EOFs are the canonical
+	// "connection died while we were reading" signals.
+	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+		return true
+	}
+	// Timeout on a net.Op (dial, read, write).
+	var ne net.Error
+	if errors.As(err, &ne) && ne.Timeout() {
+		return true
+	}
+	// "Connection refused" / "connection reset" / "broken pipe" all
+	// surface as syscall errors wrapped in *net.OpError. We don't
+	// reach into the syscall package because the constants are
+	// platform-specific; the message form is stable enough across
+	// Linux/macOS/BSD that a single substring check is acceptable
+	// for this narrow case (only matched after we've already
+	// confirmed the error is a net.OpError, so we won't false-
+	// positive on unrelated strings).
+	var op *net.OpError
+	if errors.As(err, &op) {
+		msg := op.Err.Error()
+		switch {
+		case strings.Contains(msg, "connection refused"),
+			strings.Contains(msg, "connection reset"),
+			strings.Contains(msg, "broken pipe"):
+			return true
+		}
+	}
+	return false
+}
+
+// retryRemoteCall invokes fn up to maxRetries+1 times, sleeping a
+// jittered backoff between attempts when fn returns a retryable
+// error. Non-retryable errors short-circuit immediately. The result
+// of the final attempt — whether success or failure — is returned
+// to the caller.
+//
+// fn should not internally retry; this is the only retry layer for
+// remote calls. Layered retries silently amplify load on a flapping
+// peer.
+func retryRemoteCall(
+	ctx context.Context,
+	maxRetries int,
+	baseBackoff time.Duration,
+	fn func() (*shard.QueryResponse, error),
+) (*shard.QueryResponse, error) {
+	if maxRetries < 0 {
+		maxRetries = 0
+	}
+	var lastErr error
+	for attempt := 0; attempt <= maxRetries; attempt++ {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		resp, err := fn()
+		if err == nil {
+			return resp, nil
+		}
+		if !isRetryableRemoteError(err) {
+			return nil, err
+		}
+		lastErr = err
+		if attempt == maxRetries {
+			break // out of retries; surface the last error below
+		}
+		// Jittered backoff: base * 2^attempt with ±50% jitter. Caps
+		// the worst case for maxRetries=2 at ~1.5 * base + 3 * base
+		// = 4.5 * base, which at 25ms is well under any sane scatter
+		// timeout but long enough to ride out a quick restart.
+		delay := backoffFor(baseBackoff, attempt)
+		select {
+		case <-time.After(delay):
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+	return nil, lastErr
+}
+
+// backoffFor returns base * 2^attempt with ±50% jitter. Attempt is
+// 0-indexed; attempt=0 yields base ± 50%.
+func backoffFor(base time.Duration, attempt int) time.Duration {
+	if attempt < 0 {
+		attempt = 0
+	}
+	mult := time.Duration(1) << uint(attempt)
+	scaled := base * mult
+	// ±50% jitter via rand. The package-level rand is fine — we just
+	// want enough spread to break thundering-herd patterns.
+	jitter := time.Duration(rand.Int63n(int64(scaled)+1)) - scaled/2
+	return scaled + jitter
+}

--- a/pkg/router/retry_test.go
+++ b/pkg/router/retry_test.go
@@ -1,0 +1,218 @@
+package router
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/johnjansen/loveliness/pkg/shard"
+)
+
+// flakyRemote is a RemoteQuerier that fails the first n calls with a
+// supplied error, then succeeds on every subsequent call. Used to
+// exercise the retry loop without needing a real network failure.
+type flakyRemote struct {
+	failures int32 // remaining failures to inject (atomic)
+	err      error
+	calls    int32
+	resp     *shard.QueryResponse
+}
+
+func (f *flakyRemote) QueryRemoteShard(_ string, _ int, _ string) (*shard.QueryResponse, error) {
+	atomic.AddInt32(&f.calls, 1)
+	if atomic.AddInt32(&f.failures, -1) >= 0 {
+		return nil, f.err
+	}
+	if f.resp == nil {
+		return &shard.QueryResponse{Columns: []string{"x"}, Rows: []map[string]any{{"x": 1}}}, nil
+	}
+	return f.resp, nil
+}
+
+func (f *flakyRemote) Calls() int { return int(atomic.LoadInt32(&f.calls)) }
+
+// dial-error fixture: net.OpError wrapping a "connection refused"
+// message — what the real transport emits when a peer is down.
+func connRefusedErr() error {
+	return &net.OpError{
+		Op:  "dial",
+		Net: "tcp",
+		Err: errors.New("connection refused"),
+	}
+}
+
+func TestIsRetryableRemoteError_Classification(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"context canceled", context.Canceled, false},
+		{"context wrapped canceled", fmt.Errorf("forward: %w", context.Canceled), false},
+		{"deadline exceeded", context.DeadlineExceeded, true},
+		{"deadline wrapped", fmt.Errorf("forward to peer: %w", context.DeadlineExceeded), true},
+		{"io.EOF", io.EOF, true},
+		{"io.ErrUnexpectedEOF wrapped", fmt.Errorf("read frame: %w", io.ErrUnexpectedEOF), true},
+		{"connection refused", connRefusedErr(), true},
+		{"connection refused wrapped", fmt.Errorf("forward: %w", connRefusedErr()), true},
+		{"plain bug", errors.New("unmarshal failed"), false},
+		{"protocol error", errors.New("remote shard error: invalid query"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isRetryableRemoteError(tc.err); got != tc.want {
+				t.Errorf("isRetryableRemoteError(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRetryRemoteCall_SucceedsWithinBudget(t *testing.T) {
+	// Two transient failures, then success on the third attempt.
+	// maxRetries=2 ⇒ 3 attempts total ⇒ should succeed.
+	fr := &flakyRemote{failures: 2, err: io.ErrUnexpectedEOF}
+	resp, err := retryRemoteCall(context.Background(), 2, time.Microsecond, func() (*shard.QueryResponse, error) {
+		return fr.QueryRemoteShard("peer", 0, "q")
+	})
+	if err != nil {
+		t.Fatalf("expected success after 2 retries, got %v", err)
+	}
+	if resp == nil {
+		t.Fatal("nil response on success")
+	}
+	if fr.Calls() != 3 {
+		t.Errorf("attempts = %d, want 3 (initial + 2 retries)", fr.Calls())
+	}
+}
+
+func TestRetryRemoteCall_ExhaustsBudget(t *testing.T) {
+	// Three transient failures, maxRetries=2 ⇒ 3 attempts ⇒ surfaces error.
+	fr := &flakyRemote{failures: 3, err: io.ErrUnexpectedEOF}
+	_, err := retryRemoteCall(context.Background(), 2, time.Microsecond, func() (*shard.QueryResponse, error) {
+		return fr.QueryRemoteShard("peer", 0, "q")
+	})
+	if err == nil {
+		t.Fatal("expected error after exhausted retries, got nil")
+	}
+	if !errors.Is(err, io.ErrUnexpectedEOF) {
+		t.Errorf("expected last-attempt error to surface, got %v", err)
+	}
+	if fr.Calls() != 3 {
+		t.Errorf("attempts = %d, want 3", fr.Calls())
+	}
+}
+
+func TestRetryRemoteCall_NonRetryableShortCircuits(t *testing.T) {
+	// A plain bug should never retry. fr is set up so a retry would
+	// succeed; we want to prove no retry happens.
+	fr := &flakyRemote{failures: 1, err: errors.New("malformed response")}
+	_, err := retryRemoteCall(context.Background(), 5, time.Microsecond, func() (*shard.QueryResponse, error) {
+		return fr.QueryRemoteShard("peer", 0, "q")
+	})
+	if err == nil {
+		t.Fatal("expected non-retryable error to surface, got nil")
+	}
+	if fr.Calls() != 1 {
+		t.Errorf("non-retryable should short-circuit at 1 attempt, got %d", fr.Calls())
+	}
+}
+
+func TestRetryRemoteCall_ZeroRetriesIsSingleAttempt(t *testing.T) {
+	// maxRetries=0 ⇒ exactly one attempt (no retries).
+	fr := &flakyRemote{failures: 1, err: io.ErrUnexpectedEOF}
+	_, err := retryRemoteCall(context.Background(), 0, time.Microsecond, func() (*shard.QueryResponse, error) {
+		return fr.QueryRemoteShard("peer", 0, "q")
+	})
+	if err == nil {
+		t.Fatal("expected single attempt to fail, got nil")
+	}
+	if fr.Calls() != 1 {
+		t.Errorf("attempts = %d, want 1 (no retries)", fr.Calls())
+	}
+}
+
+func TestRetryRemoteCall_HonorsContextCancel(t *testing.T) {
+	// Cancel the context mid-loop; the retry must abort and surface
+	// the cancel error rather than the retryable error.
+	fr := &flakyRemote{failures: 100, err: io.ErrUnexpectedEOF}
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(2 * time.Millisecond)
+		cancel()
+	}()
+	_, err := retryRemoteCall(ctx, 1000, 5*time.Millisecond, func() (*shard.QueryResponse, error) {
+		return fr.QueryRemoteShard("peer", 0, "q")
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+}
+
+// TestRouter_RemoteRetry_EndToEnd is the integration-flavored check:
+// configure the router with retries and a flaky remote, prove the
+// scatter result eventually succeeds despite transport flapping.
+func TestRouter_RemoteRetry_EndToEnd(t *testing.T) {
+	const shardCount = 4
+	r := NewRouter(make([]*shard.Shard, shardCount), 2*time.Second)
+
+	fr := &flakyRemote{failures: int32(shardCount), err: io.ErrUnexpectedEOF}
+	r.SetRemoteTransport("local", fr, allRemotePlacement{})
+	r.SetRemoteRetryBackoff(time.Microsecond) // race-free fast retries
+
+	res, err := r.Execute(context.Background(), "MATCH (n) RETURN n")
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if res == nil {
+		t.Fatal("nil result")
+	}
+	// Each shard fails once and then succeeds on retry, so total calls
+	// should be 2*shardCount and Partial should be false.
+	if res.Partial {
+		t.Errorf("expected non-partial result after successful retries, got %+v", res)
+	}
+	if got, want := fr.Calls(), 2*shardCount; got != want {
+		t.Errorf("total remote attempts = %d, want %d (each shard once-failed, once-retried)", got, want)
+	}
+}
+
+// TestRouter_RemoteRetry_Disabled confirms the SetRemoteRetries(0)
+// override produces single-attempt behavior — the failure surfaces
+// as a partial result on the first call, no retries.
+func TestRouter_RemoteRetry_Disabled(t *testing.T) {
+	const shardCount = 2
+	r := NewRouter(make([]*shard.Shard, shardCount), 2*time.Second)
+
+	fr := &flakyRemote{failures: int32(shardCount), err: io.ErrUnexpectedEOF}
+	r.SetRemoteTransport("local", fr, allRemotePlacement{})
+	r.SetRemoteRetries(0) // override the auto-installed default
+	r.SetRemoteRetryBackoff(time.Microsecond)
+
+	res, _ := r.Execute(context.Background(), "MATCH (n) RETURN n")
+	if res == nil {
+		t.Fatal("nil result")
+	}
+	if !res.Partial {
+		t.Error("expected Partial=true with retries disabled and a failing remote")
+	}
+	if got, want := fr.Calls(), shardCount; got != want {
+		t.Errorf("attempts with retries=0 = %d, want %d (one per shard, no retries)", got, want)
+	}
+}
+
+func TestSetRemoteTransport_DefaultsRetryConfig(t *testing.T) {
+	r := NewRouter(make([]*shard.Shard, 4), time.Second)
+	r.SetRemoteTransport("local", &flakyRemote{}, allRemotePlacement{})
+	if r.remoteRetries != defaultRemoteRetries {
+		t.Errorf("remoteRetries default = %d, want %d", r.remoteRetries, defaultRemoteRetries)
+	}
+	if r.remoteRetryBackoff != defaultRemoteRetryBackoff {
+		t.Errorf("remoteRetryBackoff default = %v, want %v", r.remoteRetryBackoff, defaultRemoteRetryBackoff)
+	}
+}

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -89,6 +89,18 @@ type Router struct {
 	// to max(8, 2*shardCount) per the #6 spec. SetScatterConcurrency
 	// is the configuration knob.
 	scatterConcurrency int
+
+	// remoteRetries caps the number of additional attempts after a
+	// transient remote-call failure. Only transport-layer faults
+	// (timeouts, EOF mid-frame, connection refused) trigger retries —
+	// protocol or query errors short-circuit immediately. Default = 2
+	// per the #6 spec; SetRemoteRetries is the knob.
+	remoteRetries int
+
+	// remoteRetryBackoff is the base delay between retries. Jittered
+	// at use-site to break thundering-herd patterns. Tests set it
+	// short to race against the scatter timeout.
+	remoteRetryBackoff time.Duration
 }
 
 // DDLHook is called when a DDL statement registers or removes a table.
@@ -207,12 +219,13 @@ func (r *Router) SetDDLHook(h DDLHook) {
 
 // SetRemoteTransport configures distributed query routing to remote shards.
 //
-// Wiring remote transport also installs a sensible scatter-concurrency
-// cap if the caller hasn't set one yet. The default — max(8,
-// 2*shardCount) — matches the #6 spec and keeps the fan-out finite when
+// Wiring remote transport also installs sensible defaults for the
+// scatter-concurrency cap (max(8, 2*shardCount)), the retry count
+// (2), and the retry backoff (25ms). These match the #6 spec and
+// keep the fan-out finite + the per-shard retry budget bounded when
 // a deployment has more shards than the connection pool can sustain.
-// Callers that want a different value can call SetScatterConcurrency
-// after this.
+// Callers that want different values can call SetScatterConcurrency,
+// SetRemoteRetries, or SetRemoteRetryBackoff after this.
 func (r *Router) SetRemoteTransport(nodeID string, remote RemoteQuerier, placement PlacementResolver) {
 	r.nodeID = nodeID
 	r.remote = remote
@@ -220,6 +233,29 @@ func (r *Router) SetRemoteTransport(nodeID string, remote RemoteQuerier, placeme
 	if r.scatterConcurrency == 0 {
 		r.scatterConcurrency = defaultScatterConcurrency(r.shardCount)
 	}
+	if r.remoteRetries == 0 {
+		r.remoteRetries = defaultRemoteRetries
+	}
+	if r.remoteRetryBackoff == 0 {
+		r.remoteRetryBackoff = defaultRemoteRetryBackoff
+	}
+}
+
+// SetRemoteRetries sets the maximum number of additional attempts
+// per transient remote-call failure. n=0 disables retries; matches
+// the legacy single-attempt behavior. n>0 enables jittered retries.
+func (r *Router) SetRemoteRetries(n int) {
+	if n < 0 {
+		n = 0
+	}
+	r.remoteRetries = n
+}
+
+// SetRemoteRetryBackoff sets the base delay between retry attempts.
+// Tests set it short (e.g. 1ms) so retries don't dominate test time;
+// production should leave it at the default 25ms.
+func (r *Router) SetRemoteRetryBackoff(d time.Duration) {
+	r.remoteRetryBackoff = d
 }
 
 // SetScatterConcurrency sets the upper bound on parallel per-shard
@@ -246,6 +282,12 @@ func defaultScatterConcurrency(shardCount int) int {
 
 // queryShardRaw queries a shard and returns the raw QueryResponse.
 // Used by scatterGather which needs raw responses for merging.
+//
+// Local shards execute synchronously — no retry, since a panic /
+// CGo crash inside the local shard is a different failure model
+// (handled by panic recovery in shard.Query). Remote shards run
+// through retryRemoteCall, which retries transient transport
+// faults up to r.remoteRetries times with jittered backoff.
 func (r *Router) queryShardRaw(shardID int, cypher string) (*shard.QueryResponse, error) {
 	// Fast path: local shard.
 	if shardID >= 0 && shardID < len(r.shards) && r.shards[shardID] != nil {
@@ -259,7 +301,16 @@ func (r *Router) queryShardRaw(shardID int, cypher string) (*shard.QueryResponse
 	if nodeID == "" {
 		return nil, fmt.Errorf("shard %d has no assigned primary", shardID)
 	}
-	return r.remote.QueryRemoteShard(nodeID, shardID, cypher)
+	// retryRemoteCall handles its own bounds checking; if retries are
+	// disabled it does exactly one attempt.
+	return retryRemoteCall(
+		context.Background(),
+		r.remoteRetries,
+		r.remoteRetryBackoff,
+		func() (*shard.QueryResponse, error) {
+			return r.remote.QueryRemoteShard(nodeID, shardID, cypher)
+		},
+	)
 }
 
 // replicateDDL sends schema changes to the DDL hook for Raft replication.


### PR DESCRIPTION
## Summary

Polish slice 2 of 5 for #6 — replaces the single-shot remote call with a bounded, jittered retry loop. Previously any remote-shard failure became a per-shard error on the first attempt, even when the failure was a transient blip the peer would recover from in milliseconds (a TCP reset during a node restart, EOF mid-frame on a flapping link, ephemeral connection refused while a peer comes up).

## Behavior

- **Structural error classification** — \`errors.Is\` / \`errors.As\` on the unwrap chain. No substring matching on volatile messages. Retryable: \`context.DeadlineExceeded\`, \`io.EOF\`, \`io.ErrUnexpectedEOF\`, \`net.Error.Timeout()\`, \`*net.OpError\` whose \`Op.Err\` mentions connection refused / reset / broken pipe.
- **Non-retryable short-circuit** — protocol errors, query errors, marshal/unmarshal failures, \`context.Canceled\` all surface on the first attempt.
- **Bounded budget** — default 2 retries with 25ms jittered base backoff (\`base * 2^attempt\` ± 50%). Auto-installed by \`SetRemoteTransport\`. Knobs: \`SetRemoteRetries(n)\`, \`SetRemoteRetryBackoff(d)\`.
- **Local shards unaffected** — local panics ride the existing recover path in \`shard.Query\`; the retry loop only wraps the remote dispatch.

## Test plan

- [x] \`TestIsRetryableRemoteError_Classification\` — 11-case matrix: nil, context cancel/deadline (wrapped + raw), io.EOF / ErrUnexpectedEOF, conn refused (wrapped + raw), plain bug, protocol error
- [x] \`TestRetryRemoteCall_SucceedsWithinBudget\` — 2 failures, then success on retry 2
- [x] \`TestRetryRemoteCall_ExhaustsBudget\` — 3 failures, error surfaces with \`errors.Is\` chain intact
- [x] \`TestRetryRemoteCall_NonRetryableShortCircuits\` — 1 attempt, no retries
- [x] \`TestRetryRemoteCall_ZeroRetriesIsSingleAttempt\` — legacy behavior preserved
- [x] \`TestRetryRemoteCall_HonorsContextCancel\` — cancel mid-loop aborts and surfaces \`context.Canceled\`
- [x] \`TestRouter_RemoteRetry_EndToEnd\` — 4-shard scatter against a flaky remote, succeeds non-partial
- [x] \`TestRouter_RemoteRetry_Disabled\` — \`SetRemoteRetries(0)\` reproduces single-attempt path
- [x] \`TestSetRemoteTransport_DefaultsRetryConfig\` — wiring side-effect installs both default count and backoff
- [x] \`go test -race ./pkg/router/\` clean
- [x] \`go test ./...\` clean

## Related

- Issue #6 (cross-node scatter-gather, polish slice 2 of 5)
- PR #65 (slice 1: bounded concurrency, merged)
- Spike #64 tracks the deferred transport-architecture review

🤖 Generated with [Claude Code](https://claude.com/claude-code)