### PR TITLE
feat(router): per-shard remote RTT, errors, bloom-skip metrics (#6)

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -32,6 +32,9 @@ explicitly here, not by collector defaults.
 | `loveliness_replication_lag_entries` | gauge | `shard_id`, `replica_id` | ≤ 256 × RF |
 | `loveliness_replication_lag_bytes` | gauge | `shard_id`, `replica_id` | ≤ 256 × RF |
 | `loveliness_replication_lag_seconds` | gauge | `shard_id`, `replica_id` | ≤ 256 × RF |
+| `loveliness_router_remote_rtt_seconds` | histogram | `shard_id` | ≤ 256 × (14 buckets + `_sum` + `_count` + `+Inf`) ≈ **4 352** |
+| `loveliness_router_remote_errors_total` | counter | `code` | ≤ 7 (closed set) |
+| `loveliness_router_bloom_skip_total` | counter | `shard_id` | ≤ 256 |
 | `loveliness_go_goroutines` | gauge | — | 1 |
 | `loveliness_go_memstats_alloc_bytes` | gauge | — | 1 |
 | `loveliness_go_memstats_sys_bytes` | gauge | — | 1 |
@@ -50,11 +53,14 @@ query_duration       ≈ 256
 bulk_load_rows_total ≤ 200
 wal_head_sequence    ≤ 256
 replication_lag × 3  ≤ 256 × 3 × 3 = 2304
+router_remote_rtt    ≤ 256 × 17 ≈ 4 352
+router_remote_errors ≤ 7
+router_bloom_skip    ≤ 256
 ─────────────────────
-total                ≲ 3 100
+total                ≲ 7 700
 ```
 
-That leaves ~7 000 of headroom under the 10 000 budget for additional
+That leaves ~2 300 of headroom under the 10 000 budget for additional
 per-shard gauges (e.g. RSS, vertex/edge count) when those land.
 
 ## Label values
@@ -91,6 +97,15 @@ plan. Bounded by `RF × shard_count`.
 Catalogued node/edge table name. Cardinality is bounded by the schema —
 production deployments typically have ≤ ~200 tables.
 
+### `code` (router remote error, closed set ≤ 7)
+
+`timeout` · `canceled` · `conn_refused` · `conn_reset` · `broken_pipe` ·
+`eof` · `other`. Computed by `classifyRemoteError` in
+`pkg/router/metrics.go` from the unwrap chain of the transport error
+(`errors.Is`, `errors.As` on `*net.OpError`). The `other` bucket
+collapses every protocol/query error into a single label so a flood of
+unique error strings can't blow up the scrape.
+
 ## Histogram buckets
 
 `loveliness_query_duration_seconds` uses these upper bounds (seconds):
@@ -103,6 +118,18 @@ production deployments typically have ≤ ~200 tables.
 Aligned with the Loveliness latency targets — most reads sit in the
 first six buckets, most writes in the next three; the long tail covers
 slow scans without burning a bucket on every order of magnitude.
+
+`loveliness_router_remote_rtt_seconds` uses these upper bounds (seconds):
+
+```
+0.00025, 0.0005, 0.001, 0.0025, 0.005, 0.01,
+0.025,   0.05,   0.1,   0.25,   0.5,   1.0, 2.5, 5.0
+```
+
+The lower end (250 µs) covers in-process loopback (single-host
+multi-shard); the upper end (5 s) brackets the worst-case scatter
+timeout. Widened compared to the query histogram because cross-node
+latency has a longer tail than local execution.
 
 ## Adding a new metric
 

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/johnjansen/loveliness/pkg/router"
 	"github.com/johnjansen/loveliness/pkg/shard"
 )
 
@@ -96,6 +97,10 @@ func writeMetrics(w io.Writer, s *Server) {
 		writeBulkLoadMetrics(w, s.bulkLoadCounters.Snapshot())
 	}
 
+	if s.router != nil {
+		writeRouterMetrics(w, s.router.Metrics().Snapshot())
+	}
+
 	if s.dr == nil || s.dr.WAL == nil {
 		return
 	}
@@ -119,6 +124,51 @@ func writeMetrics(w io.Writer, s *Server) {
 	}
 
 	writeWALMetrics(w, s.dr.WAL, shardIDs, s.dr.ReplicaState, pairs)
+}
+
+// writeRouterMetrics emits the three series owned by the router's
+// observability primitives:
+//
+//	loveliness_router_remote_rtt_seconds{shard_id}    histogram
+//	loveliness_router_remote_errors_total{code}       counter
+//	loveliness_router_bloom_skip_total{shard_id}      counter
+//
+// Each section guards on a non-empty snapshot so series only appear
+// once they've been observed at least once — matching the lazy-
+// creation semantics the rest of /metrics already uses.
+func writeRouterMetrics(w io.Writer, snap router.RouterMetricsSnapshot) {
+	if len(snap.RTT) > 0 {
+		emitHelp(w, "loveliness_router_remote_rtt_seconds",
+			"Per-shard remote RPC round-trip latency in seconds. Includes failed attempts so slow failures are visible.", "histogram")
+		for _, h := range snap.RTT {
+			for _, p := range h.Buckets {
+				fprintf(w,
+					"loveliness_router_remote_rtt_seconds_bucket{shard_id=\"%d\",le=%q} %d\n",
+					h.ShardID, formatBucketBound(p.UpperBound), p.Count)
+			}
+			fprintf(w, "loveliness_router_remote_rtt_seconds_sum{shard_id=\"%d\"} %s\n",
+				h.ShardID, formatGaugeFloat(h.Sum))
+			fprintf(w, "loveliness_router_remote_rtt_seconds_count{shard_id=\"%d\"} %d\n",
+				h.ShardID, h.Count)
+		}
+	}
+
+	if len(snap.Errors) > 0 {
+		emitHelp(w, "loveliness_router_remote_errors_total",
+			"Cumulative remote RPC failures, classified by transport-layer code (timeout, conn_refused, eof, …).", "counter")
+		for _, s := range snap.Errors {
+			fprintf(w, "loveliness_router_remote_errors_total{code=%q} %d\n", s.Code, s.Count)
+		}
+	}
+
+	if len(snap.BloomSkips) > 0 {
+		emitHelp(w, "loveliness_router_bloom_skip_total",
+			"Cumulative remote RPCs avoided because the per-shard Bloom filter ruled out the lookup key.", "counter")
+		for _, s := range snap.BloomSkips {
+			fprintf(w, "loveliness_router_bloom_skip_total{shard_id=\"%d\"} %d\n",
+				s.ShardID, s.Count)
+		}
+	}
 }
 
 // writeQueryHistogramMetrics emits loveliness_query_duration_seconds in

--- a/pkg/api/router_metrics_test.go
+++ b/pkg/api/router_metrics_test.go
@@ -1,0 +1,173 @@
+package api
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/johnjansen/loveliness/pkg/router"
+)
+
+// The exposition writer must produce a Prometheus-shaped block for
+// each non-empty section of the snapshot. An empty snapshot must
+// produce no output at all — series should only appear once they've
+// been observed at least once, matching the lazy-creation semantics
+// the rest of /metrics already uses.
+func TestWriteRouterMetrics_EmptySnapshotEmitsNothing(t *testing.T) {
+	var buf bytes.Buffer
+	writeRouterMetrics(&buf, router.RouterMetricsSnapshot{})
+	if buf.Len() != 0 {
+		t.Errorf("empty snapshot produced %d bytes; want 0\noutput:\n%s", buf.Len(), buf.String())
+	}
+}
+
+// Full snapshot: every primitive populated. Verifies the exact
+// Prometheus shape — HELP + TYPE headers, _bucket lines per (shard,
+// le), _sum / _count, +Inf bucket, error counters, bloom skip
+// counters — so a future writer change can't silently corrupt the
+// scrape format.
+func TestWriteRouterMetrics_FullShape(t *testing.T) {
+	m := router.NewRouterMetrics()
+
+	m.ObserveRemoteRTT(0, 0.0005)
+	m.ObserveRemoteRTT(0, 0.05)
+	m.ObserveRemoteRTT(3, 0.001)
+
+	m.IncRemoteError("timeout")
+	m.IncRemoteError("conn_refused")
+	m.IncRemoteError("conn_refused")
+
+	m.IncBloomSkip(0)
+	m.IncBloomSkip(3)
+	m.IncBloomSkip(3)
+
+	var buf bytes.Buffer
+	writeRouterMetrics(&buf, m.Snapshot())
+	out := buf.String()
+
+	wants := []string{
+		"# HELP loveliness_router_remote_rtt_seconds",
+		"# TYPE loveliness_router_remote_rtt_seconds histogram",
+		"loveliness_router_remote_rtt_seconds_bucket{shard_id=\"0\",le=\"0.0005\"}",
+		"loveliness_router_remote_rtt_seconds_bucket{shard_id=\"0\",le=\"+Inf\"} 2",
+		"loveliness_router_remote_rtt_seconds_count{shard_id=\"0\"} 2",
+		"loveliness_router_remote_rtt_seconds_count{shard_id=\"3\"} 1",
+		"# HELP loveliness_router_remote_errors_total",
+		"# TYPE loveliness_router_remote_errors_total counter",
+		"loveliness_router_remote_errors_total{code=\"conn_refused\"} 2",
+		"loveliness_router_remote_errors_total{code=\"timeout\"} 1",
+		"# HELP loveliness_router_bloom_skip_total",
+		"# TYPE loveliness_router_bloom_skip_total counter",
+		"loveliness_router_bloom_skip_total{shard_id=\"0\"} 1",
+		"loveliness_router_bloom_skip_total{shard_id=\"3\"} 2",
+	}
+	for _, w := range wants {
+		if !strings.Contains(out, w) {
+			t.Errorf("output missing %q\nfull output:\n%s", w, out)
+		}
+	}
+}
+
+// Series ordering: every metric block must list its samples in the
+// stable, sorted order that the snapshot promises (shard_id ascending
+// for histograms + bloom skips, code alphabetical for errors). Diff-
+// friendly scrapes depend on this not drifting.
+func TestWriteRouterMetrics_DeterministicOrder(t *testing.T) {
+	m := router.NewRouterMetrics()
+	for _, sid := range []int{7, 2, 5} {
+		m.ObserveRemoteRTT(sid, 0.001)
+	}
+	for _, code := range []string{"timeout", "conn_refused", "eof"} {
+		m.IncRemoteError(code)
+	}
+	for _, sid := range []int{9, 1, 4} {
+		m.IncBloomSkip(sid)
+	}
+
+	var buf bytes.Buffer
+	writeRouterMetrics(&buf, m.Snapshot())
+	out := buf.String()
+
+	// Helper: each value should appear before the next in stable order.
+	// Use _count lines (one per shard) for the histogram check.
+	mustOrder := func(label string, parts []string) {
+		t.Helper()
+		positions := make([]int, len(parts))
+		for i, p := range parts {
+			positions[i] = strings.Index(out, p)
+			if positions[i] < 0 {
+				t.Errorf("%s: missing %q", label, p)
+				return
+			}
+		}
+		for i := 1; i < len(positions); i++ {
+			if positions[i] <= positions[i-1] {
+				t.Errorf("%s: %q (pos %d) must come after %q (pos %d)",
+					label, parts[i], positions[i], parts[i-1], positions[i-1])
+			}
+		}
+	}
+
+	mustOrder("RTT shard order", []string{
+		`loveliness_router_remote_rtt_seconds_count{shard_id="2"}`,
+		`loveliness_router_remote_rtt_seconds_count{shard_id="5"}`,
+		`loveliness_router_remote_rtt_seconds_count{shard_id="7"}`,
+	})
+	mustOrder("Errors alphabetical", []string{
+		`loveliness_router_remote_errors_total{code="conn_refused"}`,
+		`loveliness_router_remote_errors_total{code="eof"}`,
+		`loveliness_router_remote_errors_total{code="timeout"}`,
+	})
+	mustOrder("Bloom skip shard order", []string{
+		`loveliness_router_bloom_skip_total{shard_id="1"}`,
+		`loveliness_router_bloom_skip_total{shard_id="4"}`,
+		`loveliness_router_bloom_skip_total{shard_id="9"}`,
+	})
+}
+
+// Partial-population sanity: only one of the three sections present.
+// The other two must stay completely absent — no stray HELP lines,
+// no zero-valued series.
+func TestWriteRouterMetrics_PartialSection(t *testing.T) {
+	m := router.NewRouterMetrics()
+	m.IncRemoteError("timeout")
+
+	var buf bytes.Buffer
+	writeRouterMetrics(&buf, m.Snapshot())
+	out := buf.String()
+
+	if !strings.Contains(out, "loveliness_router_remote_errors_total") {
+		t.Errorf("errors section missing")
+	}
+	if strings.Contains(out, "loveliness_router_remote_rtt_seconds") {
+		t.Errorf("RTT section should be absent in partial snapshot")
+	}
+	if strings.Contains(out, "loveliness_router_bloom_skip_total") {
+		t.Errorf("bloom-skip section should be absent in partial snapshot")
+	}
+}
+
+// Sum + count consistency: with N observations summing to S, the
+// emitted _sum and _count must round-trip exactly.
+func TestWriteRouterMetrics_SumAndCountConsistent(t *testing.T) {
+	m := router.NewRouterMetrics()
+	durations := []float64{0.001, 0.002, 0.003, 0.005}
+	for _, d := range durations {
+		m.ObserveRemoteRTT(0, d)
+	}
+
+	var buf bytes.Buffer
+	writeRouterMetrics(&buf, m.Snapshot())
+	out := buf.String()
+
+	wantCount := fmt.Sprintf("loveliness_router_remote_rtt_seconds_count{shard_id=\"0\"} %d", len(durations))
+	if !strings.Contains(out, wantCount) {
+		t.Errorf("count line missing or wrong; expected %q\nfull:\n%s", wantCount, out)
+	}
+	// Sum is 0.011s; formatGaugeFloat trims trailing zeros so the
+	// exact rendering is "0.011".
+	if !strings.Contains(out, `loveliness_router_remote_rtt_seconds_sum{shard_id="0"} 0.011`) {
+		t.Errorf("sum line missing the expected 0.011 value\nfull:\n%s", out)
+	}
+}

--- a/pkg/router/metrics.go
+++ b/pkg/router/metrics.go
@@ -1,0 +1,340 @@
+package router
+
+import (
+	"context"
+	"errors"
+	"io"
+	"math"
+	"net"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Per-router observability primitives for the cross-node scatter
+// path. Hand-rolled to match pkg/api/query_metrics.go and avoid
+// dragging the prometheus client_golang dependency into this package.
+//
+// Three series are exposed:
+//
+//	loveliness_router_remote_rtt_seconds{shard_id}     histogram
+//	loveliness_router_remote_errors_total{code}        counter
+//	loveliness_router_bloom_skip_total{shard_id}       counter
+//
+// All are populated lazily — a series only materialises after the
+// first observation, matching client_golang's create-on-first-use
+// semantics. The shard_id label is bounded by shardCount; the code
+// label is bounded by the closed set in classifyRemoteError.
+
+// remoteRTTBuckets are the histogram bucket upper bounds in seconds
+// for per-shard RPC round-trip times. The lower end (250µs) covers
+// in-process loopback; the upper end (5s) brackets the worst-case
+// scatter timeout in production. The intermediate steps are sized to
+// give meaningful resolution across the 1ms–1s decade where most
+// real cross-node calls land.
+var remoteRTTBuckets = []float64{
+	0.00025, 0.0005, 0.001, 0.0025, 0.005, 0.01,
+	0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0,
+}
+
+// RouterMetrics owns the three series above. Pointer-receiver methods
+// are safe to call from any goroutine. A nil *RouterMetrics is a
+// no-op for every method, so call sites don't need to nil-check.
+type RouterMetrics struct {
+	rtt        *remoteRTTHistogram
+	errors     *remoteErrorCounters
+	bloomSkips *bloomSkipCounters
+}
+
+// NewRouterMetrics constructs an empty metrics container. Buckets and
+// keyed maps are populated on first observation.
+func NewRouterMetrics() *RouterMetrics {
+	return &RouterMetrics{
+		rtt:        newRemoteRTTHistogram(),
+		errors:     newRemoteErrorCounters(),
+		bloomSkips: newBloomSkipCounters(),
+	}
+}
+
+// ObserveRemoteRTT records a single remote-call duration against
+// shardID. The duration is always observed, success or failure —
+// failed calls also have a measurable transport latency and seeing
+// them in the histogram is what makes "slow failures" diagnosable.
+func (m *RouterMetrics) ObserveRemoteRTT(shardID int, seconds float64) {
+	if m == nil {
+		return
+	}
+	m.rtt.Observe(shardID, seconds)
+}
+
+// IncRemoteError records one classified remote-call failure. The
+// code label is bounded by the closed set in classifyRemoteError;
+// callers should not invent new codes.
+func (m *RouterMetrics) IncRemoteError(code string) {
+	if m == nil {
+		return
+	}
+	m.errors.Inc(code)
+}
+
+// IncBloomSkip records a remote RPC that was skipped because the
+// shard's Bloom filter ruled out the lookup key. Reserved for slice
+// 4; primitives live here so the metrics writer is fully wired up
+// the moment the increment site lands.
+func (m *RouterMetrics) IncBloomSkip(shardID int) {
+	if m == nil {
+		return
+	}
+	m.bloomSkips.Inc(shardID)
+}
+
+// Snapshot returns a deterministic, sorted view of all three series.
+// Stable ordering keeps diff-friendly tests honest and matches the
+// scrape ordering the Prometheus convention expects.
+func (m *RouterMetrics) Snapshot() RouterMetricsSnapshot {
+	if m == nil {
+		return RouterMetricsSnapshot{}
+	}
+	return RouterMetricsSnapshot{
+		RTT:        m.rtt.Snapshot(),
+		Errors:     m.errors.Snapshot(),
+		BloomSkips: m.bloomSkips.Snapshot(),
+	}
+}
+
+// RouterMetricsSnapshot is the shape consumed by the metrics writer
+// in pkg/api. The three slices are independently sorted and safe to
+// emit in any order.
+type RouterMetricsSnapshot struct {
+	RTT        []RemoteRTTSnapshot
+	Errors     []RemoteErrorSample
+	BloomSkips []BloomSkipSample
+}
+
+// remote RTT histogram
+
+// remoteRTTHistogram is a per-shard latency histogram. Same shape as
+// pkg/api.queryHistogram: cumulative bucket counts plus count + sum.
+type remoteRTTHistogram struct {
+	mu      sync.Mutex
+	buckets []float64
+	series  map[int]*rttSeries
+}
+
+type rttSeries struct {
+	bucketCounts []uint64
+	count        uint64
+	sum          float64
+}
+
+func newRemoteRTTHistogram() *remoteRTTHistogram {
+	return &remoteRTTHistogram{
+		buckets: append([]float64(nil), remoteRTTBuckets...),
+		series:  make(map[int]*rttSeries),
+	}
+}
+
+// Observe records a duration. Negative values are clamped to 0; they
+// only happen if a clock skews backward mid-call and emitting a
+// negative bucket would corrupt the cumulative invariant.
+func (h *remoteRTTHistogram) Observe(shardID int, seconds float64) {
+	if seconds < 0 {
+		seconds = 0
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	s := h.series[shardID]
+	if s == nil {
+		s = &rttSeries{bucketCounts: make([]uint64, len(h.buckets))}
+		h.series[shardID] = s
+	}
+	for i, b := range h.buckets {
+		if seconds <= b {
+			s.bucketCounts[i]++
+		}
+	}
+	s.count++
+	s.sum += seconds
+}
+
+// RemoteRTTSnapshot is one (shard_id, histogram) tuple in deterministic
+// form. A synthetic +Inf bucket is appended at the end so the writer
+// emits the standard Prometheus shape without re-deriving it.
+type RemoteRTTSnapshot struct {
+	ShardID int
+	Buckets []RTTBucketPoint
+	Count   uint64
+	Sum     float64
+}
+
+type RTTBucketPoint struct {
+	UpperBound float64
+	Count      uint64
+}
+
+// Snapshot returns the histogram series sorted by shard_id ascending.
+func (h *remoteRTTHistogram) Snapshot() []RemoteRTTSnapshot {
+	h.mu.Lock()
+	out := make([]RemoteRTTSnapshot, 0, len(h.series))
+	for sid, s := range h.series {
+		points := make([]RTTBucketPoint, 0, len(h.buckets)+1)
+		for i, b := range h.buckets {
+			points = append(points, RTTBucketPoint{UpperBound: b, Count: s.bucketCounts[i]})
+		}
+		points = append(points, RTTBucketPoint{UpperBound: math.Inf(1), Count: s.count})
+		out = append(out, RemoteRTTSnapshot{
+			ShardID: sid,
+			Buckets: points,
+			Count:   s.count,
+			Sum:     s.sum,
+		})
+	}
+	h.mu.Unlock()
+	sort.Slice(out, func(i, j int) bool { return out[i].ShardID < out[j].ShardID })
+	return out
+}
+
+// remote error counters
+
+// remoteErrorCounters tracks failed remote RPCs by classified code.
+// Cardinality is bounded by the closed set in classifyRemoteError.
+type remoteErrorCounters struct {
+	mu     sync.Mutex
+	counts map[string]uint64
+}
+
+func newRemoteErrorCounters() *remoteErrorCounters {
+	return &remoteErrorCounters{counts: make(map[string]uint64)}
+}
+
+// Inc records one failure for the given code. Empty codes are
+// dropped — every classifyRemoteError path returns a non-empty
+// string, so an empty code here means a programming error upstream.
+func (c *remoteErrorCounters) Inc(code string) {
+	if code == "" {
+		return
+	}
+	c.mu.Lock()
+	c.counts[code]++
+	c.mu.Unlock()
+}
+
+type RemoteErrorSample struct {
+	Code  string
+	Count uint64
+}
+
+// Snapshot returns the counters sorted alphabetically by code.
+func (c *remoteErrorCounters) Snapshot() []RemoteErrorSample {
+	c.mu.Lock()
+	out := make([]RemoteErrorSample, 0, len(c.counts))
+	for k, v := range c.counts {
+		out = append(out, RemoteErrorSample{Code: k, Count: v})
+	}
+	c.mu.Unlock()
+	sort.Slice(out, func(i, j int) bool { return out[i].Code < out[j].Code })
+	return out
+}
+
+// bloom-skip counters
+
+// bloomSkipCounters tracks remote RPCs avoided because the per-shard
+// Bloom filter ruled out the key. Cardinality is bounded by the
+// number of shards.
+type bloomSkipCounters struct {
+	mu     sync.Mutex
+	counts map[int]uint64
+}
+
+func newBloomSkipCounters() *bloomSkipCounters {
+	return &bloomSkipCounters{counts: make(map[int]uint64)}
+}
+
+// Inc records one Bloom-filter-avoided RPC for shardID.
+func (c *bloomSkipCounters) Inc(shardID int) {
+	c.mu.Lock()
+	c.counts[shardID]++
+	c.mu.Unlock()
+}
+
+type BloomSkipSample struct {
+	ShardID int
+	Count   uint64
+}
+
+// Snapshot returns the counters sorted by shard_id ascending.
+func (c *bloomSkipCounters) Snapshot() []BloomSkipSample {
+	c.mu.Lock()
+	out := make([]BloomSkipSample, 0, len(c.counts))
+	for k, v := range c.counts {
+		out = append(out, BloomSkipSample{ShardID: k, Count: v})
+	}
+	c.mu.Unlock()
+	sort.Slice(out, func(i, j int) bool { return out[i].ShardID < out[j].ShardID })
+	return out
+}
+
+// classifyRemoteError maps an error from a RemoteQuerier call to a
+// stable, low-cardinality code suitable for a Prometheus label. The
+// closed set is:
+//
+//	"timeout"        — context.DeadlineExceeded or net.Error.Timeout()
+//	"canceled"       — context.Canceled (caller-driven, not a fault)
+//	"conn_refused"   — *net.OpError carrying "connection refused"
+//	"conn_reset"     — *net.OpError carrying "connection reset"
+//	"broken_pipe"    — *net.OpError carrying "broken pipe"
+//	"eof"            — io.EOF / io.ErrUnexpectedEOF
+//	"other"          — anything else (protocol errors, query errors,
+//	                   peer not found, …). Caps cardinality so a flood
+//	                   of unique error strings can't blow up the
+//	                   /metrics scrape.
+//
+// Mirrors the structural checks in isRetryableRemoteError so the two
+// stay coherent: every error class the retry layer recognises shows
+// up here under a stable label.
+func classifyRemoteError(err error) string {
+	if err == nil {
+		return ""
+	}
+	if errors.Is(err, context.Canceled) {
+		return "canceled"
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return "timeout"
+	}
+	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+		return "eof"
+	}
+	var ne net.Error
+	if errors.As(err, &ne) && ne.Timeout() {
+		return "timeout"
+	}
+	var op *net.OpError
+	if errors.As(err, &op) {
+		msg := op.Err.Error()
+		switch {
+		case strings.Contains(msg, "connection refused"):
+			return "conn_refused"
+		case strings.Contains(msg, "connection reset"):
+			return "conn_reset"
+		case strings.Contains(msg, "broken pipe"):
+			return "broken_pipe"
+		}
+	}
+	return "other"
+}
+
+// observeRemote records one (RTT, optional-error) pair against
+// shardID. Call sites compute the elapsed wall time around their
+// remote.QueryRemoteShard invocation and pass it here so the metrics
+// surface even when the result type doesn't fit a single helper.
+func (m *RouterMetrics) observeRemote(shardID int, elapsed time.Duration, err error) {
+	if m == nil {
+		return
+	}
+	m.ObserveRemoteRTT(shardID, elapsed.Seconds())
+	if err != nil {
+		m.IncRemoteError(classifyRemoteError(err))
+	}
+}

--- a/pkg/router/metrics_test.go
+++ b/pkg/router/metrics_test.go
@@ -1,0 +1,259 @@
+package router
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/johnjansen/loveliness/pkg/shard"
+)
+
+// classifyRemoteError contract: every transport class we recognise
+// in isRetryableRemoteError must also classify here, so the retry
+// counter and the error counter are coherent. A protocol/query
+// error must collapse to "other" so cardinality stays bounded.
+func TestClassifyRemoteError_StableLabels(t *testing.T) {
+	connRefused := &net.OpError{Op: "dial", Net: "tcp",
+		Err: errors.New("connection refused")}
+	connReset := &net.OpError{Op: "read", Net: "tcp",
+		Err: errors.New("connection reset by peer")}
+	brokenPipe := &net.OpError{Op: "write", Net: "tcp",
+		Err: errors.New("broken pipe")}
+
+	cases := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"nil", nil, ""},
+		{"context canceled", context.Canceled, "canceled"},
+		{"deadline exceeded", context.DeadlineExceeded, "timeout"},
+		{"deadline wrapped", fmt.Errorf("forward: %w", context.DeadlineExceeded), "timeout"},
+		{"io.EOF", io.EOF, "eof"},
+		{"unexpected EOF wrapped", fmt.Errorf("read frame: %w", io.ErrUnexpectedEOF), "eof"},
+		{"connection refused", connRefused, "conn_refused"},
+		{"connection refused wrapped", fmt.Errorf("forward: %w", connRefused), "conn_refused"},
+		{"connection reset", connReset, "conn_reset"},
+		{"broken pipe", brokenPipe, "broken_pipe"},
+		{"protocol", errors.New("remote shard error: invalid query"), "other"},
+		{"plain bug", errors.New("unmarshal failed"), "other"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := classifyRemoteError(tc.err)
+			if got != tc.want {
+				t.Errorf("classifyRemoteError(%v) = %q, want %q", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+// timeout-via-net.Error: anything reporting Timeout()=true (without
+// an explicit context.DeadlineExceeded) must still bucket as
+// "timeout". A user-defined net.Error proves we're not relying on
+// the concrete *net.OpError type for that branch.
+func TestClassifyRemoteError_NetTimeoutInterface(t *testing.T) {
+	if got := classifyRemoteError(timeoutNetError{}); got != "timeout" {
+		t.Errorf("net.Error.Timeout()=true should classify as timeout, got %q", got)
+	}
+}
+
+type timeoutNetError struct{}
+
+func (timeoutNetError) Error() string   { return "i/o timeout" }
+func (timeoutNetError) Timeout() bool   { return true }
+func (timeoutNetError) Temporary() bool { return false }
+
+// RTT histogram: bucket cumulation must match the contract. An
+// observation at 0.001 should land in 0.001 and every higher bucket;
+// nothing below.
+func TestRouterMetrics_RTTBucketCumulation(t *testing.T) {
+	m := NewRouterMetrics()
+	m.ObserveRemoteRTT(3, 0.001)
+
+	snap := m.Snapshot().RTT
+	if len(snap) != 1 || snap[0].ShardID != 3 {
+		t.Fatalf("snapshot shape = %+v, want one entry for shard 3", snap)
+	}
+	for _, p := range snap[0].Buckets {
+		// Every bucket >= 0.001 should have count 1; the +Inf
+		// bucket is the synthetic total.
+		if p.UpperBound >= 0.001 {
+			if p.Count != 1 {
+				t.Errorf("bucket %v count = %d, want 1", p.UpperBound, p.Count)
+			}
+		} else if p.Count != 0 {
+			t.Errorf("bucket %v count = %d, want 0", p.UpperBound, p.Count)
+		}
+	}
+	if snap[0].Count != 1 {
+		t.Errorf("count = %d, want 1", snap[0].Count)
+	}
+	if snap[0].Sum != 0.001 {
+		t.Errorf("sum = %v, want 0.001", snap[0].Sum)
+	}
+
+	// +Inf must always equal the total count — that's the histogram
+	// contract Prometheus relies on.
+	last := snap[0].Buckets[len(snap[0].Buckets)-1]
+	if !math.IsInf(last.UpperBound, 1) {
+		t.Errorf("last bucket upper bound = %v, want +Inf", last.UpperBound)
+	}
+	if last.Count != snap[0].Count {
+		t.Errorf("+Inf bucket count = %d, want %d (== total count)", last.Count, snap[0].Count)
+	}
+}
+
+// Negative durations (clock skew) clamp to zero. Otherwise a
+// backwards clock would corrupt the cumulative invariant.
+func TestRouterMetrics_RTTNegativeClampsToZero(t *testing.T) {
+	m := NewRouterMetrics()
+	m.ObserveRemoteRTT(0, -1.5)
+	snap := m.Snapshot().RTT
+	if len(snap) != 1 {
+		t.Fatalf("expected one shard entry, got %d", len(snap))
+	}
+	if snap[0].Sum != 0 {
+		t.Errorf("sum after clamp = %v, want 0", snap[0].Sum)
+	}
+	// First bucket (smallest upper bound) must already include the
+	// clamped-to-zero observation.
+	if snap[0].Buckets[0].Count != 1 {
+		t.Errorf("first bucket count = %d, want 1", snap[0].Buckets[0].Count)
+	}
+}
+
+// Snapshot ordering: shards must come out sorted ascending, errors
+// alphabetical, bloom skips by shard. Stable order is what makes
+// /metrics scrape-diff-friendly.
+func TestRouterMetrics_SnapshotIsDeterministic(t *testing.T) {
+	m := NewRouterMetrics()
+	m.ObserveRemoteRTT(7, 0.01)
+	m.ObserveRemoteRTT(2, 0.02)
+	m.ObserveRemoteRTT(5, 0.03)
+	m.IncRemoteError("conn_refused")
+	m.IncRemoteError("timeout")
+	m.IncRemoteError("eof")
+	m.IncBloomSkip(9)
+	m.IncBloomSkip(1)
+
+	for i := 0; i < 5; i++ { // run a few times; map iteration is randomised
+		snap := m.Snapshot()
+		if got := []int{snap.RTT[0].ShardID, snap.RTT[1].ShardID, snap.RTT[2].ShardID}; got[0] != 2 || got[1] != 5 || got[2] != 7 {
+			t.Errorf("RTT shard order = %v, want [2 5 7]", got)
+		}
+		if got := []string{snap.Errors[0].Code, snap.Errors[1].Code, snap.Errors[2].Code}; got[0] != "conn_refused" || got[1] != "eof" || got[2] != "timeout" {
+			t.Errorf("Errors code order = %v, want [conn_refused eof timeout]", got)
+		}
+		if got := []int{snap.BloomSkips[0].ShardID, snap.BloomSkips[1].ShardID}; got[0] != 1 || got[1] != 9 {
+			t.Errorf("BloomSkip shard order = %v, want [1 9]", got)
+		}
+	}
+}
+
+// Counters: empty codes are dropped (defence in depth — every
+// classifyRemoteError path returns a non-empty code, so an empty
+// here means a programming error upstream and we'd rather lose the
+// observation than pollute the label set).
+func TestRouterMetrics_ErrorEmptyCodeDropped(t *testing.T) {
+	m := NewRouterMetrics()
+	m.IncRemoteError("")
+	if len(m.Snapshot().Errors) != 0 {
+		t.Errorf("empty code should not produce a sample")
+	}
+}
+
+// Concurrency: many goroutines hammering the same primitives must
+// produce a consistent total (no lost increments under -race).
+func TestRouterMetrics_ConcurrentSafe(t *testing.T) {
+	m := NewRouterMetrics()
+	const writers = 16
+	const opsPerWriter = 250
+
+	var wg sync.WaitGroup
+	wg.Add(writers)
+	for w := 0; w < writers; w++ {
+		go func() {
+			defer wg.Done()
+			for i := 0; i < opsPerWriter; i++ {
+				m.ObserveRemoteRTT(0, 0.001)
+				m.IncRemoteError("timeout")
+				m.IncBloomSkip(0)
+			}
+		}()
+	}
+	wg.Wait()
+
+	snap := m.Snapshot()
+	want := uint64(writers * opsPerWriter)
+	if snap.RTT[0].Count != want {
+		t.Errorf("RTT count = %d, want %d", snap.RTT[0].Count, want)
+	}
+	if snap.Errors[0].Count != want {
+		t.Errorf("error count = %d, want %d", snap.Errors[0].Count, want)
+	}
+	if snap.BloomSkips[0].Count != want {
+		t.Errorf("bloom skip count = %d, want %d", snap.BloomSkips[0].Count, want)
+	}
+}
+
+// Nil-safety: every method on (*RouterMetrics)(nil) must be a no-op
+// so call sites (tests, or future code paths that bypass NewRouter)
+// don't have to nil-check.
+func TestRouterMetrics_NilSafe(t *testing.T) {
+	var m *RouterMetrics
+	m.ObserveRemoteRTT(0, 1.0)
+	m.IncRemoteError("timeout")
+	m.IncBloomSkip(0)
+	m.observeRemote(0, time.Millisecond, errors.New("x"))
+	snap := m.Snapshot()
+	if snap.RTT != nil || snap.Errors != nil || snap.BloomSkips != nil {
+		t.Errorf("nil snapshot must be empty, got %+v", snap)
+	}
+}
+
+// End-to-end: a Router configured with a flaky remote should record
+// the failed attempts in error counters and the (failed + final
+// successful) attempts in the RTT histogram. Proves the metrics are
+// wired into the real call site, not just the primitives.
+func TestRouter_RemoteCallObservedInMetrics(t *testing.T) {
+	const shardCount = 2
+	r := NewRouter(make([]*shard.Shard, shardCount), 2*time.Second)
+
+	connRefused := &net.OpError{Op: "dial", Net: "tcp",
+		Err: errors.New("connection refused")}
+	fr := &flakyRemote{failures: int32(shardCount), err: connRefused}
+	r.SetRemoteTransport("local", fr, allRemotePlacement{})
+	r.SetRemoteRetryBackoff(time.Microsecond)
+
+	if _, err := r.Execute(context.Background(), "MATCH (n) RETURN n"); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	snap := r.Metrics().Snapshot()
+	// Two shards × (1 fail + 1 retry success) = 4 RTT samples spread
+	// across two shard_id series.
+	if len(snap.RTT) != shardCount {
+		t.Fatalf("RTT series = %d, want %d", len(snap.RTT), shardCount)
+	}
+	var totalRTT uint64
+	for _, s := range snap.RTT {
+		totalRTT += s.Count
+	}
+	if totalRTT != uint64(2*shardCount) {
+		t.Errorf("RTT total observations = %d, want %d", totalRTT, 2*shardCount)
+	}
+	// One conn_refused error per shard → counter at shardCount.
+	if len(snap.Errors) != 1 || snap.Errors[0].Code != "conn_refused" {
+		t.Fatalf("error snapshot = %+v, want one conn_refused entry", snap.Errors)
+	}
+	if snap.Errors[0].Count != uint64(shardCount) {
+		t.Errorf("conn_refused count = %d, want %d", snap.Errors[0].Count, shardCount)
+	}
+}

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -101,6 +101,14 @@ type Router struct {
 	// at use-site to break thundering-herd patterns. Tests set it
 	// short to race against the scatter timeout.
 	remoteRetryBackoff time.Duration
+
+	// metrics owns the per-router observability primitives — remote
+	// RTT histogram, remote error counter, bloom-skip counter. Every
+	// remote RPC site reports through this. Eagerly initialised in
+	// the constructors so call sites don't need a nil check, but
+	// every method on *RouterMetrics is also nil-safe for callers
+	// that bypass the constructors (rare; mostly tests).
+	metrics *RouterMetrics
 }
 
 // DDLHook is called when a DDL statement registers or removes a table.
@@ -152,6 +160,7 @@ func NewRouter(shards []*shard.Shard, timeout time.Duration) *Router {
 		shards:     shards,
 		shardCount: len(shards),
 		timeout:    timeout,
+		metrics:    NewRouterMetrics(),
 	}
 }
 
@@ -164,6 +173,7 @@ func NewRouterWithSchema(shards []*shard.Shard, timeout time.Duration, reg *sche
 		timeout:    timeout,
 		schema:     reg,
 		bloomIndex: NewShardBloomIndex(),
+		metrics:    NewRouterMetrics(),
 	}
 	r.resolver = NewResolver(shards, reg, r)
 	r.edgeCut = NewEdgeCutReplicator(shards, r)
@@ -175,6 +185,13 @@ func NewRouterWithSchema(shards []*shard.Shard, timeout time.Duration, reg *sche
 // BloomIndex returns the Bloom filter index for external use (e.g., bulk load populates it).
 func (r *Router) BloomIndex() *ShardBloomIndex {
 	return r.bloomIndex
+}
+
+// Metrics returns the router's observability primitives. The pkg/api
+// metrics writer reads snapshots from here. Safe to call before any
+// remote RPC has happened — the snapshot will simply be empty.
+func (r *Router) Metrics() *RouterMetrics {
+	return r.metrics
 }
 
 // EdgeCut returns the edge-cut replicator.
@@ -302,13 +319,19 @@ func (r *Router) queryShardRaw(shardID int, cypher string) (*shard.QueryResponse
 		return nil, fmt.Errorf("shard %d has no assigned primary", shardID)
 	}
 	// retryRemoteCall handles its own bounds checking; if retries are
-	// disabled it does exactly one attempt.
+	// disabled it does exactly one attempt. Per-attempt RTT and
+	// classified-error counts are observed inside the closure so a
+	// flapping peer's failed retries are visible in /metrics, not
+	// hidden by the eventual success of the outer call.
 	return retryRemoteCall(
 		context.Background(),
 		r.remoteRetries,
 		r.remoteRetryBackoff,
 		func() (*shard.QueryResponse, error) {
-			return r.remote.QueryRemoteShard(nodeID, shardID, cypher)
+			start := time.Now()
+			resp, err := r.remote.QueryRemoteShard(nodeID, shardID, cypher)
+			r.metrics.observeRemote(shardID, time.Since(start), err)
+			return resp, err
 		},
 	)
 }
@@ -537,7 +560,9 @@ func (r *Router) queryShard(ctx context.Context, shardID int, cypher string) (*R
 			if nodeID == "" {
 				err = fmt.Errorf("shard %d has no assigned primary", shardID)
 			} else {
+				start := time.Now()
 				resp, err = r.remote.QueryRemoteShard(nodeID, shardID, cypher)
+				r.metrics.observeRemote(shardID, time.Since(start), err)
 			}
 		}
 		ch <- queryResult{resp, err}


### PR DESCRIPTION
## Summary
- Three new Prometheus series for the cross-node scatter path:
  - `loveliness_router_remote_rtt_seconds{shard_id}` — histogram including failed attempts so slow failures are visible
  - `loveliness_router_remote_errors_total{code}` — counter over a closed set of seven transport codes (`timeout`, `canceled`, `conn_refused`, `conn_reset`, `broken_pipe`, `eof`, `other`)
  - `loveliness_router_bloom_skip_total{shard_id}` — counter (primitive wired now; increment site lands in slice 4)
- Both remote call sites (`queryShardRaw` via retry, `queryShard` direct) feed the same `RouterMetrics`. Hand-rolled to match `pkg/api/query_metrics.go` — no new prometheus client_golang dep.

## Why
Slice 3 of #6 polish. Without per-shard RTT and classified error counters there's no way to tell a flapping peer from a slow query, no way to size scatter timeouts off real data, and no way to alert on transport-class failures specifically. Closes the observability gap before the cross-node benchmark slice (5) lands.

## Test plan
- [x] `go test ./... -race` — 18 packages green
- [x] `go test ./pkg/router/ -run "TestRouterMetrics|TestClassifyRemoteError|TestRouter_RemoteCallObservedInMetrics" -race` — bucket cumulation, +Inf invariant, neg clock-skew clamp, deterministic ordering, concurrent-safe (16 writers × 250 ops), end-to-end via `Router.Execute` with a flaky remote
- [x] `go test ./pkg/api/ -run TestWriteRouterMetrics -race` — empty snapshot emits nothing, full-shape exposition, deterministic series ordering, partial section, sum/count round-trip
- [x] `golangci-lint run ./pkg/router/... ./pkg/api/...` — 0 issues
- [x] `docs/metrics.md` updated: new series in cardinality table, new bucket bounds, new closed-set `code` label documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)