### PR TITLE
feat(analytics): leiden multi-resolution sweep (phase 2)

### DIFF
--- a/pkg/analytics/plugins/leiden.go
+++ b/pkg/analytics/plugins/leiden.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"sync"
 
 	"github.com/johnjansen/loveliness/pkg/analytics/leiden"
 	"github.com/johnjansen/loveliness/pkg/router"
@@ -13,18 +14,25 @@ import (
 // interpreted as an edge list. Returns per-community size histogram,
 // modularity, and (optionally) per-node community assignments.
 //
-// Params:
+// Resolution modes:
+//
+//	gamma   (float64, default 1.0) — single resolution; >1 finer, <1 coarser.
+//	gammas  ([]float64, optional)  — multi-resolution sweep. If set, the
+//	    plugin runs Leiden once per γ in parallel (one goroutine each, all
+//	    sharing the same input graph) and returns "partitions": [...] in
+//	    the same order. Mutually exclusive with `gamma`.
+//
+// Other params:
 //
 //	src    (string, default "src")     — column with source node id
 //	dst    (string, default "dst")     — column with destination node id
 //	weight (string, optional)          — column with edge weight (default 1.0)
-//	gamma  (float64, default 1.0)      — resolution; >1 finer, <1 coarser
-//	seed   (int64, default 0)          — RNG seed for determinism
-//	max_iter (int, default 32)         — outer-iteration cap
+//	seed   (int64, default 0)          — RNG seed for determinism (per γ)
+//	max_iter (int, default 32)         — outer-iteration cap (per γ)
 //	include_assignments (bool, default false)
-//	    — if true, the result includes "assignments": map[id]community.
-//	      Off by default because for large graphs this dominates the
-//	      response payload; clients that want it must opt in.
+//	    — if true, every partition's result includes "assignments":
+//	      map[id]community. Off by default because for large graphs this
+//	      dominates the response payload; clients that want it must opt in.
 type Leiden struct{}
 
 func (Leiden) Name() string { return "leiden" }
@@ -33,7 +41,6 @@ func (Leiden) Compute(_ context.Context, result *router.Result, params map[strin
 	srcCol := stringOr(params, "src", "src")
 	dstCol := stringOr(params, "dst", "dst")
 	weightCol, _ := params["weight"].(string)
-	gamma := float64Or(params, "gamma", 1.0)
 	seed := int64Or(params, "seed", 0)
 	maxIter := intOr(params, "max_iter", 0)
 	includeAssignments, _ := params["include_assignments"].(bool)
@@ -47,14 +54,90 @@ func (Leiden) Compute(_ context.Context, result *router.Result, params map[strin
 	if weightCol != "" && !columnExists(result.Columns, weightCol) {
 		return nil, fmt.Errorf("leiden: weight column %q not in result", weightCol)
 	}
-	if gamma < 0 {
-		return nil, fmt.Errorf("leiden: gamma must be ≥ 0, got %v", gamma)
+
+	gammas, sweep, err := resolveGammas(params)
+	if err != nil {
+		return nil, err
 	}
 
-	// Build the graph. Each unique node id becomes an integer index.
-	// We iterate twice over rows: first to assign indices in
-	// stable first-seen order (so the output is deterministic for a
-	// given input order); second to add edges.
+	g, nodeIDs := buildLeidenGraph(result, srcCol, dstCol, weightCol)
+
+	if !sweep {
+		// Single-resolution mode: flat result shape (unchanged).
+		gamma := gammas[0]
+		part := runOneGamma(g, gamma, seed, maxIter, nodeIDs, includeAssignments)
+		out := map[string]any{
+			"num_communities": part["num_communities"],
+			"num_nodes":       len(nodeIDs),
+			"modularity":      part["modularity"],
+			"iterations":      part["iterations"],
+			"gamma":           gamma,
+			"size_histogram":  part["size_histogram"],
+		}
+		if includeAssignments {
+			out["assignments"] = part["assignments"]
+		}
+		return out, nil
+	}
+
+	// Sweep mode: run all γ values in parallel against the shared
+	// (read-only) graph. leiden.Run does not mutate g; each call
+	// constructs its own working state, so concurrent execution is safe.
+	partitions := make([]map[string]any, len(gammas))
+	var wg sync.WaitGroup
+	wg.Add(len(gammas))
+	for i, gamma := range gammas {
+		go func(i int, gamma float64) {
+			defer wg.Done()
+			partitions[i] = runOneGamma(g, gamma, seed, maxIter, nodeIDs, includeAssignments)
+		}(i, gamma)
+	}
+	wg.Wait()
+
+	return map[string]any{
+		"num_nodes":  len(nodeIDs),
+		"partitions": partitions,
+	}, nil
+}
+
+// resolveGammas picks single-vs-sweep mode and validates inputs.
+// Returns the gamma list (length 1 in single mode), a sweep flag, and
+// any validation error.
+func resolveGammas(params map[string]any) ([]float64, bool, error) {
+	_, hasGamma := params["gamma"]
+	rawList, hasGammas := params["gammas"]
+	if hasGamma && hasGammas {
+		return nil, false, fmt.Errorf("leiden: pass either gamma or gammas, not both")
+	}
+
+	if hasGammas {
+		list, err := toFloat64Slice(rawList)
+		if err != nil {
+			return nil, false, fmt.Errorf("leiden: gammas: %w", err)
+		}
+		if len(list) == 0 {
+			return nil, false, fmt.Errorf("leiden: gammas must be non-empty")
+		}
+		for _, g := range list {
+			if g < 0 {
+				return nil, false, fmt.Errorf("leiden: gamma must be ≥ 0, got %v", g)
+			}
+		}
+		return list, true, nil
+	}
+
+	gamma := float64Or(params, "gamma", 1.0)
+	if gamma < 0 {
+		return nil, false, fmt.Errorf("leiden: gamma must be ≥ 0, got %v", gamma)
+	}
+	return []float64{gamma}, false, nil
+}
+
+// buildLeidenGraph turns edge-list rows into a *leiden.Graph plus the
+// stable id→index mapping (returned as the ordered nodeIDs slice).
+// Iterates twice over rows: first to assign indices in first-seen order
+// (so output is deterministic for a given input), second to add edges.
+func buildLeidenGraph(result *router.Result, srcCol, dstCol, weightCol string) (*leiden.Graph, []string) {
 	idIndex := map[string]int{}
 	nodeIDs := []string{}
 	indexOf := func(id string) int {
@@ -67,10 +150,8 @@ func (Leiden) Compute(_ context.Context, result *router.Result, params map[strin
 		return i
 	}
 	for _, row := range result.Rows {
-		s := keyOf(row[srcCol])
-		d := keyOf(row[dstCol])
-		indexOf(s)
-		indexOf(d)
+		indexOf(keyOf(row[srcCol]))
+		indexOf(keyOf(row[dstCol]))
 	}
 
 	g := leiden.NewGraph(len(nodeIDs))
@@ -86,10 +167,14 @@ func (Leiden) Compute(_ context.Context, result *router.Result, params map[strin
 		}
 		g.AddEdge(u, v, w)
 	}
+	return g, nodeIDs
+}
 
+// runOneGamma executes Leiden at a single γ and produces the partition
+// dict shared between the single-result and sweep paths.
+func runOneGamma(g *leiden.Graph, gamma float64, seed int64, maxIter int, nodeIDs []string, includeAssignments bool) map[string]any {
 	res := leiden.Run(g, gamma, seed, maxIter)
 
-	// Build size histogram (descending).
 	sizes := make([]int, res.NumComms)
 	for _, c := range res.Communities {
 		sizes[c]++
@@ -97,11 +182,10 @@ func (Leiden) Compute(_ context.Context, result *router.Result, params map[strin
 	sort.Sort(sort.Reverse(sort.IntSlice(sizes)))
 
 	out := map[string]any{
+		"gamma":           gamma,
 		"num_communities": res.NumComms,
-		"num_nodes":       len(nodeIDs),
 		"modularity":      res.Modularity,
 		"iterations":      res.Iterations,
-		"gamma":           gamma,
 		"size_histogram":  sizes,
 	}
 	if includeAssignments {
@@ -111,7 +195,39 @@ func (Leiden) Compute(_ context.Context, result *router.Result, params map[strin
 		}
 		out["assignments"] = assign
 	}
-	return out, nil
+	return out
+}
+
+// toFloat64Slice accepts the JSON-decoded forms a `gammas` list can
+// take ([]any with float/int entries, or []float64 directly) and
+// returns a clean []float64.
+func toFloat64Slice(raw any) ([]float64, error) {
+	switch v := raw.(type) {
+	case []float64:
+		out := make([]float64, len(v))
+		copy(out, v)
+		return out, nil
+	case []any:
+		out := make([]float64, len(v))
+		for i, x := range v {
+			switch n := x.(type) {
+			case float64:
+				out[i] = n
+			case float32:
+				out[i] = float64(n)
+			case int:
+				out[i] = float64(n)
+			case int64:
+				out[i] = float64(n)
+			case int32:
+				out[i] = float64(n)
+			default:
+				return nil, fmt.Errorf("entry %d is not a number (%T)", i, x)
+			}
+		}
+		return out, nil
+	}
+	return nil, fmt.Errorf("expected array, got %T", raw)
 }
 
 // float64Or extracts a float64 from JSON params (which arrive as

--- a/pkg/analytics/plugins/leiden.go
+++ b/pkg/analytics/plugins/leiden.go
@@ -3,6 +3,8 @@ package plugins
 import (
 	"context"
 	"fmt"
+	"math"
+	"runtime"
 	"sort"
 	"sync"
 
@@ -37,7 +39,11 @@ type Leiden struct{}
 
 func (Leiden) Name() string { return "leiden" }
 
-func (Leiden) Compute(_ context.Context, result *router.Result, params map[string]any) (any, error) {
+func (Leiden) Compute(ctx context.Context, result *router.Result, params map[string]any) (any, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
 	srcCol := stringOr(params, "src", "src")
 	dstCol := stringOr(params, "dst", "dst")
 	weightCol, _ := params["weight"].(string)
@@ -80,24 +86,54 @@ func (Leiden) Compute(_ context.Context, result *router.Result, params map[strin
 		return out, nil
 	}
 
-	// Sweep mode: run all γ values in parallel against the shared
-	// (read-only) graph. leiden.Run does not mutate g; each call
-	// constructs its own working state, so concurrent execution is safe.
+	// Sweep mode: run γ values in parallel against the shared (read-only)
+	// graph. leiden.Run does not mutate g; each call constructs its own
+	// working state, so concurrent execution is safe.
+	//
+	// Concurrency is bounded to runtime.NumCPU() so that a request with a
+	// pathologically large gammas list (e.g., 1000 entries) cannot saturate
+	// the host. Workers respect ctx between slots: a cancelled request stops
+	// admitting new γs immediately, though a γ already running completes
+	// (leiden.Run is CPU-bound and does not currently take ctx).
 	partitions := make([]map[string]any, len(gammas))
+	sem := make(chan struct{}, sweepConcurrency(len(gammas)))
 	var wg sync.WaitGroup
-	wg.Add(len(gammas))
 	for i, gamma := range gammas {
+		select {
+		case <-ctx.Done():
+			wg.Wait()
+			return nil, ctx.Err()
+		case sem <- struct{}{}:
+		}
+		wg.Add(1)
 		go func(i int, gamma float64) {
 			defer wg.Done()
+			defer func() { <-sem }()
 			partitions[i] = runOneGamma(g, gamma, seed, maxIter, nodeIDs, includeAssignments)
 		}(i, gamma)
 	}
 	wg.Wait()
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 
 	return map[string]any{
 		"num_nodes":  len(nodeIDs),
 		"partitions": partitions,
 	}, nil
+}
+
+// sweepConcurrency caps parallel γ workers to runtime.NumCPU() but never
+// allocates more slots than there are γs to run.
+func sweepConcurrency(n int) int {
+	c := runtime.NumCPU()
+	if c < 1 {
+		c = 1
+	}
+	if n < c {
+		return n
+	}
+	return c
 }
 
 // resolveGammas picks single-vs-sweep mode and validates inputs.
@@ -119,18 +155,35 @@ func resolveGammas(params map[string]any) ([]float64, bool, error) {
 			return nil, false, fmt.Errorf("leiden: gammas must be non-empty")
 		}
 		for _, g := range list {
-			if g < 0 {
-				return nil, false, fmt.Errorf("leiden: gamma must be ≥ 0, got %v", g)
+			if err := validateGamma(g); err != nil {
+				return nil, false, err
 			}
 		}
 		return list, true, nil
 	}
 
 	gamma := float64Or(params, "gamma", 1.0)
-	if gamma < 0 {
-		return nil, false, fmt.Errorf("leiden: gamma must be ≥ 0, got %v", gamma)
+	if err := validateGamma(gamma); err != nil {
+		return nil, false, err
 	}
 	return []float64{gamma}, false, nil
+}
+
+// validateGamma rejects negative, NaN, and ±Inf γ values. NaN in particular
+// would otherwise pass `g < 0` (NaN comparisons are false) and produce a
+// silent identity partition because every ΔQ comparison in localMove would
+// evaluate to false — a wrong-answer failure with no error signal.
+func validateGamma(g float64) error {
+	if math.IsNaN(g) {
+		return fmt.Errorf("leiden: gamma must be a finite real number, got NaN")
+	}
+	if math.IsInf(g, 0) {
+		return fmt.Errorf("leiden: gamma must be a finite real number, got %v", g)
+	}
+	if g < 0 {
+		return fmt.Errorf("leiden: gamma must be ≥ 0, got %v", g)
+	}
+	return nil
 }
 
 // buildLeidenGraph turns edge-list rows into a *leiden.Graph plus the

--- a/pkg/analytics/plugins/leiden_test.go
+++ b/pkg/analytics/plugins/leiden_test.go
@@ -135,3 +135,185 @@ func TestLeiden_EmptyResult(t *testing.T) {
 		t.Errorf("empty graph: num_communities=%v", got["num_communities"])
 	}
 }
+
+// twoCliquesPlusBridge: 8-node graph used as a multi-resolution probe.
+// Two 4-cliques joined by a single weak edge — at low γ everything
+// merges, at γ≈1 we see the 2-clique partition, and at high γ the
+// cliques shatter.
+func twoCliquesPlusBridge() *router.Result {
+	rows := []map[string]any{}
+	// clique A on {a0..a3}
+	for _, e := range [][2]string{{"a0", "a1"}, {"a0", "a2"}, {"a0", "a3"}, {"a1", "a2"}, {"a1", "a3"}, {"a2", "a3"}} {
+		rows = append(rows, edgeRow(e[0], e[1]))
+	}
+	// clique B on {b0..b3}
+	for _, e := range [][2]string{{"b0", "b1"}, {"b0", "b2"}, {"b0", "b3"}, {"b1", "b2"}, {"b1", "b3"}, {"b2", "b3"}} {
+		rows = append(rows, edgeRow(e[0], e[1]))
+	}
+	rows = append(rows, edgeRow("a3", "b0")) // weak bridge
+	return &router.Result{Columns: []string{"src", "dst"}, Rows: rows}
+}
+
+// TestLeiden_GammaSweep_Shape: passing `gammas` returns a partitions
+// list of the right length, with one entry per γ, in order.
+func TestLeiden_GammaSweep_Shape(t *testing.T) {
+	gammas := []any{float64(0.5), float64(1.0), float64(2.0)}
+	out, err := Leiden{}.Compute(context.Background(), twoCliquesPlusBridge(), map[string]any{
+		"gammas": gammas,
+		"seed":   float64(11),
+	})
+	if err != nil {
+		t.Fatalf("compute: %v", err)
+	}
+	got := out.(map[string]any)
+	if got["num_nodes"].(int) != 8 {
+		t.Errorf("num_nodes: %v", got["num_nodes"])
+	}
+	if _, ok := got["partitions"]; !ok {
+		t.Fatalf("expected partitions key, got %v", got)
+	}
+	parts := got["partitions"].([]map[string]any)
+	if len(parts) != len(gammas) {
+		t.Fatalf("expected %d partitions, got %d", len(gammas), len(parts))
+	}
+	for i, p := range parts {
+		want := gammas[i].(float64)
+		if p["gamma"].(float64) != want {
+			t.Errorf("partition[%d]: gamma=%v, want %v", i, p["gamma"], want)
+		}
+		// Required per-partition fields.
+		for _, k := range []string{"num_communities", "modularity", "iterations", "size_histogram"} {
+			if _, ok := p[k]; !ok {
+				t.Errorf("partition[%d] missing %q (%v)", i, k, p)
+			}
+		}
+		// Sweep mode without include_assignments must omit them.
+		if _, present := p["assignments"]; present {
+			t.Errorf("partition[%d]: assignments should be omitted when not requested", i)
+		}
+	}
+}
+
+// TestLeiden_GammaSweep_ResolvesByGamma: the same graph at γ=0.1
+// (very coarse) should yield ≤ communities than at γ=5 (very fine).
+// Specifically: at γ=5 the 4-cliques shatter (≥4 communities); at
+// γ=0.1 the bridge wins and everything collapses (1 community).
+func TestLeiden_GammaSweep_ResolvesByGamma(t *testing.T) {
+	out, err := Leiden{}.Compute(context.Background(), twoCliquesPlusBridge(), map[string]any{
+		"gammas": []any{float64(0.1), float64(5.0)},
+		"seed":   float64(3),
+	})
+	if err != nil {
+		t.Fatalf("compute: %v", err)
+	}
+	parts := out.(map[string]any)["partitions"].([]map[string]any)
+	low := parts[0]["num_communities"].(int)
+	high := parts[1]["num_communities"].(int)
+	if low > high {
+		t.Errorf("low γ should yield ≤ communities than high γ, got %d vs %d", low, high)
+	}
+	if low != 1 {
+		t.Errorf("γ=0.1 should collapse to 1 community, got %d", low)
+	}
+	if high < 8 {
+		t.Errorf("γ=5 should fragment into at least 8 communities (singletons), got %d", high)
+	}
+}
+
+// TestLeiden_GammaSweep_Determinism: same gammas + seed → same per-γ
+// partitions. Locks that parallel goroutine execution doesn't introduce
+// nondeterminism (each Run owns its RNG seeded from the shared seed).
+func TestLeiden_GammaSweep_Determinism(t *testing.T) {
+	params := map[string]any{
+		"gammas":              []any{float64(0.5), float64(1.0), float64(2.0)},
+		"seed":                float64(42),
+		"include_assignments": true,
+	}
+	a, _ := Leiden{}.Compute(context.Background(), twoCliquesPlusBridge(), params)
+	b, _ := Leiden{}.Compute(context.Background(), twoCliquesPlusBridge(), params)
+	aps := a.(map[string]any)["partitions"].([]map[string]any)
+	bps := b.(map[string]any)["partitions"].([]map[string]any)
+	if len(aps) != len(bps) {
+		t.Fatalf("partition count differs: %d vs %d", len(aps), len(bps))
+	}
+	for i := range aps {
+		aa := aps[i]["assignments"].(map[string]int)
+		bb := bps[i]["assignments"].(map[string]int)
+		for k, v := range aa {
+			if bb[k] != v {
+				t.Errorf("partition[%d] non-deterministic at %q: %d vs %d", i, k, v, bb[k])
+			}
+		}
+	}
+}
+
+// TestLeiden_GammaSweep_AssignmentsPerPartition: include_assignments
+// applies to every entry in the sweep, not just one.
+func TestLeiden_GammaSweep_AssignmentsPerPartition(t *testing.T) {
+	out, err := Leiden{}.Compute(context.Background(), twoCliquesPlusBridge(), map[string]any{
+		"gammas":              []any{float64(0.5), float64(1.0)},
+		"include_assignments": true,
+	})
+	if err != nil {
+		t.Fatalf("compute: %v", err)
+	}
+	parts := out.(map[string]any)["partitions"].([]map[string]any)
+	for i, p := range parts {
+		a, ok := p["assignments"].(map[string]int)
+		if !ok {
+			t.Fatalf("partition[%d]: missing assignments map", i)
+		}
+		if len(a) != 8 {
+			t.Errorf("partition[%d]: expected 8 assignments, got %d", i, len(a))
+		}
+	}
+}
+
+// TestLeiden_GammaSweep_RejectsBoth: passing both gamma and gammas is
+// ambiguous and must error rather than silently picking one.
+func TestLeiden_GammaSweep_RejectsBoth(t *testing.T) {
+	r := &router.Result{Columns: []string{"src", "dst"}, Rows: nil}
+	_, err := Leiden{}.Compute(context.Background(), r, map[string]any{
+		"gamma":  float64(1),
+		"gammas": []any{float64(0.5), float64(1.0)},
+	})
+	if err == nil {
+		t.Fatal("expected error when both gamma and gammas are set")
+	}
+}
+
+// TestLeiden_GammaSweep_RejectsEmpty: an empty gammas list is
+// nonsensical and must error.
+func TestLeiden_GammaSweep_RejectsEmpty(t *testing.T) {
+	r := &router.Result{Columns: []string{"src", "dst"}, Rows: nil}
+	_, err := Leiden{}.Compute(context.Background(), r, map[string]any{
+		"gammas": []any{},
+	})
+	if err == nil {
+		t.Fatal("expected error for empty gammas")
+	}
+}
+
+// TestLeiden_GammaSweep_RejectsNegative: any negative γ in the list
+// invalidates the whole sweep.
+func TestLeiden_GammaSweep_RejectsNegative(t *testing.T) {
+	r := &router.Result{Columns: []string{"src", "dst"}, Rows: nil}
+	_, err := Leiden{}.Compute(context.Background(), r, map[string]any{
+		"gammas": []any{float64(0.5), float64(-1)},
+	})
+	if err == nil {
+		t.Fatal("expected error for negative gamma in sweep")
+	}
+}
+
+// TestLeiden_GammaSweep_RejectsBadType: gammas must be a list, not a
+// scalar or other shape.
+func TestLeiden_GammaSweep_RejectsBadType(t *testing.T) {
+	r := &router.Result{Columns: []string{"src", "dst"}, Rows: nil}
+	_, err := Leiden{}.Compute(context.Background(), r, map[string]any{
+		"gammas": float64(1.0),
+	})
+	if err == nil {
+		t.Fatal("expected error for scalar gammas")
+	}
+}

--- a/pkg/analytics/plugins/leiden_test.go
+++ b/pkg/analytics/plugins/leiden_test.go
@@ -2,8 +2,10 @@ package plugins
 
 import (
 	"context"
+	"errors"
 	"math"
 	"testing"
+	"time"
 
 	"github.com/johnjansen/loveliness/pkg/router"
 )
@@ -335,18 +337,27 @@ func TestLeiden_RejectsNaNGamma(t *testing.T) {
 	}
 }
 
-// TestLeiden_RejectsInfGamma: ±Inf must error in either gamma or gammas.
+// TestLeiden_RejectsInfGamma: both ±Inf must error in either path.
+// Covered as a table to ensure both signs hit both single and sweep
+// modes (validateGamma is shared, but the test's job is to lock that
+// in).
 func TestLeiden_RejectsInfGamma(t *testing.T) {
 	r := &router.Result{Columns: []string{"src", "dst"}, Rows: nil}
-	if _, err := (Leiden{}).Compute(context.Background(), r, map[string]any{
-		"gamma": math.Inf(1),
-	}); err == nil {
-		t.Fatal("expected error for +Inf gamma")
+	cases := []struct {
+		name   string
+		params map[string]any
+	}{
+		{"single +Inf", map[string]any{"gamma": math.Inf(1)}},
+		{"single -Inf", map[string]any{"gamma": math.Inf(-1)}},
+		{"sweep +Inf", map[string]any{"gammas": []any{float64(1.0), math.Inf(1)}}},
+		{"sweep -Inf", map[string]any{"gammas": []any{math.Inf(-1)}}},
 	}
-	if _, err := (Leiden{}).Compute(context.Background(), r, map[string]any{
-		"gammas": []any{float64(1.0), math.Inf(-1)},
-	}); err == nil {
-		t.Fatal("expected error for -Inf in gammas")
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if _, err := (Leiden{}).Compute(context.Background(), r, c.params); err == nil {
+				t.Fatalf("expected error for %s", c.name)
+			}
+		})
 	}
 }
 
@@ -380,6 +391,7 @@ func TestLeiden_GammaSweep_SingleElement(t *testing.T) {
 
 // TestLeiden_GammaSweep_HonorsCancelledContext: a context already
 // cancelled at entry must error out without running any Leiden work.
+// Exercises the entry-guard ctx check.
 func TestLeiden_GammaSweep_HonorsCancelledContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // pre-cancel
@@ -390,7 +402,48 @@ func TestLeiden_GammaSweep_HonorsCancelledContext(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error from pre-cancelled context")
 	}
-	if err != context.Canceled {
+	if !errors.Is(err, context.Canceled) {
 		t.Errorf("expected context.Canceled, got %v", err)
+	}
+}
+
+// TestLeiden_GammaSweep_CancelMidSweep: cancelling ctx while a sweep is
+// in flight must (a) eventually return ctx.Err() and (b) not leak
+// goroutines or race on partitions[i] writes. The wg.Wait() drain in
+// the cancellation branch is what we're really exercising — combined
+// with -race it locks the goroutine-cleanup contract.
+//
+// We use a deeply parallel sweep (32 γ values) on a non-trivial graph
+// and cancel after a short delay. Because sweepConcurrency caps to
+// NumCPU(), most γs are queued behind the semaphore — cancellation
+// short-circuits those, and any in-flight workers finish naturally
+// before wg.Wait returns.
+func TestLeiden_GammaSweep_CancelMidSweep(t *testing.T) {
+	r := twoCliquesPlusBridge()
+	gammas := make([]any, 32)
+	for i := range gammas {
+		gammas[i] = float64(0.5 + 0.1*float64(i))
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		// Cancel almost immediately; the exact moment doesn't matter —
+		// we just need ctx to fire while the sweep is mid-loop.
+		time.Sleep(1 * time.Millisecond)
+		cancel()
+	}()
+
+	_, err := Leiden{}.Compute(ctx, r, map[string]any{
+		"gammas": gammas,
+		"seed":   float64(1),
+	})
+
+	// Either: cancellation hit mid-loop and we got context.Canceled,
+	// or all 32 γs finished before cancel fired (ultra-fast machine)
+	// and we got a normal result. Both are valid; the test's job is to
+	// exercise the cancellation path race-free, not to force it to
+	// always win.
+	if err != nil && !errors.Is(err, context.Canceled) {
+		t.Errorf("expected nil or context.Canceled, got %v", err)
 	}
 }

--- a/pkg/analytics/plugins/leiden_test.go
+++ b/pkg/analytics/plugins/leiden_test.go
@@ -2,6 +2,7 @@ package plugins
 
 import (
 	"context"
+	"math"
 	"testing"
 
 	"github.com/johnjansen/loveliness/pkg/router"
@@ -315,5 +316,81 @@ func TestLeiden_GammaSweep_RejectsBadType(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("expected error for scalar gammas")
+	}
+}
+
+// TestLeiden_RejectsNaNGamma: NaN must error (otherwise it silently
+// produces an identity partition because NaN comparisons are false).
+func TestLeiden_RejectsNaNGamma(t *testing.T) {
+	r := &router.Result{Columns: []string{"src", "dst"}, Rows: nil}
+	if _, err := (Leiden{}).Compute(context.Background(), r, map[string]any{
+		"gamma": math.NaN(),
+	}); err == nil {
+		t.Fatal("expected error for NaN gamma")
+	}
+	if _, err := (Leiden{}).Compute(context.Background(), r, map[string]any{
+		"gammas": []any{math.NaN()},
+	}); err == nil {
+		t.Fatal("expected error for NaN in gammas")
+	}
+}
+
+// TestLeiden_RejectsInfGamma: ±Inf must error in either gamma or gammas.
+func TestLeiden_RejectsInfGamma(t *testing.T) {
+	r := &router.Result{Columns: []string{"src", "dst"}, Rows: nil}
+	if _, err := (Leiden{}).Compute(context.Background(), r, map[string]any{
+		"gamma": math.Inf(1),
+	}); err == nil {
+		t.Fatal("expected error for +Inf gamma")
+	}
+	if _, err := (Leiden{}).Compute(context.Background(), r, map[string]any{
+		"gammas": []any{float64(1.0), math.Inf(-1)},
+	}); err == nil {
+		t.Fatal("expected error for -Inf in gammas")
+	}
+}
+
+// TestLeiden_GammaSweep_SingleElement: a one-element gammas list still
+// routes to sweep mode and returns a partitions array (length 1) — this
+// keeps the response shape stable for callers iterating over partitions
+// regardless of how many γ values they passed.
+func TestLeiden_GammaSweep_SingleElement(t *testing.T) {
+	out, err := Leiden{}.Compute(context.Background(), twoCliquesPlusBridge(), map[string]any{
+		"gammas": []any{float64(1.0)},
+	})
+	if err != nil {
+		t.Fatalf("compute: %v", err)
+	}
+	got := out.(map[string]any)
+	parts, ok := got["partitions"].([]map[string]any)
+	if !ok {
+		t.Fatalf("expected partitions array, got %T (%v)", got["partitions"], got)
+	}
+	if len(parts) != 1 {
+		t.Fatalf("expected 1 partition, got %d", len(parts))
+	}
+	if parts[0]["gamma"].(float64) != 1.0 {
+		t.Errorf("partition[0].gamma = %v, want 1.0", parts[0]["gamma"])
+	}
+	// Single-element sweep must NOT also produce the flat single-mode keys.
+	if _, present := got["num_communities"]; present {
+		t.Errorf("sweep response must not carry top-level num_communities, got %v", got)
+	}
+}
+
+// TestLeiden_GammaSweep_HonorsCancelledContext: a context already
+// cancelled at entry must error out without running any Leiden work.
+func TestLeiden_GammaSweep_HonorsCancelledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // pre-cancel
+
+	_, err := Leiden{}.Compute(ctx, twoCliquesPlusBridge(), map[string]any{
+		"gammas": []any{float64(0.5), float64(1.0), float64(2.0)},
+	})
+	if err == nil {
+		t.Fatal("expected error from pre-cancelled context")
+	}
+	if err != context.Canceled {
+		t.Errorf("expected context.Canceled, got %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

- New `gammas: [...]` param on the `leiden` plugin runs Leiden once per γ in parallel against the shared graph and returns `partitions: [...]` in input order.
- Single-resolution mode (`gamma` or neither) keeps the flat shape it had in Phase 1 — no breaking change.
- Parallelism is safe: `leiden.Run` doesn't mutate its input `*Graph`; per-γ work owns its own RNG and partition arrays.

## Wire shape

Sweep mode:
```json
{
  "num_nodes": 8,
  "partitions": [
    {"gamma": 0.5, "num_communities": 1, "modularity": ..., "iterations": ..., "size_histogram": [8]},
    {"gamma": 1.0, "num_communities": 2, "modularity": ..., "iterations": ..., "size_histogram": [4, 4]},
    {"gamma": 5.0, "num_communities": 8, "modularity": ..., "iterations": ..., "size_histogram": [1,1,1,1,1,1,1,1]}
  ]
}
```

Single mode (unchanged):
```json
{"num_communities": 2, "num_nodes": 8, "modularity": ..., "iterations": ..., "gamma": 1.0, "size_histogram": [4,4]}
```

## Validation

- empty `gammas` → error
- any γ < 0 in the list → error
- `gammas` not a list → error
- both `gamma` and `gammas` set → error

## Test plan

- [x] `go test -race -count=1 ./...` — all packages green, race-clean
- [x] sweep returns partitions in γ-order
- [x] low γ collapses, high γ shatters (resolution monotonicity)
- [x] determinism under parallel goroutine execution (same seed → same per-γ results)
- [x] `include_assignments` populates every partition entry
- [x] all four rejection paths produce errors

Refs #69.

🤖 Generated with [Claude Code](https://claude.com/claude-code)