### PR TITLE
feat(analytics): pure-Go Leiden plugin (phase 1: single γ)

### DIFF
--- a/pkg/analytics/leiden/leiden.go
+++ b/pkg/analytics/leiden/leiden.go
@@ -243,9 +243,17 @@ func countDistinct(p []int) int {
 //
 //	Q = 1/(2m) * Σ_C [Σ_in(C) - γ * (Σ_tot(C))^2 / (2m)]
 //
-// where Σ_in(C) is internal weight (each internal edge counted twice
-// for non-self-loops, twice for self-loops too), and Σ_tot(C) is total
-// incident weight.
+// Convention: A_uv = w throughout (including the diagonal — a self-loop
+// contributes w to A_uu, not 2w). Under this convention, summing the
+// adjacency-list directly yields each undirected non-self edge counted
+// twice (once from each endpoint) and each self-loop counted once. This
+// matches the bookkeeping in NodeWeight and TotalWeight: 2m =
+// Σ_u NodeWeight[u] = Σ_uv A_uv. Σ_in(C) is the sum of A_uv over u,v∈C
+// (so each internal non-self edge contributes 2w, each internal self-loop
+// contributes w). Σ_tot(C) is the sum of node weights in C.
+//
+// aggregate preserves all three quantities exactly: 2m, Σ_in(C), and
+// Σ_tot(C) under collapse, so Q is invariant across aggregation levels.
 func modularity(g *Graph, comm []int, gamma float64) float64 {
 	if g.TotalWeight == 0 {
 		return 0

--- a/pkg/analytics/leiden/leiden.go
+++ b/pkg/analytics/leiden/leiden.go
@@ -34,14 +34,20 @@ type Neighbor struct {
 }
 
 // Graph is an undirected weighted graph. Adj[i] holds i's outgoing
-// edges; for an undirected edge (u,v,w) both Adj[u] and Adj[v] hold it.
-// Self-loops appear once in Adj[i] and contribute weight w (not 2w) to
-// NodeWeight[i] — the doubling for modularity is handled in the kernel.
+// edges; for an undirected non-self edge (u,v,w) both Adj[u] and
+// Adj[v] hold an entry of weight w. A self-loop (u,u,w) appears once
+// in Adj[u].
+//
+// Convention: under modularity, a self-loop of weight w contributes w
+// (not 2w) to NodeWeight[u] and w to TotalWeight. The kernel's ΔQ
+// formula is symmetric under this choice — the self-loop terms cancel
+// when a node moves communities — so localMove handles self-loops
+// correctly without an explicit branch.
 type Graph struct {
 	N           int
 	Adj         [][]Neighbor
-	NodeWeight  []float64 // sum of incident edge weights
-	TotalWeight float64   // 2m: sum of all edge weights, with each edge counted twice
+	NodeWeight  []float64 // sum of incident edge weights (self-loop counted once)
+	TotalWeight float64   // sum over nodes of NodeWeight[i]
 }
 
 // NewGraph allocates an empty graph with n nodes.
@@ -54,8 +60,12 @@ func NewGraph(n int) *Graph {
 }
 
 // AddEdge adds an undirected edge u—v with weight w. Self-loops are
-// allowed and contribute correctly to modularity. Adding a duplicate
-// edge stacks weights — callers can pre-aggregate or rely on this.
+// allowed. Adding a duplicate edge stacks weights — callers can
+// pre-aggregate or rely on this.
+//
+// Self-loop convention: weight w contributes w (not 2w) to
+// NodeWeight[u] and w to TotalWeight. See Graph for why this choice
+// is internally consistent with the kernel formulas.
 func (g *Graph) AddEdge(u, v int, w float64) {
 	if w == 0 {
 		return
@@ -66,13 +76,6 @@ func (g *Graph) AddEdge(u, v int, w float64) {
 	if u != v {
 		g.Adj[v] = append(g.Adj[v], Neighbor{To: u, Weight: w})
 		g.NodeWeight[v] += w
-		g.TotalWeight += w
-	}
-	// Self-loop: counted once in Adj, w added once to NodeWeight, w
-	// added once to TotalWeight here. Modularity treats self-loops as
-	// 2w in degree and 2w in TotalWeight; we'll correct in the kernel.
-	if u == v {
-		g.NodeWeight[u] += w
 		g.TotalWeight += w
 	}
 }
@@ -318,17 +321,20 @@ func localMove(g *Graph, comm []int, gamma float64, rng *rand.Rand) bool {
 			eUtoCU := toComm[cu] // weight from u to cu \ {u} (self-loop excluded above)
 			sumCUminusU := sTot[cu] - ku
 
+			// Self-loops are excluded from toComm above. They cancel
+			// out of ΔQ symmetrically (a self-loop on u moves with u,
+			// so its Σ_in contribution leaves cu and enters c by the
+			// same amount), so ignoring them here is correct.
+			_ = selfLoop
+
 			for c, eUtoC := range toComm {
 				if c == cu {
 					continue
 				}
 				sumC := sTot[c]
-				// ΔQ for u: cu -> c
-				// gain: (eUtoC - eUtoCU)/m - gamma*ku*(sumC - sumCUminusU)/(2m^2)
-				// Factor out 1/m and 1/(2m): use twoM (which is 2m).
-				delta := (eUtoC-eUtoCU)/(twoM/2) - gamma*ku*(sumC-sumCUminusU)/(twoM*twoM/2)
-				// Equivalent simpler form:
-				delta = 2*(eUtoC-eUtoCU)/twoM - gamma*ku*(sumC-sumCUminusU)*2/(twoM*twoM)
+				// ΔQ for u: cu -> c, derived from
+				//   ΔQ = 2(eUtoC - eUtoCU)/2m - γ·ku·(sumC - (sumCu-ku))/(2m)²
+				delta := 2*(eUtoC-eUtoCU)/twoM - 2*gamma*ku*(sumC-sumCUminusU)/(twoM*twoM)
 				if delta > bestDelta+1e-12 {
 					bestDelta = delta
 					bestComm = c
@@ -336,17 +342,12 @@ func localMove(g *Graph, comm []int, gamma float64, rng *rand.Rand) bool {
 			}
 
 			if bestComm != cu {
-				// Apply move.
 				sTot[cu] -= ku
 				sTot[bestComm] += ku
 				comm[u] = bestComm
 				improvedThisPass = true
 				anyImproved = true
 			}
-			// Self-loop value used implicitly via toComm[cu] not
-			// including selfLoop; since we never move to cu, it does
-			// not matter for the comparison above.
-			_ = selfLoop
 		}
 		if !improvedThisPass {
 			break
@@ -358,11 +359,15 @@ func localMove(g *Graph, comm []int, gamma float64, rng *rand.Rand) bool {
 
 // refine takes the post-local-move partition and, for each community
 // from that partition, splits it into well-connected sub-communities.
-// We start every node in its own singleton sub-community, then run a
-// Leiden-style refinement: a node may move only to a sub-community
-// that lies entirely inside its parent community, and only if the move
-// strictly improves Q at the current γ. This guarantees the aggregated
-// graph respects connectivity (the central Leiden fix vs. Louvain).
+// Each node starts in its own singleton sub-community; we then run a
+// Leiden-style refinement to fixpoint: a node may move only to a
+// sub-community that lies entirely inside its parent community, and
+// only if the move strictly improves Q at the current γ. Iterating to
+// fixpoint matches the paper's specification — a single pass would let
+// early-shuffled nodes block better moves for later nodes.
+//
+// This restriction is what makes the aggregated graph respect
+// connectivity (the central Leiden fix vs. Louvain).
 func refine(g *Graph, parent []int, gamma float64, rng *rand.Rand) []int {
 	twoM := g.TotalWeight
 	if twoM == 0 {
@@ -370,60 +375,64 @@ func refine(g *Graph, parent []int, gamma float64, rng *rand.Rand) []int {
 	}
 
 	// Each node starts in its own sub-community. Sub-community labels
-	// are global (across parent communities) and use the original node
-	// indices as labels.
+	// are global (across parent communities); we seed them with the
+	// original node indices.
 	sub := identityPartition(g.N)
 	sTot := make(map[int]float64, g.N)
 	for u := 0; u < g.N; u++ {
 		sTot[sub[u]] = g.NodeWeight[u]
 	}
 
-	// Iterate nodes in random order. For each node u, consider only
-	// sub-communities in u's parent community. Apply the best move if
-	// it's a strict improvement.
 	order := make([]int, g.N)
 	for i := range order {
 		order[i] = i
 	}
-	rng.Shuffle(len(order), func(i, j int) { order[i], order[j] = order[j], order[i] })
 
-	for _, u := range order {
-		pu := parent[u]
-		ku := g.NodeWeight[u]
-		cu := sub[u]
+	for {
+		rng.Shuffle(len(order), func(i, j int) { order[i], order[j] = order[j], order[i] })
+		improved := false
+		for _, u := range order {
+			pu := parent[u]
+			ku := g.NodeWeight[u]
+			cu := sub[u]
 
-		toSub := map[int]float64{}
-		for _, e := range g.Adj[u] {
-			if e.To == u {
-				continue
+			toSub := map[int]float64{}
+			for _, e := range g.Adj[u] {
+				if e.To == u {
+					continue
+				}
+				if parent[e.To] != pu {
+					continue
+				}
+				toSub[sub[e.To]] += e.Weight
 			}
-			if parent[e.To] != pu {
-				continue
+
+			bestDelta := 0.0
+			bestComm := cu
+			eUtoCU := toSub[cu]
+			sumCUminusU := sTot[cu] - ku
+
+			for c, eUtoC := range toSub {
+				if c == cu {
+					continue
+				}
+				sumC := sTot[c]
+				delta := 2*(eUtoC-eUtoCU)/twoM - 2*gamma*ku*(sumC-sumCUminusU)/(twoM*twoM)
+				if delta > bestDelta+1e-12 {
+					bestDelta = delta
+					bestComm = c
+				}
 			}
-			toSub[sub[e.To]] += e.Weight
+
+			if bestComm != cu {
+				sTot[cu] -= ku
+				sTot[bestComm] += ku
+				sub[u] = bestComm
+				improved = true
+			}
 		}
-
-		bestDelta := 0.0
-		bestComm := cu
-		eUtoCU := toSub[cu]
-		sumCUminusU := sTot[cu] - ku
-
-		for c, eUtoC := range toSub {
-			if c == cu {
-				continue
-			}
-			sumC := sTot[c]
-			delta := 2*(eUtoC-eUtoCU)/twoM - gamma*ku*(sumC-sumCUminusU)*2/(twoM*twoM)
-			if delta > bestDelta+1e-12 {
-				bestDelta = delta
-				bestComm = c
-			}
-		}
-
-		if bestComm != cu {
-			sTot[cu] -= ku
-			sTot[bestComm] += ku
-			sub[u] = bestComm
+		if !improved {
+			break
 		}
 	}
 
@@ -433,8 +442,20 @@ func refine(g *Graph, parent []int, gamma float64, rng *rand.Rand) []int {
 // aggregate collapses each refined sub-community into one node in a
 // new graph. Returns the aggregate graph and a mapping
 // newNode -> []origNode.
+//
+// 2m invariance: original 2m must equal aggregated 2m. With our
+// self-loop-weight-w-contributes-w-to-2m convention this means:
+//
+//   - cross-community non-self edges (u,v,w) → super-edge (a,b,w)
+//   - within-community non-self edge (u,v,w) → contributes 2w to the
+//     self-loop on its super-node (each end of the original edge added
+//     w to original 2m; the resulting self-loop must add 2w to keep 2m
+//     invariant under our convention)
+//   - within-community self-loop (u,u,w) → contributes w to the self-
+//     loop on its super-node
 func aggregate(g *Graph, sub []int) (*Graph, [][]int) {
-	// Gather members of each sub-community in deterministic order.
+	// Gather members of each sub-community in deterministic order so
+	// the new node indexing is stable across runs with the same RNG.
 	type pair struct{ label, node int }
 	pairs := make([]pair, 0, g.N)
 	for u, c := range sub {
@@ -460,54 +481,44 @@ func aggregate(g *Graph, sub []int) (*Graph, [][]int) {
 	}
 
 	newG := NewGraph(len(mapping))
-	// Sum edge weights between super-nodes.
+
 	type key struct{ a, b int }
-	weights := map[key]float64{}
+	cross := map[key]float64{} // canonical a<=b: sum of original cross edge weights, each counted ONCE
+	self := map[int]float64{}  // super-node a: aggregated self-loop weight (already adjusted)
+
 	for u := 0; u < g.N; u++ {
 		nu := labelToNew[sub[u]]
 		for _, e := range g.Adj[u] {
 			nv := labelToNew[sub[e.To]]
-			if nv < nu {
+			if e.To == u {
+				// Original self-loop: appears once in Adj[u].
+				self[nu] += e.Weight
 				continue
 			}
-			weights[key{nu, nv}] += e.Weight
-		}
-	}
-	// Collapse: for each (a,b) pair, the AddEdge call below counts
-	// the undirected edge once. But our weights map already summed
-	// weights from BOTH directions (u->v and v->u contributed when
-	// nv >= nu)... wait, no — we only added when nv >= nu, so each
-	// undirected edge contributed once from u->v (when nu==nv it's a
-	// self-loop and we count only once; when nu<nv we count u->v but
-	// not v->u). Let's re-check.
-	//
-	// For an undirected edge u—v with nu != nv, Adj[u] has (v,w) and
-	// Adj[v] has (u,w). When iterating u, e.To=v gives (nu, nv). If
-	// nv > nu we record. When iterating v, e.To=u gives (nv, nu).
-	// Since nu < nv, "nv < nu" is false → we'd record (nv, nu) too.
-	// That's two records for one undirected edge. Fix: restrict
-	// the storage key to ordered pairs.
-	weights = map[key]float64{}
-	for u := 0; u < g.N; u++ {
-		nu := labelToNew[sub[u]]
-		for _, e := range g.Adj[u] {
-			nv := labelToNew[sub[e.To]]
+			if nu == nv {
+				// Within-community non-self edge u-v (u≠v). Adj[u] has
+				// (v,w) and Adj[v] has (u,w); both iterations contribute
+				// e.Weight here. Sum of both = 2w, which is exactly the
+				// self-loop weight needed to preserve 2m.
+				self[nu] += e.Weight
+				continue
+			}
+			// Cross-community non-self edge. Both directions contribute;
+			// halve at the end for canonical single-counting.
 			a, b := nu, nv
 			if a > b {
 				a, b = b, a
 			}
-			weights[key{a, b}] += e.Weight
+			cross[key{a, b}] += e.Weight
 		}
 	}
-	// Each undirected edge u—v (u != v) is recorded in both Adj[u]
-	// and Adj[v]; so weights[key{a,b}] for a<b is 2*w_uv. For
-	// self-loops (a==b) Adj[u] has (u,w) once, so weights[key{u,u}]
-	// is w. But AddEdge expects single-edge weight. Halve non-self.
-	for k, w := range weights {
-		if k.a == k.b {
-			newG.AddEdge(k.a, k.b, w)
-		} else {
-			newG.AddEdge(k.a, k.b, w/2)
+
+	for k, w := range cross {
+		newG.AddEdge(k.a, k.b, w/2)
+	}
+	for a, w := range self {
+		if w > 0 {
+			newG.AddEdge(a, a, w)
 		}
 	}
 

--- a/pkg/analytics/leiden/leiden.go
+++ b/pkg/analytics/leiden/leiden.go
@@ -1,0 +1,515 @@
+// Package leiden is a pure-Go implementation of the Leiden community
+// detection algorithm (Traag, Waltman, van Eck 2019), an improvement on
+// Louvain that guarantees connected communities and avoids badly-
+// connected splits.
+//
+// Quality function is resolution-parameterised modularity:
+//
+//	Q(γ) = 1/(2m) Σ_C [Σ_in(C) - γ * (Σ_tot(C))^2 / (2m)]
+//
+// At γ=1 this is standard Newman-Girvan modularity. Higher γ pushes
+// toward smaller communities, lower γ toward fewer larger ones.
+//
+// The implementation runs three phases per outer iteration:
+//   - local move: greedy ΔQ-improving moves until no node moves
+//   - refinement: split each community into well-connected
+//     sub-communities so the aggregate graph respects connectivity
+//   - aggregate: collapse refined communities into super-nodes; recurse
+//
+// Determinism: with a fixed seed, the same graph + γ produce the same
+// partition on the same Go version. Internal node iteration order is
+// shuffled each pass via the seeded RNG.
+package leiden
+
+import (
+	"math/rand"
+	"sort"
+)
+
+// Neighbor is one entry in an adjacency list: a destination node and
+// the weight of the edge to it.
+type Neighbor struct {
+	To     int
+	Weight float64
+}
+
+// Graph is an undirected weighted graph. Adj[i] holds i's outgoing
+// edges; for an undirected edge (u,v,w) both Adj[u] and Adj[v] hold it.
+// Self-loops appear once in Adj[i] and contribute weight w (not 2w) to
+// NodeWeight[i] — the doubling for modularity is handled in the kernel.
+type Graph struct {
+	N           int
+	Adj         [][]Neighbor
+	NodeWeight  []float64 // sum of incident edge weights
+	TotalWeight float64   // 2m: sum of all edge weights, with each edge counted twice
+}
+
+// NewGraph allocates an empty graph with n nodes.
+func NewGraph(n int) *Graph {
+	return &Graph{
+		N:          n,
+		Adj:        make([][]Neighbor, n),
+		NodeWeight: make([]float64, n),
+	}
+}
+
+// AddEdge adds an undirected edge u—v with weight w. Self-loops are
+// allowed and contribute correctly to modularity. Adding a duplicate
+// edge stacks weights — callers can pre-aggregate or rely on this.
+func (g *Graph) AddEdge(u, v int, w float64) {
+	if w == 0 {
+		return
+	}
+	g.Adj[u] = append(g.Adj[u], Neighbor{To: v, Weight: w})
+	g.NodeWeight[u] += w
+	g.TotalWeight += w
+	if u != v {
+		g.Adj[v] = append(g.Adj[v], Neighbor{To: u, Weight: w})
+		g.NodeWeight[v] += w
+		g.TotalWeight += w
+	}
+	// Self-loop: counted once in Adj, w added once to NodeWeight, w
+	// added once to TotalWeight here. Modularity treats self-loops as
+	// 2w in degree and 2w in TotalWeight; we'll correct in the kernel.
+	if u == v {
+		g.NodeWeight[u] += w
+		g.TotalWeight += w
+	}
+}
+
+// Result is the output of Run.
+type Result struct {
+	// Communities[i] is the community label for node i, relabelled so
+	// labels are dense in [0, NumComms).
+	Communities []int
+	NumComms    int
+	// Modularity is Q(γ) of the returned partition.
+	Modularity float64
+	// Iterations counts completed outer iterations (local-move +
+	// refine + aggregate cycles).
+	Iterations int
+}
+
+// Run executes Leiden with resolution γ. Seed controls RNG ordering;
+// pass 0 for a fixed default. maxIter caps the outer loop; ≤0 falls
+// back to a sensible default. Returns a partition over g's nodes.
+func Run(g *Graph, gamma float64, seed int64, maxIter int) *Result {
+	if maxIter <= 0 {
+		maxIter = 32
+	}
+	rng := rand.New(rand.NewSource(seed))
+
+	// Phase-0 partition: every node its own community.
+	current := identityPartition(g.N)
+
+	working := g
+	// trace[level][i] = community of original node i in `current` at
+	// level. We reconstruct the original-node partition from the
+	// aggregated communities by following the chain.
+	type level struct {
+		// nodeOf[k] = list of working-graph indices that node k aggregates.
+		// At level 0 this is identity ([k] -> [k]).
+		nodeToOriginals [][]int
+		// commAfterMove[k] = community of working-graph node k after
+		// local-moving but BEFORE the refinement split (used to seed
+		// the next level's partition; see Traag et al. §3.3).
+		commAfterMove []int
+	}
+
+	levels := []level{{nodeToOriginals: identityNodeMap(g.N)}}
+	iter := 0
+	for ; iter < maxIter; iter++ {
+		// Local move on the working graph, starting from `current`.
+		localMoveImproved := localMove(working, current, gamma, rng)
+
+		// Snapshot post-local-move partition (used to seed next level).
+		postLocal := append([]int(nil), current...)
+
+		// Refine inside each community, then aggregate.
+		refined := refine(working, current, gamma, rng)
+		aggregated, mapping := aggregate(working, refined)
+
+		// If aggregation didn't change anything (every refined comm has
+		// one node — i.e., the partition is fully refined-stable) and
+		// local move didn't improve, we're done.
+		if !localMoveImproved && len(aggregated.Adj) == working.N {
+			levels[len(levels)-1].commAfterMove = postLocal
+			iter++
+			break
+		}
+
+		// Seed next level's partition from `postLocal` projected onto
+		// the aggregated graph: each new node's community is the
+		// post-local-move community of any of its constituents (they
+		// all share one because refinement only splits within them).
+		nextPartition := make([]int, len(aggregated.Adj))
+		for newIdx, originals := range mapping {
+			// Pick the community label from the first original.
+			nextPartition[newIdx] = postLocal[originals[0]]
+		}
+		// Densify labels.
+		nextPartition = densify(nextPartition)
+
+		levels[len(levels)-1].commAfterMove = postLocal
+		levels = append(levels, level{nodeToOriginals: expandMapping(mapping, levels[len(levels)-1].nodeToOriginals)})
+
+		working = aggregated
+		current = nextPartition
+	}
+
+	// Project the final partition (`current` over the deepest aggregate)
+	// back onto the original nodes.
+	finalPerOrig := make([]int, g.N)
+	deepest := levels[len(levels)-1].nodeToOriginals
+	for newIdx, comm := range current {
+		for _, orig := range deepest[newIdx] {
+			finalPerOrig[orig] = comm
+		}
+	}
+	finalPerOrig = densify(finalPerOrig)
+	q := modularity(g, finalPerOrig, gamma)
+
+	return &Result{
+		Communities: finalPerOrig,
+		NumComms:    countDistinct(finalPerOrig),
+		Modularity:  q,
+		Iterations:  iter,
+	}
+}
+
+// identityPartition returns [0,1,2,...,n-1].
+func identityPartition(n int) []int {
+	p := make([]int, n)
+	for i := range p {
+		p[i] = i
+	}
+	return p
+}
+
+// identityNodeMap returns [[0],[1],...,[n-1]] for level-0 mapping.
+func identityNodeMap(n int) [][]int {
+	m := make([][]int, n)
+	for i := range m {
+		m[i] = []int{i}
+	}
+	return m
+}
+
+// expandMapping composes a level-N mapping (newNode -> []prevNode)
+// with a level-(N-1) mapping (prevNode -> []origNode) to produce
+// level-N -> []origNode.
+func expandMapping(newToPrev [][]int, prevToOrig [][]int) [][]int {
+	out := make([][]int, len(newToPrev))
+	for i, prevs := range newToPrev {
+		var origs []int
+		for _, p := range prevs {
+			origs = append(origs, prevToOrig[p]...)
+		}
+		out[i] = origs
+	}
+	return out
+}
+
+// densify rewrites a partition so labels are 0..k-1 in order of first
+// appearance. Stable for deterministic output.
+func densify(p []int) []int {
+	remap := map[int]int{}
+	out := make([]int, len(p))
+	next := 0
+	for i, c := range p {
+		nc, ok := remap[c]
+		if !ok {
+			nc = next
+			next++
+			remap[c] = nc
+		}
+		out[i] = nc
+	}
+	return out
+}
+
+func countDistinct(p []int) int {
+	seen := map[int]struct{}{}
+	for _, c := range p {
+		seen[c] = struct{}{}
+	}
+	return len(seen)
+}
+
+// modularity computes Q(γ) for the given partition.
+//
+//	Q = 1/(2m) * Σ_C [Σ_in(C) - γ * (Σ_tot(C))^2 / (2m)]
+//
+// where Σ_in(C) is internal weight (each internal edge counted twice
+// for non-self-loops, twice for self-loops too), and Σ_tot(C) is total
+// incident weight.
+func modularity(g *Graph, comm []int, gamma float64) float64 {
+	if g.TotalWeight == 0 {
+		return 0
+	}
+	twoM := g.TotalWeight
+	// Σ_in(C) and Σ_tot(C).
+	sIn := map[int]float64{}
+	sTot := map[int]float64{}
+	for u := 0; u < g.N; u++ {
+		cu := comm[u]
+		sTot[cu] += g.NodeWeight[u]
+		for _, e := range g.Adj[u] {
+			if comm[e.To] == cu {
+				sIn[cu] += e.Weight
+			}
+		}
+	}
+	q := 0.0
+	for c, in := range sIn {
+		tot := sTot[c]
+		q += in/twoM - gamma*(tot/twoM)*(tot/twoM)
+	}
+	return q
+}
+
+// localMove runs the greedy local-moving phase. Each pass shuffles
+// node order, considers the best-ΔQ move for each node, and applies
+// it. Loops until a full pass produces no movement. Returns whether
+// any move happened across all passes.
+func localMove(g *Graph, comm []int, gamma float64, rng *rand.Rand) bool {
+	twoM := g.TotalWeight
+	if twoM == 0 {
+		return false
+	}
+
+	// Σ_tot(C): degree-sum per community.
+	sTot := make(map[int]float64)
+	for u := 0; u < g.N; u++ {
+		sTot[comm[u]] += g.NodeWeight[u]
+	}
+
+	order := make([]int, g.N)
+	for i := range order {
+		order[i] = i
+	}
+
+	anyImproved := false
+	for {
+		rng.Shuffle(len(order), func(i, j int) { order[i], order[j] = order[j], order[i] })
+		improvedThisPass := false
+		for _, u := range order {
+			cu := comm[u]
+			ku := g.NodeWeight[u]
+
+			// Sum of edge weights from u to each candidate community.
+			toComm := map[int]float64{}
+			selfLoop := 0.0
+			for _, e := range g.Adj[u] {
+				if e.To == u {
+					selfLoop += e.Weight
+					continue
+				}
+				toComm[comm[e.To]] += e.Weight
+			}
+
+			// Removing u from cu drops Σ_tot(cu) by ku.
+			// "Adjusted" removal gain (cost of being where we are):
+			//   removing u recovers gamma*ku*(Σ_tot(cu)-ku)/m  − 2*e_u_cu/2m
+			// We compute ΔQ for moving to each candidate (including
+			// staying: stay yields 0 by construction).
+			bestDelta := 0.0
+			bestComm := cu
+			eUtoCU := toComm[cu] // weight from u to cu \ {u} (self-loop excluded above)
+			sumCUminusU := sTot[cu] - ku
+
+			for c, eUtoC := range toComm {
+				if c == cu {
+					continue
+				}
+				sumC := sTot[c]
+				// ΔQ for u: cu -> c
+				// gain: (eUtoC - eUtoCU)/m - gamma*ku*(sumC - sumCUminusU)/(2m^2)
+				// Factor out 1/m and 1/(2m): use twoM (which is 2m).
+				delta := (eUtoC-eUtoCU)/(twoM/2) - gamma*ku*(sumC-sumCUminusU)/(twoM*twoM/2)
+				// Equivalent simpler form:
+				delta = 2*(eUtoC-eUtoCU)/twoM - gamma*ku*(sumC-sumCUminusU)*2/(twoM*twoM)
+				if delta > bestDelta+1e-12 {
+					bestDelta = delta
+					bestComm = c
+				}
+			}
+
+			if bestComm != cu {
+				// Apply move.
+				sTot[cu] -= ku
+				sTot[bestComm] += ku
+				comm[u] = bestComm
+				improvedThisPass = true
+				anyImproved = true
+			}
+			// Self-loop value used implicitly via toComm[cu] not
+			// including selfLoop; since we never move to cu, it does
+			// not matter for the comparison above.
+			_ = selfLoop
+		}
+		if !improvedThisPass {
+			break
+		}
+	}
+
+	return anyImproved
+}
+
+// refine takes the post-local-move partition and, for each community
+// from that partition, splits it into well-connected sub-communities.
+// We start every node in its own singleton sub-community, then run a
+// Leiden-style refinement: a node may move only to a sub-community
+// that lies entirely inside its parent community, and only if the move
+// strictly improves Q at the current γ. This guarantees the aggregated
+// graph respects connectivity (the central Leiden fix vs. Louvain).
+func refine(g *Graph, parent []int, gamma float64, rng *rand.Rand) []int {
+	twoM := g.TotalWeight
+	if twoM == 0 {
+		return append([]int(nil), parent...)
+	}
+
+	// Each node starts in its own sub-community. Sub-community labels
+	// are global (across parent communities) and use the original node
+	// indices as labels.
+	sub := identityPartition(g.N)
+	sTot := make(map[int]float64, g.N)
+	for u := 0; u < g.N; u++ {
+		sTot[sub[u]] = g.NodeWeight[u]
+	}
+
+	// Iterate nodes in random order. For each node u, consider only
+	// sub-communities in u's parent community. Apply the best move if
+	// it's a strict improvement.
+	order := make([]int, g.N)
+	for i := range order {
+		order[i] = i
+	}
+	rng.Shuffle(len(order), func(i, j int) { order[i], order[j] = order[j], order[i] })
+
+	for _, u := range order {
+		pu := parent[u]
+		ku := g.NodeWeight[u]
+		cu := sub[u]
+
+		toSub := map[int]float64{}
+		for _, e := range g.Adj[u] {
+			if e.To == u {
+				continue
+			}
+			if parent[e.To] != pu {
+				continue
+			}
+			toSub[sub[e.To]] += e.Weight
+		}
+
+		bestDelta := 0.0
+		bestComm := cu
+		eUtoCU := toSub[cu]
+		sumCUminusU := sTot[cu] - ku
+
+		for c, eUtoC := range toSub {
+			if c == cu {
+				continue
+			}
+			sumC := sTot[c]
+			delta := 2*(eUtoC-eUtoCU)/twoM - gamma*ku*(sumC-sumCUminusU)*2/(twoM*twoM)
+			if delta > bestDelta+1e-12 {
+				bestDelta = delta
+				bestComm = c
+			}
+		}
+
+		if bestComm != cu {
+			sTot[cu] -= ku
+			sTot[bestComm] += ku
+			sub[u] = bestComm
+		}
+	}
+
+	return sub
+}
+
+// aggregate collapses each refined sub-community into one node in a
+// new graph. Returns the aggregate graph and a mapping
+// newNode -> []origNode.
+func aggregate(g *Graph, sub []int) (*Graph, [][]int) {
+	// Gather members of each sub-community in deterministic order.
+	type pair struct{ label, node int }
+	pairs := make([]pair, 0, g.N)
+	for u, c := range sub {
+		pairs = append(pairs, pair{c, u})
+	}
+	sort.Slice(pairs, func(i, j int) bool {
+		if pairs[i].label != pairs[j].label {
+			return pairs[i].label < pairs[j].label
+		}
+		return pairs[i].node < pairs[j].node
+	})
+
+	labelToNew := map[int]int{}
+	mapping := [][]int{}
+	for _, p := range pairs {
+		idx, ok := labelToNew[p.label]
+		if !ok {
+			idx = len(mapping)
+			labelToNew[p.label] = idx
+			mapping = append(mapping, nil)
+		}
+		mapping[idx] = append(mapping[idx], p.node)
+	}
+
+	newG := NewGraph(len(mapping))
+	// Sum edge weights between super-nodes.
+	type key struct{ a, b int }
+	weights := map[key]float64{}
+	for u := 0; u < g.N; u++ {
+		nu := labelToNew[sub[u]]
+		for _, e := range g.Adj[u] {
+			nv := labelToNew[sub[e.To]]
+			if nv < nu {
+				continue
+			}
+			weights[key{nu, nv}] += e.Weight
+		}
+	}
+	// Collapse: for each (a,b) pair, the AddEdge call below counts
+	// the undirected edge once. But our weights map already summed
+	// weights from BOTH directions (u->v and v->u contributed when
+	// nv >= nu)... wait, no — we only added when nv >= nu, so each
+	// undirected edge contributed once from u->v (when nu==nv it's a
+	// self-loop and we count only once; when nu<nv we count u->v but
+	// not v->u). Let's re-check.
+	//
+	// For an undirected edge u—v with nu != nv, Adj[u] has (v,w) and
+	// Adj[v] has (u,w). When iterating u, e.To=v gives (nu, nv). If
+	// nv > nu we record. When iterating v, e.To=u gives (nv, nu).
+	// Since nu < nv, "nv < nu" is false → we'd record (nv, nu) too.
+	// That's two records for one undirected edge. Fix: restrict
+	// the storage key to ordered pairs.
+	weights = map[key]float64{}
+	for u := 0; u < g.N; u++ {
+		nu := labelToNew[sub[u]]
+		for _, e := range g.Adj[u] {
+			nv := labelToNew[sub[e.To]]
+			a, b := nu, nv
+			if a > b {
+				a, b = b, a
+			}
+			weights[key{a, b}] += e.Weight
+		}
+	}
+	// Each undirected edge u—v (u != v) is recorded in both Adj[u]
+	// and Adj[v]; so weights[key{a,b}] for a<b is 2*w_uv. For
+	// self-loops (a==b) Adj[u] has (u,w) once, so weights[key{u,u}]
+	// is w. But AddEdge expects single-edge weight. Halve non-self.
+	for k, w := range weights {
+		if k.a == k.b {
+			newG.AddEdge(k.a, k.b, w)
+		} else {
+			newG.AddEdge(k.a, k.b, w/2)
+		}
+	}
+
+	return newG, mapping
+}

--- a/pkg/analytics/leiden/leiden_test.go
+++ b/pkg/analytics/leiden/leiden_test.go
@@ -88,6 +88,13 @@ func TestRun_GraphWithSelfLoops(t *testing.T) {
 		t.Errorf("clique with self-loops at γ=1 should be 1 community, got %d (%v)",
 			res.NumComms, res.Communities)
 	}
+	// For any complete graph with everything in one community,
+	// Σ_in = Σ_tot = 2m, so Q = 1 - 1 = 0 at γ=1. This locks in
+	// that the A_ii=w convention is consistent end-to-end (NodeWeight,
+	// TotalWeight, and modularity's sIn all agree on self-loop weight).
+	if math.Abs(res.Modularity) > 1e-9 {
+		t.Errorf("expected Q=0 for one-community complete graph, got %v", res.Modularity)
+	}
 }
 
 // TestAggregate_PreservesTotalWeight: 2m must be invariant under

--- a/pkg/analytics/leiden/leiden_test.go
+++ b/pkg/analytics/leiden/leiden_test.go
@@ -53,10 +53,9 @@ func TestRun_SingleClique(t *testing.T) {
 	}
 }
 
-// TestRun_HighGammaShattersClique: at very high γ the resolution
-// penalty exceeds the internal-edge gain, and even a clique should
-// fragment. We don't assert an exact community count — just "more
-// than 1" — because the exact value depends on node count.
+// TestRun_HighGammaShattersClique: at γ well above any internal-edge
+// gain, every node should be alone in its own community. For an
+// 8-clique with unit weights, γ=5 is far past the shatter threshold.
 func TestRun_HighGammaShattersClique(t *testing.T) {
 	const n = 8
 	g := NewGraph(n)
@@ -66,8 +65,71 @@ func TestRun_HighGammaShattersClique(t *testing.T) {
 		}
 	}
 	res := Run(g, 5.0, 1, 0)
-	if res.NumComms == 1 {
-		t.Errorf("γ=5 should fragment a clique, got 1 community")
+	if res.NumComms != n {
+		t.Errorf("γ=5 should fully fragment an %d-clique into %d communities, got %d (%v)",
+			n, n, res.NumComms, res.Communities)
+	}
+}
+
+// TestRun_GraphWithSelfLoops verifies the self-loop convention is
+// internally consistent. A clique whose nodes carry self-loops should
+// still resolve to one community at γ=1.
+func TestRun_GraphWithSelfLoops(t *testing.T) {
+	const n = 5
+	g := NewGraph(n)
+	for i := 0; i < n; i++ {
+		g.AddEdge(i, i, 0.5) // self-loop on every node
+		for j := i + 1; j < n; j++ {
+			g.AddEdge(i, j, 1.0)
+		}
+	}
+	res := Run(g, 1.0, 1, 0)
+	if res.NumComms != 1 {
+		t.Errorf("clique with self-loops at γ=1 should be 1 community, got %d (%v)",
+			res.NumComms, res.Communities)
+	}
+}
+
+// TestAggregate_PreservesTotalWeight: 2m must be invariant under
+// aggregation. A direct check that the aggregate routine doesn't
+// inflate (or shrink) total edge weight.
+func TestAggregate_PreservesTotalWeight(t *testing.T) {
+	g := NewGraph(6)
+	addUndirectedEdges(g, [][2]int{
+		{0, 1}, {1, 2}, {2, 0}, // triangle A
+		{3, 4}, {4, 5}, {5, 3}, // triangle B
+		{2, 3},                 // bridge
+	})
+	// Group: nodes 0..2 in label 100, nodes 3..5 in label 200.
+	// (Labels need not be 0-indexed; aggregate normalises.)
+	sub := []int{100, 100, 100, 200, 200, 200}
+	originalTW := g.TotalWeight
+	agg, _ := aggregate(g, sub)
+	if math.Abs(agg.TotalWeight-originalTW) > 1e-9 {
+		t.Errorf("aggregate altered TotalWeight: original=%v aggregated=%v",
+			originalTW, agg.TotalWeight)
+	}
+}
+
+// TestAggregate_SelfLoopFromInternalEdges: if every edge in a graph
+// is internal to one community, the aggregate should be a single
+// node with a self-loop whose weight equals 2 × (sum of original
+// edge weights), matching the modularity 2m invariance.
+func TestAggregate_SelfLoopFromInternalEdges(t *testing.T) {
+	g := NewGraph(3)
+	addUndirectedEdges(g, [][2]int{{0, 1}, {1, 2}, {2, 0}})
+	originalTW := g.TotalWeight // 2m = 6 (3 edges × 2)
+	sub := []int{42, 42, 42}
+	agg, mapping := aggregate(g, sub)
+	if len(mapping) != 1 {
+		t.Fatalf("expected 1 super-node, got %d", len(mapping))
+	}
+	if math.Abs(agg.TotalWeight-originalTW) > 1e-9 {
+		t.Errorf("2m not preserved: original=%v aggregated=%v", originalTW, agg.TotalWeight)
+	}
+	// Single node should carry one self-loop (with the aggregated weight).
+	if len(agg.Adj[0]) != 1 || agg.Adj[0][0].To != 0 {
+		t.Errorf("expected single self-loop on the super-node, got Adj[0]=%v", agg.Adj[0])
 	}
 }
 

--- a/pkg/analytics/leiden/leiden_test.go
+++ b/pkg/analytics/leiden/leiden_test.go
@@ -1,0 +1,183 @@
+package leiden
+
+import (
+	"math"
+	"reflect"
+	"testing"
+)
+
+// addUndirectedEdges helps tests express graphs as edge lists.
+func addUndirectedEdges(g *Graph, edges [][2]int) {
+	for _, e := range edges {
+		g.AddEdge(e[0], e[1], 1.0)
+	}
+}
+
+// TestRun_TwoDisjointTriangles is the classic sanity check: a graph
+// of two triangles with no inter-triangle edges must yield exactly
+// two communities at γ=1, with the two halves cleanly separated.
+func TestRun_TwoDisjointTriangles(t *testing.T) {
+	g := NewGraph(6)
+	addUndirectedEdges(g, [][2]int{{0, 1}, {1, 2}, {2, 0}, {3, 4}, {4, 5}, {5, 3}})
+
+	res := Run(g, 1.0, 42, 0)
+	if res.NumComms != 2 {
+		t.Errorf("expected 2 communities, got %d (comms=%v)", res.NumComms, res.Communities)
+	}
+	// Nodes 0,1,2 share a community; 3,4,5 share another.
+	if res.Communities[0] != res.Communities[1] || res.Communities[1] != res.Communities[2] {
+		t.Errorf("triangle 1 split: %v", res.Communities)
+	}
+	if res.Communities[3] != res.Communities[4] || res.Communities[4] != res.Communities[5] {
+		t.Errorf("triangle 2 split: %v", res.Communities)
+	}
+	if res.Communities[0] == res.Communities[3] {
+		t.Errorf("triangles should be in different communities: %v", res.Communities)
+	}
+}
+
+// TestRun_SingleClique: a fully-connected graph at γ=1 should resolve
+// to one community (modularity is maximised by keeping it whole — no
+// split improves Q for a clique with no resolution boost).
+func TestRun_SingleClique(t *testing.T) {
+	const n = 6
+	g := NewGraph(n)
+	for i := 0; i < n; i++ {
+		for j := i + 1; j < n; j++ {
+			g.AddEdge(i, j, 1.0)
+		}
+	}
+	res := Run(g, 1.0, 1, 0)
+	if res.NumComms != 1 {
+		t.Errorf("clique at γ=1 should be one community, got %d (%v)", res.NumComms, res.Communities)
+	}
+}
+
+// TestRun_HighGammaShattersClique: at very high γ the resolution
+// penalty exceeds the internal-edge gain, and even a clique should
+// fragment. We don't assert an exact community count — just "more
+// than 1" — because the exact value depends on node count.
+func TestRun_HighGammaShattersClique(t *testing.T) {
+	const n = 8
+	g := NewGraph(n)
+	for i := 0; i < n; i++ {
+		for j := i + 1; j < n; j++ {
+			g.AddEdge(i, j, 1.0)
+		}
+	}
+	res := Run(g, 5.0, 1, 0)
+	if res.NumComms == 1 {
+		t.Errorf("γ=5 should fragment a clique, got 1 community")
+	}
+}
+
+// TestRun_EmptyGraph: zero nodes, zero edges — should not crash and
+// should return an empty result.
+func TestRun_EmptyGraph(t *testing.T) {
+	g := NewGraph(0)
+	res := Run(g, 1.0, 0, 0)
+	if res.NumComms != 0 {
+		t.Errorf("empty graph: NumComms=%d", res.NumComms)
+	}
+	if len(res.Communities) != 0 {
+		t.Errorf("empty graph: Communities=%v", res.Communities)
+	}
+}
+
+// TestRun_IsolatedNodes: nodes with no edges. Each isolated node
+// is its own community.
+func TestRun_IsolatedNodes(t *testing.T) {
+	g := NewGraph(4)
+	res := Run(g, 1.0, 0, 0)
+	if res.NumComms != 4 {
+		t.Errorf("4 isolated nodes should be 4 communities, got %d", res.NumComms)
+	}
+}
+
+// TestRun_Deterministic: same seed, same graph, same γ → same partition.
+func TestRun_Deterministic(t *testing.T) {
+	build := func() *Graph {
+		g := NewGraph(10)
+		// Two near-cliques with one bridge.
+		for _, e := range [][2]int{
+			{0, 1}, {1, 2}, {2, 3}, {3, 4}, {4, 0}, {0, 2}, {1, 3},
+			{5, 6}, {6, 7}, {7, 8}, {8, 9}, {9, 5}, {5, 7}, {6, 8},
+			{4, 5}, // bridge
+		} {
+			g.AddEdge(e[0], e[1], 1.0)
+		}
+		return g
+	}
+	a := Run(build(), 1.0, 1234, 0)
+	b := Run(build(), 1.0, 1234, 0)
+	if !reflect.DeepEqual(a.Communities, b.Communities) {
+		t.Errorf("non-deterministic: %v vs %v", a.Communities, b.Communities)
+	}
+}
+
+// TestRun_PlantedPartition: 3 cliques of size 5 connected by single
+// bridge edges between adjacent cliques. At γ=1 we expect to recover
+// the 3 planted communities.
+func TestRun_PlantedPartition(t *testing.T) {
+	const k = 3   // number of communities
+	const s = 5   // size of each
+	const n = k * s
+	g := NewGraph(n)
+	for c := 0; c < k; c++ {
+		base := c * s
+		for i := 0; i < s; i++ {
+			for j := i + 1; j < s; j++ {
+				g.AddEdge(base+i, base+j, 1.0)
+			}
+		}
+	}
+	// Bridges between consecutive cliques.
+	for c := 0; c < k-1; c++ {
+		g.AddEdge(c*s+s-1, (c+1)*s, 1.0)
+	}
+
+	res := Run(g, 1.0, 7, 0)
+	if res.NumComms != k {
+		t.Errorf("planted-partition: expected %d communities, got %d (%v)", k, res.NumComms, res.Communities)
+	}
+	// Each planted clique must be intact.
+	for c := 0; c < k; c++ {
+		base := c * s
+		want := res.Communities[base]
+		for i := 1; i < s; i++ {
+			if res.Communities[base+i] != want {
+				t.Errorf("clique %d split at node %d: %v", c, base+i, res.Communities)
+				break
+			}
+		}
+	}
+}
+
+// TestModularity_SingleClique: a 4-clique as one community at γ=1.
+// Σ_in = 12 (6 edges × 2), Σ_tot = 12 (each node degree 3, 4 nodes × 3),
+// 2m = 12. Q = 12/12 - (12/12)^2 = 0.
+func TestModularity_SingleClique(t *testing.T) {
+	g := NewGraph(4)
+	for i := 0; i < 4; i++ {
+		for j := i + 1; j < 4; j++ {
+			g.AddEdge(i, j, 1.0)
+		}
+	}
+	q := modularity(g, []int{0, 0, 0, 0}, 1.0)
+	if math.Abs(q-0.0) > 1e-9 {
+		t.Errorf("expected Q=0 for one-community 4-clique, got %v", q)
+	}
+}
+
+// TestModularity_TwoDisjointTriangles: each triangle is one community.
+// Per triangle: Σ_in = 6 (3 edges × 2), Σ_tot = 6, 2m_local = 6.
+// Total 2m = 12. Σ_in/2m for each = 6/12 = 0.5. (Σ_tot/2m)^2 = (6/12)^2 = 0.25.
+// Q = 2 × (0.5 - 0.25) = 0.5.
+func TestModularity_TwoDisjointTriangles(t *testing.T) {
+	g := NewGraph(6)
+	addUndirectedEdges(g, [][2]int{{0, 1}, {1, 2}, {2, 0}, {3, 4}, {4, 5}, {5, 3}})
+	q := modularity(g, []int{0, 0, 0, 1, 1, 1}, 1.0)
+	if math.Abs(q-0.5) > 1e-9 {
+		t.Errorf("expected Q=0.5, got %v", q)
+	}
+}

--- a/pkg/analytics/plugins/leiden.go
+++ b/pkg/analytics/plugins/leiden.go
@@ -1,0 +1,171 @@
+package plugins
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/johnjansen/loveliness/pkg/analytics/leiden"
+	"github.com/johnjansen/loveliness/pkg/router"
+)
+
+// Leiden runs the Leiden community-detection algorithm on the result
+// interpreted as an edge list. Returns per-community size histogram,
+// modularity, and (optionally) per-node community assignments.
+//
+// Params:
+//
+//	src    (string, default "src")     — column with source node id
+//	dst    (string, default "dst")     — column with destination node id
+//	weight (string, optional)          — column with edge weight (default 1.0)
+//	gamma  (float64, default 1.0)      — resolution; >1 finer, <1 coarser
+//	seed   (int64, default 0)          — RNG seed for determinism
+//	max_iter (int, default 32)         — outer-iteration cap
+//	include_assignments (bool, default false)
+//	    — if true, the result includes "assignments": map[id]community.
+//	      Off by default because for large graphs this dominates the
+//	      response payload; clients that want it must opt in.
+type Leiden struct{}
+
+func (Leiden) Name() string { return "leiden" }
+
+func (Leiden) Compute(_ context.Context, result *router.Result, params map[string]any) (any, error) {
+	srcCol := stringOr(params, "src", "src")
+	dstCol := stringOr(params, "dst", "dst")
+	weightCol, _ := params["weight"].(string)
+	gamma := float64Or(params, "gamma", 1.0)
+	seed := int64Or(params, "seed", 0)
+	maxIter := intOr(params, "max_iter", 0)
+	includeAssignments, _ := params["include_assignments"].(bool)
+
+	if !columnExists(result.Columns, srcCol) {
+		return nil, fmt.Errorf("leiden: src column %q not in result", srcCol)
+	}
+	if !columnExists(result.Columns, dstCol) {
+		return nil, fmt.Errorf("leiden: dst column %q not in result", dstCol)
+	}
+	if weightCol != "" && !columnExists(result.Columns, weightCol) {
+		return nil, fmt.Errorf("leiden: weight column %q not in result", weightCol)
+	}
+	if gamma < 0 {
+		return nil, fmt.Errorf("leiden: gamma must be ≥ 0, got %v", gamma)
+	}
+
+	// Build the graph. Each unique node id becomes an integer index.
+	// We iterate twice over rows: first to assign indices in
+	// stable first-seen order (so the output is deterministic for a
+	// given input order); second to add edges.
+	idIndex := map[string]int{}
+	nodeIDs := []string{}
+	indexOf := func(id string) int {
+		if i, ok := idIndex[id]; ok {
+			return i
+		}
+		i := len(nodeIDs)
+		idIndex[id] = i
+		nodeIDs = append(nodeIDs, id)
+		return i
+	}
+	for _, row := range result.Rows {
+		s := keyOf(row[srcCol])
+		d := keyOf(row[dstCol])
+		indexOf(s)
+		indexOf(d)
+	}
+
+	g := leiden.NewGraph(len(nodeIDs))
+	for _, row := range result.Rows {
+		u := idIndex[keyOf(row[srcCol])]
+		v := idIndex[keyOf(row[dstCol])]
+		w := 1.0
+		if weightCol != "" {
+			w = floatOf(row[weightCol])
+		}
+		if w <= 0 {
+			continue
+		}
+		g.AddEdge(u, v, w)
+	}
+
+	res := leiden.Run(g, gamma, seed, maxIter)
+
+	// Build size histogram (descending).
+	sizes := make([]int, res.NumComms)
+	for _, c := range res.Communities {
+		sizes[c]++
+	}
+	sort.Sort(sort.Reverse(sort.IntSlice(sizes)))
+
+	out := map[string]any{
+		"num_communities": res.NumComms,
+		"num_nodes":       len(nodeIDs),
+		"modularity":      res.Modularity,
+		"iterations":      res.Iterations,
+		"gamma":           gamma,
+		"size_histogram":  sizes,
+	}
+	if includeAssignments {
+		assign := make(map[string]int, len(nodeIDs))
+		for i, id := range nodeIDs {
+			assign[id] = res.Communities[i]
+		}
+		out["assignments"] = assign
+	}
+	return out, nil
+}
+
+// float64Or extracts a float64 from JSON params (which arrive as
+// float64 from encoding/json) with a default fallback.
+func float64Or(m map[string]any, k string, def float64) float64 {
+	if m == nil {
+		return def
+	}
+	switch v := m[k].(type) {
+	case float64:
+		return v
+	case int:
+		return float64(v)
+	case int64:
+		return float64(v)
+	}
+	return def
+}
+
+// int64Or extracts an int64 from params; encoding/json gives float64
+// for numbers so we accept both.
+func int64Or(m map[string]any, k string, def int64) int64 {
+	if m == nil {
+		return def
+	}
+	switch v := m[k].(type) {
+	case float64:
+		return int64(v)
+	case int:
+		return int64(v)
+	case int64:
+		return v
+	}
+	return def
+}
+
+func intOr(m map[string]any, k string, def int) int {
+	return int(int64Or(m, k, int64(def)))
+}
+
+// floatOf coerces a row cell to float64. Returns 0 for non-numeric
+// values, which AddEdge then skips.
+func floatOf(v any) float64 {
+	switch x := v.(type) {
+	case float64:
+		return x
+	case float32:
+		return float64(x)
+	case int:
+		return float64(x)
+	case int64:
+		return float64(x)
+	case int32:
+		return float64(x)
+	}
+	return 0
+}

--- a/pkg/analytics/plugins/leiden_test.go
+++ b/pkg/analytics/plugins/leiden_test.go
@@ -1,0 +1,137 @@
+package plugins
+
+import (
+	"context"
+	"testing"
+
+	"github.com/johnjansen/loveliness/pkg/router"
+)
+
+// edgeRow constructs a result row with src/dst columns.
+func edgeRow(s, d any) map[string]any {
+	return map[string]any{"src": s, "dst": d}
+}
+
+func TestLeiden_TwoTriangles(t *testing.T) {
+	r := &router.Result{
+		Columns: []string{"src", "dst"},
+		Rows: []map[string]any{
+			edgeRow("a", "b"), edgeRow("b", "c"), edgeRow("c", "a"),
+			edgeRow("x", "y"), edgeRow("y", "z"), edgeRow("z", "x"),
+		},
+	}
+	out, err := Leiden{}.Compute(context.Background(), r, map[string]any{
+		"include_assignments": true,
+		"seed":                float64(7),
+	})
+	if err != nil {
+		t.Fatalf("compute: %v", err)
+	}
+	got := out.(map[string]any)
+	if got["num_communities"].(int) != 2 {
+		t.Errorf("num_communities: %v (full=%v)", got["num_communities"], got)
+	}
+	assigns := got["assignments"].(map[string]int)
+	if assigns["a"] != assigns["b"] || assigns["b"] != assigns["c"] {
+		t.Errorf("triangle 1 split: %v", assigns)
+	}
+	if assigns["x"] != assigns["y"] || assigns["y"] != assigns["z"] {
+		t.Errorf("triangle 2 split: %v", assigns)
+	}
+	if assigns["a"] == assigns["x"] {
+		t.Errorf("triangles should be different communities: %v", assigns)
+	}
+}
+
+func TestLeiden_MissingSrcColumn(t *testing.T) {
+	r := &router.Result{Columns: []string{"a", "dst"}, Rows: []map[string]any{}}
+	if _, err := (Leiden{}).Compute(context.Background(), r, nil); err == nil {
+		t.Fatal("expected error for missing src column")
+	}
+}
+
+func TestLeiden_NegativeGammaRejected(t *testing.T) {
+	r := &router.Result{Columns: []string{"src", "dst"}, Rows: nil}
+	_, err := Leiden{}.Compute(context.Background(), r, map[string]any{"gamma": float64(-1)})
+	if err == nil {
+		t.Fatal("expected error for negative gamma")
+	}
+}
+
+func TestLeiden_WeightedEdges(t *testing.T) {
+	// Two near-cliques with a weak bridge. With weight=1 on bridge but
+	// weight=10 on internal edges, the partition should clearly split.
+	r := &router.Result{
+		Columns: []string{"src", "dst", "w"},
+		Rows: []map[string]any{
+			{"src": "a", "dst": "b", "w": float64(10)},
+			{"src": "b", "dst": "c", "w": float64(10)},
+			{"src": "c", "dst": "a", "w": float64(10)},
+			{"src": "d", "dst": "e", "w": float64(10)},
+			{"src": "e", "dst": "f", "w": float64(10)},
+			{"src": "f", "dst": "d", "w": float64(10)},
+			{"src": "c", "dst": "d", "w": float64(1)}, // bridge
+		},
+	}
+	out, err := Leiden{}.Compute(context.Background(), r, map[string]any{
+		"weight":              "w",
+		"include_assignments": true,
+	})
+	if err != nil {
+		t.Fatalf("compute: %v", err)
+	}
+	got := out.(map[string]any)
+	if got["num_communities"].(int) != 2 {
+		t.Errorf("expected 2 communities with weighted bridge, got %v", got)
+	}
+}
+
+func TestLeiden_Determinism(t *testing.T) {
+	build := func() *router.Result {
+		return &router.Result{
+			Columns: []string{"src", "dst"},
+			Rows: []map[string]any{
+				edgeRow("a", "b"), edgeRow("b", "c"), edgeRow("c", "d"),
+				edgeRow("d", "a"), edgeRow("a", "c"), edgeRow("e", "f"),
+				edgeRow("f", "g"), edgeRow("g", "e"), edgeRow("d", "e"),
+			},
+		}
+	}
+	params := map[string]any{"seed": float64(42), "include_assignments": true}
+	a, _ := Leiden{}.Compute(context.Background(), build(), params)
+	b, _ := Leiden{}.Compute(context.Background(), build(), params)
+	aa := a.(map[string]any)["assignments"].(map[string]int)
+	bb := b.(map[string]any)["assignments"].(map[string]int)
+	for k, v := range aa {
+		if bb[k] != v {
+			t.Errorf("non-deterministic at %q: %d vs %d", k, v, bb[k])
+		}
+	}
+}
+
+func TestLeiden_AssignmentsHiddenByDefault(t *testing.T) {
+	r := &router.Result{
+		Columns: []string{"src", "dst"},
+		Rows:    []map[string]any{edgeRow("a", "b")},
+	}
+	out, err := Leiden{}.Compute(context.Background(), r, nil)
+	if err != nil {
+		t.Fatalf("compute: %v", err)
+	}
+	got := out.(map[string]any)
+	if _, present := got["assignments"]; present {
+		t.Error("assignments should be omitted when not requested")
+	}
+}
+
+func TestLeiden_EmptyResult(t *testing.T) {
+	r := &router.Result{Columns: []string{"src", "dst"}, Rows: []map[string]any{}}
+	out, err := Leiden{}.Compute(context.Background(), r, nil)
+	if err != nil {
+		t.Fatalf("compute: %v", err)
+	}
+	got := out.(map[string]any)
+	if got["num_communities"].(int) != 0 {
+		t.Errorf("empty graph: num_communities=%v", got["num_communities"])
+	}
+}

--- a/pkg/api/analytics_test.go
+++ b/pkg/api/analytics_test.go
@@ -327,14 +327,35 @@ func TestAnalyticsList(t *testing.T) {
 		t.Fatal(err)
 	}
 	plugins := got["plugins"]
-	if len(plugins) != 2 {
-		t.Errorf("expected 2 built-in plugins, got %v", plugins)
+	if len(plugins) != 3 {
+		t.Errorf("expected 3 built-in plugins, got %v", plugins)
 	}
 	have := map[string]bool{}
 	for _, n := range plugins {
 		have[n] = true
 	}
-	if !have["count_by_label"] || !have["connected_components"] {
-		t.Errorf("missing built-in plugin: %v", plugins)
+	for _, want := range []string{"count_by_label", "connected_components", "leiden"} {
+		if !have[want] {
+			t.Errorf("missing built-in plugin %q: %v", want, plugins)
+		}
+	}
+}
+
+func TestQuery_LeidenSurfacesErrorOnMissingColumns(t *testing.T) {
+	// MATCH (n) RETURN n returns a single 'n' column. Leiden requires
+	// src/dst columns; the plugin should surface a clean error in
+	// analytics_errors rather than crashing or silently producing
+	// empty results.
+	srv := setupAnalyticsServer(t)
+	body := `{
+		"cypher": "MATCH (n) RETURN n",
+		"analytics": [{"name": "leiden"}]
+	}`
+	w, resp := postQuery(t, srv, body)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if _, ok := resp.AnalyticsErrors["leiden"]; !ok {
+		t.Errorf("expected leiden error for missing src column: %+v", resp.AnalyticsErrors)
 	}
 }

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -102,6 +102,7 @@ func defaultAnalyticsRegistry() *analytics.Registry {
 	for _, p := range []analytics.Plugin{
 		plugins.CountByLabel{},
 		plugins.ConnectedComponents{},
+		plugins.Leiden{},
 	} {
 		if err := reg.Register(p); err != nil {
 			panic(fmt.Sprintf("analytics: register %q: %v", p.Name(), err))


### PR DESCRIPTION
First slice of #69. Lays down a pure-Go Leiden implementation and the analytics-plugin wrapper. Two follow-up PRs will land multi-resolution sweep (phase 2) and plateau detection (phase 3) against the same issue.

## Why pure-Go (not leiden-rs FFI)
Decision per direction in #69 thread: skip the FFI complexity, native goroutine parallelism path remains open, full integration with shard structures is preserved, no cargo-in-Go-build pain, no daemon-takedown risk from Rust panics.

## What's in this PR
- pkg/analytics/leiden/ — algorithm core (~470 LOC):
  - Graph (weighted undirected adjacency, self-loops handled)
  - Run(g, γ, seed, maxIter) — outer loop: local-move → refine → aggregate
  - Resolution-parameterised modularity Q(γ)
  - Deterministic for a given seed
- pkg/analytics/plugins/leiden.go — plugin wrapper:
  - Reads result rows as edges (src, dst, optional weight column)
  - Params: gamma, seed, max_iter, include_assignments (off by default; assignments dominate payload for large graphs)
  - Returns num_communities, num_nodes, modularity, iterations, gamma, size_histogram, optional assignments
- Registered in defaultAnalyticsRegistry alongside count_by_label and connected_components.

## Test plan
- [x] go build ./...
- [x] go test -race ./... (all packages green)
- [x] Algorithm tests: two disjoint triangles, single clique, high-γ shatters clique, planted partition (3 cliques + bridges), determinism, empty/isolated nodes
- [x] Modularity formula spot-checks (single 4-clique → Q=0; two triangles → Q=0.5)
- [x] Plugin tests: weighted edges with weak bridge, determinism, assignments hidden by default, missing-column error, empty result
- [x] API-level: leiden appears in GET /analytics directory; surfaces clean error in analytics_errors when src/dst columns missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)