### PR TITLE
feat(analytics): plateau detection over γ-sweep (phase 3)

### DIFF
--- a/pkg/analytics/leiden/plateau.go
+++ b/pkg/analytics/leiden/plateau.go
@@ -110,11 +110,9 @@ func NMI(a, b []int) float64 {
 		mi += pXY * math.Log(pXY/(pX*pY))
 	}
 
-	denom := hA + hB
-	if denom == 0 {
-		return 0
-	}
-	nmi := 2 * mi / denom
+	// hA + hB > 0 here: the trivial-vs-trivial case (hA == 0 && hB == 0)
+	// already returned 1 above.
+	nmi := 2 * mi / (hA + hB)
 	// Clamp to [0,1] to absorb floating-point drift; with finite-precision
 	// arithmetic NMI can land at 1.0000000003 for an identical partition.
 	if nmi > 1 {

--- a/pkg/analytics/leiden/plateau.go
+++ b/pkg/analytics/leiden/plateau.go
@@ -1,0 +1,139 @@
+package leiden
+
+import "math"
+
+// Plateau is a contiguous run of γ values that produce
+// near-identical partitions, separated by region(s) where the
+// partition shifts. Plateaus indicate natural community-structure
+// scales: γ values inside one give the same answer, so picking any
+// representative is safe.
+type Plateau struct {
+	// GammaMin/GammaMax bracket the plateau (inclusive on both ends).
+	GammaMin float64
+	GammaMax float64
+	// Indices into the original gamma slice (inclusive). A plateau
+	// of one entry has IndexLo == IndexHi.
+	IndexLo int
+	IndexHi int
+	// NumCommunities is the partition size shared across the plateau.
+	NumCommunities int
+	// Representative is the index of the γ chosen as the plateau's
+	// canonical sample (currently the midpoint).
+	Representative int
+}
+
+// DetectPlateaus groups a list of γ-ordered partitions into plateaus.
+// Two adjacent partitions belong to the same plateau when their
+// normalized mutual information is ≥ threshold. The input must be
+// sorted by ascending γ; partitions[i] is the partition produced at
+// gammas[i] (every slice is over the same node set, with N == len of
+// each entry).
+//
+// Threshold semantics: 1.0 means "must be identical"; 0.95 (the typical
+// default) tolerates tiny boundary jitter; lower values widen plateaus
+// at the cost of merging genuinely distinct scales.
+//
+// Returns plateaus in ascending γ order. An empty input returns nil.
+func DetectPlateaus(gammas []float64, partitions [][]int, threshold float64) []Plateau {
+	if len(gammas) == 0 {
+		return nil
+	}
+	if len(gammas) != len(partitions) {
+		return nil
+	}
+
+	plateaus := []Plateau{}
+	startIdx := 0
+	for i := 1; i < len(gammas); i++ {
+		nmi := NMI(partitions[i-1], partitions[i])
+		if nmi >= threshold {
+			continue
+		}
+		plateaus = append(plateaus, makePlateau(gammas, partitions, startIdx, i-1))
+		startIdx = i
+	}
+	plateaus = append(plateaus, makePlateau(gammas, partitions, startIdx, len(gammas)-1))
+	return plateaus
+}
+
+func makePlateau(gammas []float64, partitions [][]int, lo, hi int) Plateau {
+	rep := lo + (hi-lo)/2
+	return Plateau{
+		GammaMin:       gammas[lo],
+		GammaMax:       gammas[hi],
+		IndexLo:        lo,
+		IndexHi:        hi,
+		NumCommunities: countDistinct(partitions[rep]),
+		Representative: rep,
+	}
+}
+
+// NMI is the normalized mutual information between two partitions
+// of the same node set, using the symmetric arithmetic-mean
+// normalization 2·I(X;Y) / (H(X)+H(Y)).
+//
+// Range: [0, 1]. Returns 1 if both partitions are constant (single
+// community on each side — H is zero on both, MI is zero, by
+// convention NMI(trivial, trivial) is 1 because the partitions are
+// trivially identical). Returns NaN for length-mismatched input.
+func NMI(a, b []int) float64 {
+	if len(a) != len(b) {
+		return math.NaN()
+	}
+	n := len(a)
+	if n == 0 {
+		return 1
+	}
+
+	// Joint and marginal counts.
+	joint := map[[2]int]int{}
+	countA := map[int]int{}
+	countB := map[int]int{}
+	for i := 0; i < n; i++ {
+		joint[[2]int{a[i], b[i]}]++
+		countA[a[i]]++
+		countB[b[i]]++
+	}
+
+	hA := entropy(countA, n)
+	hB := entropy(countB, n)
+	if hA == 0 && hB == 0 {
+		// Both partitions are trivial; consider them identical.
+		return 1
+	}
+
+	mi := 0.0
+	for k, c := range joint {
+		pXY := float64(c) / float64(n)
+		pX := float64(countA[k[0]]) / float64(n)
+		pY := float64(countB[k[1]]) / float64(n)
+		mi += pXY * math.Log(pXY/(pX*pY))
+	}
+
+	denom := hA + hB
+	if denom == 0 {
+		return 0
+	}
+	nmi := 2 * mi / denom
+	// Clamp to [0,1] to absorb floating-point drift; with finite-precision
+	// arithmetic NMI can land at 1.0000000003 for an identical partition.
+	if nmi > 1 {
+		nmi = 1
+	}
+	if nmi < 0 {
+		nmi = 0
+	}
+	return nmi
+}
+
+func entropy(counts map[int]int, n int) float64 {
+	h := 0.0
+	for _, c := range counts {
+		if c == 0 {
+			continue
+		}
+		p := float64(c) / float64(n)
+		h -= p * math.Log(p)
+	}
+	return h
+}

--- a/pkg/analytics/leiden/plateau_test.go
+++ b/pkg/analytics/leiden/plateau_test.go
@@ -1,0 +1,143 @@
+package leiden
+
+import (
+	"math"
+	"reflect"
+	"testing"
+)
+
+// TestNMI_Identical: a partition compared against itself yields 1.
+func TestNMI_Identical(t *testing.T) {
+	a := []int{0, 0, 1, 1, 2, 2}
+	if v := NMI(a, a); math.Abs(v-1.0) > 1e-9 {
+		t.Errorf("NMI(a,a) should be 1, got %v", v)
+	}
+}
+
+// TestNMI_TrivialPartitions: two single-community partitions are
+// considered identical by convention (both H=0).
+func TestNMI_TrivialPartitions(t *testing.T) {
+	a := []int{0, 0, 0, 0}
+	b := []int{7, 7, 7, 7}
+	if v := NMI(a, b); v != 1 {
+		t.Errorf("NMI(trivial,trivial) should be 1, got %v", v)
+	}
+}
+
+// TestNMI_RelabelInvariant: NMI must not change when one partition's
+// labels are renamed (it cares about clusters, not labels).
+func TestNMI_RelabelInvariant(t *testing.T) {
+	a := []int{0, 0, 1, 1, 2, 2}
+	b := []int{9, 9, 5, 5, 3, 3} // same clustering, different labels
+	if v := NMI(a, b); math.Abs(v-1.0) > 1e-9 {
+		t.Errorf("NMI should be 1 under relabeling, got %v", v)
+	}
+}
+
+// TestNMI_OrthogonalPartitions: a uniform partition vs. its inverse
+// has NMI between 0 and 1; we just lock that the result is finite,
+// in [0,1], and not 1 (different clusterings).
+func TestNMI_OrthogonalPartitions(t *testing.T) {
+	a := []int{0, 1, 0, 1, 0, 1}
+	b := []int{0, 0, 1, 1, 2, 2}
+	v := NMI(a, b)
+	if math.IsNaN(v) || math.IsInf(v, 0) {
+		t.Fatalf("NMI not finite: %v", v)
+	}
+	if v < 0 || v > 1 {
+		t.Errorf("NMI out of [0,1]: %v", v)
+	}
+	if v == 1 {
+		t.Errorf("expected NMI < 1 for distinct partitions, got 1")
+	}
+}
+
+// TestNMI_LengthMismatch: returns NaN rather than panicking.
+func TestNMI_LengthMismatch(t *testing.T) {
+	if v := NMI([]int{0, 1}, []int{0, 0, 1}); !math.IsNaN(v) {
+		t.Errorf("expected NaN for length mismatch, got %v", v)
+	}
+}
+
+// TestDetectPlateaus_SingleStablePartition: same partition across all
+// γ values → one plateau spanning the full range.
+func TestDetectPlateaus_SingleStablePartition(t *testing.T) {
+	gammas := []float64{0.5, 1.0, 1.5, 2.0}
+	p := []int{0, 0, 1, 1, 2, 2}
+	parts := [][]int{p, p, p, p}
+	got := DetectPlateaus(gammas, parts, 0.95)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 plateau, got %d (%+v)", len(got), got)
+	}
+	if got[0].GammaMin != 0.5 || got[0].GammaMax != 2.0 {
+		t.Errorf("plateau range: [%v,%v], want [0.5,2.0]", got[0].GammaMin, got[0].GammaMax)
+	}
+	if got[0].NumCommunities != 3 {
+		t.Errorf("plateau num_communities: %d", got[0].NumCommunities)
+	}
+}
+
+// TestDetectPlateaus_TwoPlateaus: a clean break between two stable
+// regions yields two plateaus split at the transition.
+func TestDetectPlateaus_TwoPlateaus(t *testing.T) {
+	gammas := []float64{0.5, 1.0, 2.0, 3.0}
+	low := []int{0, 0, 0, 0, 0, 0}    // one community
+	high := []int{0, 1, 2, 3, 4, 5}   // all singletons
+	parts := [][]int{low, low, high, high}
+	got := DetectPlateaus(gammas, parts, 0.95)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 plateaus, got %d (%+v)", len(got), got)
+	}
+	if got[0].IndexLo != 0 || got[0].IndexHi != 1 {
+		t.Errorf("plateau[0] indices: %+v", got[0])
+	}
+	if got[1].IndexLo != 2 || got[1].IndexHi != 3 {
+		t.Errorf("plateau[1] indices: %+v", got[1])
+	}
+	if got[0].NumCommunities != 1 || got[1].NumCommunities != 6 {
+		t.Errorf("plateau community counts: %+v", got)
+	}
+}
+
+// TestDetectPlateaus_EmptyInput: zero γs → nil result.
+func TestDetectPlateaus_EmptyInput(t *testing.T) {
+	if got := DetectPlateaus(nil, nil, 0.95); got != nil {
+		t.Errorf("expected nil for empty input, got %+v", got)
+	}
+}
+
+// TestDetectPlateaus_SingleEntry: one γ → one plateau of length 1
+// covering that single entry. Representative is the entry itself.
+func TestDetectPlateaus_SingleEntry(t *testing.T) {
+	got := DetectPlateaus([]float64{1.0}, [][]int{{0, 0, 1, 1}}, 0.95)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 plateau, got %d", len(got))
+	}
+	want := Plateau{GammaMin: 1.0, GammaMax: 1.0, IndexLo: 0, IndexHi: 0, NumCommunities: 2, Representative: 0}
+	if !reflect.DeepEqual(got[0], want) {
+		t.Errorf("plateau: %+v, want %+v", got[0], want)
+	}
+}
+
+// TestDetectPlateaus_LengthMismatch: defensive — returns nil on bad input.
+func TestDetectPlateaus_LengthMismatch(t *testing.T) {
+	got := DetectPlateaus([]float64{1.0, 2.0}, [][]int{{0, 0}}, 0.95)
+	if got != nil {
+		t.Errorf("expected nil for length mismatch, got %+v", got)
+	}
+}
+
+// TestDetectPlateaus_RepresentativeIsMidpoint: a 5-entry plateau picks
+// the middle index (2). For 4 entries, picks lo + (hi-lo)/2 = 0+3/2 = 1.
+func TestDetectPlateaus_RepresentativeIsMidpoint(t *testing.T) {
+	gammas := []float64{0.1, 0.2, 0.3, 0.4, 0.5}
+	p := []int{0, 0, 1, 1}
+	parts := [][]int{p, p, p, p, p}
+	got := DetectPlateaus(gammas, parts, 0.95)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 plateau, got %d", len(got))
+	}
+	if got[0].Representative != 2 {
+		t.Errorf("expected midpoint 2, got %d", got[0].Representative)
+	}
+}

--- a/pkg/analytics/plugins/resolution_plateau.go
+++ b/pkg/analytics/plugins/resolution_plateau.go
@@ -1,0 +1,232 @@
+package plugins
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"sort"
+	"sync"
+
+	"github.com/johnjansen/loveliness/pkg/analytics/leiden"
+	"github.com/johnjansen/loveliness/pkg/router"
+)
+
+// ResolutionPlateau scans γ across a range, runs Leiden at each γ, and
+// reports the resulting plateaus — contiguous γ ranges where the
+// partition is stable. Plateaus indicate natural community-structure
+// scales: γ values inside one plateau give the same answer, so picking
+// any representative is safe.
+//
+// Params:
+//
+//	src    (string, default "src") — source-id column
+//	dst    (string, default "dst") — destination-id column
+//	weight (string, optional)      — edge-weight column (default 1.0 each)
+//
+//	gammas        ([]float64, optional)
+//	    — explicit γ sweep. If absent, an auto-range [gamma_min, gamma_max]
+//	      is generated with gamma_steps points (linearly spaced).
+//	gamma_min     (float64, default 0.1)
+//	gamma_max     (float64, default 5.0)
+//	gamma_steps   (int,     default 21)
+//	    — used only when `gammas` is absent.
+//
+//	nmi_threshold (float64, default 0.95)
+//	    — adjacent γ partitions with NMI ≥ threshold are part of the same
+//	      plateau. 1.0 demands identity; lower values widen plateaus.
+//
+//	seed       (int64, default 0)  — RNG seed for determinism (per γ)
+//	max_iter   (int,   default 32) — outer-iteration cap (per γ)
+//
+//	include_partitions  (bool, default false)
+//	    — if true, the response includes every per-γ partition's summary
+//	      (gamma, num_communities, modularity, …). Off by default because
+//	      it duplicates the plateau payload for the common case.
+//	include_assignments (bool, default false)
+//	    — if true, every plateau's representative carries the full
+//	      id→community map. Required for clients that want to USE the
+//	      partition; off by default to keep responses small.
+type ResolutionPlateau struct{}
+
+func (ResolutionPlateau) Name() string { return "resolution_plateau" }
+
+func (ResolutionPlateau) Compute(ctx context.Context, result *router.Result, params map[string]any) (any, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	srcCol := stringOr(params, "src", "src")
+	dstCol := stringOr(params, "dst", "dst")
+	weightCol, _ := params["weight"].(string)
+	seed := int64Or(params, "seed", 0)
+	maxIter := intOr(params, "max_iter", 0)
+	includePartitions, _ := params["include_partitions"].(bool)
+	includeAssignments, _ := params["include_assignments"].(bool)
+	threshold := float64Or(params, "nmi_threshold", 0.95)
+
+	if !columnExists(result.Columns, srcCol) {
+		return nil, fmt.Errorf("resolution_plateau: src column %q not in result", srcCol)
+	}
+	if !columnExists(result.Columns, dstCol) {
+		return nil, fmt.Errorf("resolution_plateau: dst column %q not in result", dstCol)
+	}
+	if weightCol != "" && !columnExists(result.Columns, weightCol) {
+		return nil, fmt.Errorf("resolution_plateau: weight column %q not in result", weightCol)
+	}
+	if math.IsNaN(threshold) || threshold < 0 || threshold > 1 {
+		return nil, fmt.Errorf("resolution_plateau: nmi_threshold must be in [0,1], got %v", threshold)
+	}
+
+	gammas, err := resolvePlateauGammas(params)
+	if err != nil {
+		return nil, err
+	}
+
+	g, nodeIDs := buildLeidenGraph(result, srcCol, dstCol, weightCol)
+
+	partitions, perGamma, err := runSweep(ctx, g, gammas, seed, maxIter, nodeIDs, includeAssignments)
+	if err != nil {
+		return nil, err
+	}
+
+	plateaus := leiden.DetectPlateaus(gammas, partitions, threshold)
+	plateauOut := make([]map[string]any, len(plateaus))
+	for i, p := range plateaus {
+		entry := map[string]any{
+			"gamma_min":            p.GammaMin,
+			"gamma_max":            p.GammaMax,
+			"num_communities":      p.NumCommunities,
+			"representative_gamma": gammas[p.Representative],
+		}
+		if includeAssignments {
+			// Reuse the per-γ map that runSweep already built for the
+			// representative index — no second pass needed.
+			if a, ok := perGamma[p.Representative]["assignments"]; ok {
+				entry["representative_partition"] = a
+			}
+		}
+		plateauOut[i] = entry
+	}
+
+	out := map[string]any{
+		"num_nodes":     len(nodeIDs),
+		"nmi_threshold": threshold,
+		"plateaus":      plateauOut,
+	}
+	if includePartitions {
+		out["partitions"] = perGamma
+	}
+	return out, nil
+}
+
+// resolvePlateauGammas picks the γ range, either from an explicit list
+// or by linear-spacing gamma_min..gamma_max in gamma_steps points.
+func resolvePlateauGammas(params map[string]any) ([]float64, error) {
+	if raw, ok := params["gammas"]; ok {
+		list, err := toFloat64Slice(raw)
+		if err != nil {
+			return nil, fmt.Errorf("resolution_plateau: gammas: %w", err)
+		}
+		if len(list) == 0 {
+			return nil, fmt.Errorf("resolution_plateau: gammas must be non-empty")
+		}
+		for _, g := range list {
+			if err := validateGamma(g); err != nil {
+				return nil, err
+			}
+		}
+		// Plateau detection assumes ascending γ — sort for safety.
+		sorted := make([]float64, len(list))
+		copy(sorted, list)
+		sort.Float64s(sorted)
+		return sorted, nil
+	}
+
+	gMin := float64Or(params, "gamma_min", 0.1)
+	gMax := float64Or(params, "gamma_max", 5.0)
+	steps := intOr(params, "gamma_steps", 21)
+	if err := validateGamma(gMin); err != nil {
+		return nil, err
+	}
+	if err := validateGamma(gMax); err != nil {
+		return nil, err
+	}
+	if gMax <= gMin {
+		return nil, fmt.Errorf("resolution_plateau: gamma_max (%v) must be > gamma_min (%v)", gMax, gMin)
+	}
+	if steps < 2 {
+		return nil, fmt.Errorf("resolution_plateau: gamma_steps must be ≥ 2, got %d", steps)
+	}
+
+	out := make([]float64, steps)
+	for i := 0; i < steps; i++ {
+		t := float64(i) / float64(steps-1)
+		out[i] = gMin + t*(gMax-gMin)
+	}
+	return out, nil
+}
+
+// runSweep runs Leiden once per γ in parallel against the shared
+// (read-only) graph and returns both the raw partition slices (used
+// by DetectPlateaus) and the per-γ presentable summaries (used by
+// the response).
+//
+// Concurrency mirrors the leiden plugin's sweep: bounded to NumCPU,
+// honors ctx cancellation between slots.
+func runSweep(ctx context.Context, g *leiden.Graph, gammas []float64, seed int64, maxIter int, nodeIDs []string, includeAssignments bool) ([][]int, []map[string]any, error) {
+	partitions := make([][]int, len(gammas))
+	summaries := make([]map[string]any, len(gammas))
+
+	sem := make(chan struct{}, sweepConcurrency(len(gammas)))
+	var wg sync.WaitGroup
+	for i, gamma := range gammas {
+		select {
+		case <-ctx.Done():
+			wg.Wait()
+			return nil, nil, ctx.Err()
+		case sem <- struct{}{}:
+		}
+		wg.Add(1)
+		go func(i int, gamma float64) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			res := leiden.Run(g, gamma, seed, maxIter)
+			partitions[i] = res.Communities
+			summaries[i] = formatPartition(res, gamma, nodeIDs, includeAssignments)
+		}(i, gamma)
+	}
+	wg.Wait()
+	if err := ctx.Err(); err != nil {
+		return nil, nil, err
+	}
+	return partitions, summaries, nil
+}
+
+// formatPartition matches the per-γ shape produced by the leiden
+// plugin's sweep mode, so the two plugins return interchangeable
+// per-partition records.
+func formatPartition(res *leiden.Result, gamma float64, nodeIDs []string, includeAssignments bool) map[string]any {
+	sizes := make([]int, res.NumComms)
+	for _, c := range res.Communities {
+		sizes[c]++
+	}
+	sort.Sort(sort.Reverse(sort.IntSlice(sizes)))
+	out := map[string]any{
+		"gamma":           gamma,
+		"num_communities": res.NumComms,
+		"modularity":      res.Modularity,
+		"iterations":      res.Iterations,
+		"size_histogram":  sizes,
+	}
+	if includeAssignments {
+		assign := make(map[string]int, len(nodeIDs))
+		for i, id := range nodeIDs {
+			assign[id] = res.Communities[i]
+		}
+		out["assignments"] = assign
+	}
+	return out
+}
+
+// sweepConcurrency is shared with the leiden plugin's sweep — defined
+// in leiden.go.

--- a/pkg/analytics/plugins/resolution_plateau_test.go
+++ b/pkg/analytics/plugins/resolution_plateau_test.go
@@ -1,0 +1,210 @@
+package plugins
+
+import (
+	"context"
+	"errors"
+	"math"
+	"testing"
+
+	"github.com/johnjansen/loveliness/pkg/router"
+)
+
+// TestResolutionPlateau_TwoCliquesYieldsPlateaus: a two-clique-with-bridge
+// fixture should produce at least two plateaus across a wide γ range — a
+// low-γ "all together" plateau, a mid-γ "two clusters" plateau, and a
+// high-γ "all singletons" plateau.
+func TestResolutionPlateau_TwoCliquesYieldsPlateaus(t *testing.T) {
+	out, err := ResolutionPlateau{}.Compute(context.Background(), twoCliquesPlusBridge(), map[string]any{
+		"gamma_min":   float64(0.05),
+		"gamma_max":   float64(5.0),
+		"gamma_steps": float64(20),
+		"seed":        float64(7),
+	})
+	if err != nil {
+		t.Fatalf("compute: %v", err)
+	}
+	got := out.(map[string]any)
+	plateaus := got["plateaus"].([]map[string]any)
+	if len(plateaus) < 2 {
+		t.Errorf("expected at least 2 plateaus across [0.05, 5.0], got %d (%+v)", len(plateaus), plateaus)
+	}
+	// Plateau community counts should be monotonically non-decreasing
+	// in γ — coarser at low γ, finer at high γ.
+	for i := 1; i < len(plateaus); i++ {
+		prev := plateaus[i-1]["num_communities"].(int)
+		cur := plateaus[i]["num_communities"].(int)
+		if cur < prev {
+			t.Errorf("plateau community count decreased: %d → %d (%+v)", prev, cur, plateaus)
+		}
+	}
+}
+
+// TestResolutionPlateau_ExplicitGammas: passing an explicit `gammas`
+// list overrides the default range and is sorted internally for plateau
+// detection.
+func TestResolutionPlateau_ExplicitGammas(t *testing.T) {
+	out, err := ResolutionPlateau{}.Compute(context.Background(), twoCliquesPlusBridge(), map[string]any{
+		// Intentionally out-of-order — the plugin must sort.
+		"gammas": []any{float64(2.0), float64(0.5), float64(1.0)},
+		"seed":   float64(3),
+	})
+	if err != nil {
+		t.Fatalf("compute: %v", err)
+	}
+	got := out.(map[string]any)
+	plateaus := got["plateaus"].([]map[string]any)
+	if len(plateaus) == 0 {
+		t.Fatalf("expected ≥1 plateau, got none")
+	}
+	// Plateau ranges must be in ascending γ order.
+	for i := 1; i < len(plateaus); i++ {
+		prev := plateaus[i-1]["gamma_max"].(float64)
+		cur := plateaus[i]["gamma_min"].(float64)
+		if cur <= prev {
+			t.Errorf("plateaus[%d].gamma_min (%v) ≤ plateaus[%d].gamma_max (%v)", i, cur, i-1, prev)
+		}
+	}
+}
+
+// TestResolutionPlateau_IncludePartitions: the per-γ summaries are
+// hidden by default and surfaced when include_partitions=true.
+func TestResolutionPlateau_IncludePartitions(t *testing.T) {
+	r := twoCliquesPlusBridge()
+
+	a, err := ResolutionPlateau{}.Compute(context.Background(), r, map[string]any{
+		"gammas": []any{float64(0.5), float64(1.0), float64(2.0)},
+	})
+	if err != nil {
+		t.Fatalf("compute: %v", err)
+	}
+	if _, present := a.(map[string]any)["partitions"]; present {
+		t.Error("partitions should be hidden by default")
+	}
+
+	b, err := ResolutionPlateau{}.Compute(context.Background(), r, map[string]any{
+		"gammas":             []any{float64(0.5), float64(1.0), float64(2.0)},
+		"include_partitions": true,
+	})
+	if err != nil {
+		t.Fatalf("compute: %v", err)
+	}
+	parts, ok := b.(map[string]any)["partitions"].([]map[string]any)
+	if !ok {
+		t.Fatalf("partitions missing or wrong type: %v", b)
+	}
+	if len(parts) != 3 {
+		t.Errorf("expected 3 partitions, got %d", len(parts))
+	}
+}
+
+// TestResolutionPlateau_RepresentativePartition: include_assignments=true
+// puts a representative partition map on every plateau.
+func TestResolutionPlateau_RepresentativePartition(t *testing.T) {
+	out, err := ResolutionPlateau{}.Compute(context.Background(), twoCliquesPlusBridge(), map[string]any{
+		"gammas":              []any{float64(0.5), float64(1.0), float64(2.0)},
+		"include_assignments": true,
+	})
+	if err != nil {
+		t.Fatalf("compute: %v", err)
+	}
+	plateaus := out.(map[string]any)["plateaus"].([]map[string]any)
+	for i, p := range plateaus {
+		rep, ok := p["representative_partition"].(map[string]int)
+		if !ok {
+			t.Errorf("plateau[%d] missing representative_partition: %v", i, p)
+			continue
+		}
+		if len(rep) != 8 {
+			t.Errorf("plateau[%d] representative_partition has %d nodes, want 8", i, len(rep))
+		}
+	}
+}
+
+// TestResolutionPlateau_RejectsBadThreshold: NMI thresholds must be in [0,1].
+func TestResolutionPlateau_RejectsBadThreshold(t *testing.T) {
+	r := &router.Result{Columns: []string{"src", "dst"}, Rows: nil}
+	for _, bad := range []float64{-0.1, 1.1, 2.0, math.NaN()} {
+		_, err := ResolutionPlateau{}.Compute(context.Background(), r, map[string]any{
+			"gammas":        []any{float64(1.0)},
+			"nmi_threshold": bad,
+		})
+		if err == nil {
+			t.Errorf("expected error for nmi_threshold=%v", bad)
+		}
+	}
+}
+
+// TestResolutionPlateau_RejectsBadGammaRange: gamma_max ≤ gamma_min,
+// gamma_steps < 2, and NaN/Inf bounds must all error.
+func TestResolutionPlateau_RejectsBadGammaRange(t *testing.T) {
+	r := &router.Result{Columns: []string{"src", "dst"}, Rows: nil}
+	cases := []struct {
+		name   string
+		params map[string]any
+	}{
+		{"max ≤ min", map[string]any{"gamma_min": float64(2), "gamma_max": float64(1)}},
+		{"max == min", map[string]any{"gamma_min": float64(1), "gamma_max": float64(1)}},
+		{"steps=1", map[string]any{"gamma_steps": float64(1)}},
+		{"NaN min", map[string]any{"gamma_min": math.NaN()}},
+		{"+Inf max", map[string]any{"gamma_max": math.Inf(1)}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if _, err := (ResolutionPlateau{}).Compute(context.Background(), r, c.params); err == nil {
+				t.Fatalf("expected error for %s", c.name)
+			}
+		})
+	}
+}
+
+// TestResolutionPlateau_RejectsEmptyGammas: explicit empty gammas list.
+func TestResolutionPlateau_RejectsEmptyGammas(t *testing.T) {
+	r := &router.Result{Columns: []string{"src", "dst"}, Rows: nil}
+	if _, err := (ResolutionPlateau{}).Compute(context.Background(), r, map[string]any{
+		"gammas": []any{},
+	}); err == nil {
+		t.Fatal("expected error for empty gammas")
+	}
+}
+
+// TestResolutionPlateau_HonorsCancelledContext: a pre-cancelled ctx
+// returns context.Canceled without running any work.
+func TestResolutionPlateau_HonorsCancelledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := ResolutionPlateau{}.Compute(ctx, twoCliquesPlusBridge(), map[string]any{
+		"gammas": []any{float64(0.5), float64(1.0)},
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+}
+
+// TestResolutionPlateau_RejectsMissingColumns: missing src/dst columns
+// surface as plugin errors, not panics.
+func TestResolutionPlateau_RejectsMissingColumns(t *testing.T) {
+	r := &router.Result{Columns: []string{"a", "b"}, Rows: nil}
+	if _, err := (ResolutionPlateau{}).Compute(context.Background(), r, nil); err == nil {
+		t.Fatal("expected error for missing src column")
+	}
+}
+
+// TestResolutionPlateau_DefaultRange: with no gamma params, uses the
+// default linear range and produces a non-empty plateau list.
+func TestResolutionPlateau_DefaultRange(t *testing.T) {
+	out, err := ResolutionPlateau{}.Compute(context.Background(), twoCliquesPlusBridge(), nil)
+	if err != nil {
+		t.Fatalf("compute: %v", err)
+	}
+	got := out.(map[string]any)
+	if got["nmi_threshold"].(float64) != 0.95 {
+		t.Errorf("default threshold not 0.95: %v", got["nmi_threshold"])
+	}
+	if got["num_nodes"].(int) != 8 {
+		t.Errorf("num_nodes: %v", got["num_nodes"])
+	}
+	plateaus := got["plateaus"].([]map[string]any)
+	if len(plateaus) == 0 {
+		t.Errorf("expected non-empty plateaus from default range")
+	}
+}

--- a/pkg/analytics/plugins/resolution_plateau_test.go
+++ b/pkg/analytics/plugins/resolution_plateau_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"math"
 	"testing"
+	"time"
 
 	"github.com/johnjansen/loveliness/pkg/router"
 )
@@ -177,6 +178,37 @@ func TestResolutionPlateau_HonorsCancelledContext(t *testing.T) {
 	})
 	if !errors.Is(err, context.Canceled) {
 		t.Errorf("expected context.Canceled, got %v", err)
+	}
+}
+
+// TestResolutionPlateau_CancelMidSweep: cancelling ctx while runSweep
+// is in flight must (a) eventually return ctx.Err() and (b) not leak
+// goroutines or race on partitions[i] writes. Mirrors the leiden
+// plugin's CancelMidSweep test — combined with -race it locks the
+// goroutine-cleanup contract for the resolution_plateau sweep.
+func TestResolutionPlateau_CancelMidSweep(t *testing.T) {
+	r := twoCliquesPlusBridge()
+	gammas := make([]any, 32)
+	for i := range gammas {
+		gammas[i] = float64(0.5 + 0.1*float64(i))
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(1 * time.Millisecond)
+		cancel()
+	}()
+
+	_, err := ResolutionPlateau{}.Compute(ctx, r, map[string]any{
+		"gammas": gammas,
+		"seed":   float64(1),
+	})
+
+	// Either cancellation hit mid-loop (context.Canceled) or all 32 γs
+	// finished first (nil). Both are valid; we just need the cancellation
+	// path to be race-free when it does fire.
+	if err != nil && !errors.Is(err, context.Canceled) {
+		t.Errorf("expected nil or context.Canceled, got %v", err)
 	}
 }
 

--- a/pkg/api/analytics_test.go
+++ b/pkg/api/analytics_test.go
@@ -327,14 +327,14 @@ func TestAnalyticsList(t *testing.T) {
 		t.Fatal(err)
 	}
 	plugins := got["plugins"]
-	if len(plugins) != 3 {
-		t.Errorf("expected 3 built-in plugins, got %v", plugins)
+	if len(plugins) != 4 {
+		t.Errorf("expected 4 built-in plugins, got %v", plugins)
 	}
 	have := map[string]bool{}
 	for _, n := range plugins {
 		have[n] = true
 	}
-	for _, want := range []string{"count_by_label", "connected_components", "leiden"} {
+	for _, want := range []string{"count_by_label", "connected_components", "leiden", "resolution_plateau"} {
 		if !have[want] {
 			t.Errorf("missing built-in plugin %q: %v", want, plugins)
 		}

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -103,6 +103,7 @@ func defaultAnalyticsRegistry() *analytics.Registry {
 		plugins.CountByLabel{},
 		plugins.ConnectedComponents{},
 		plugins.Leiden{},
+		plugins.ResolutionPlateau{},
 	} {
 		if err := reg.Register(p); err != nil {
 			panic(fmt.Sprintf("analytics: register %q: %v", p.Name(), err))


### PR DESCRIPTION
## Summary

Phase 3 of the Leiden multi-resolution effort (#69). Builds plateau detection on top of the parallel γ sweep landed in #78.

- **Core (`pkg/analytics/leiden/`)**: `NMI` + `DetectPlateaus`. NMI is symmetric, arithmetic-mean normalized, clamped to [0,1], with sensible behavior on trivial-vs-trivial and length mismatch. `DetectPlateaus` groups consecutive γ entries whose adjacent NMI ≥ threshold and exposes a midpoint representative.
- **Plugin (`pkg/analytics/plugins/resolution_plateau.go`)**: standalone `resolution_plateau` plugin. Reuses the bounded-concurrency, ctx-aware sweep pattern from #78. Default payload is plateau-only; per-γ partitions and per-plateau id→community maps are opt-in.
- **Validation**: NaN/±Inf/<0 γ rejected via shared `validateGamma`. NaN `nmi_threshold` rejected explicitly (NaN comparisons are always false, so the prior bounds-only check let NaN slip through — caught by test).

Refs #69. Follows #74 → #77 → #78.

## Test plan

- [x] `go test -race -count=1 ./pkg/analytics/... ./pkg/api/...` green
- [x] `go vet ./... && go build ./...` clean
- [x] 11 plateau core tests
- [x] 10 plugin tests (two-clique fixture, monotonicity, default-hidden partitions, opt-in assignments, ctx cancel, missing columns, bad params, empty γ list)
- [x] `TestAnalyticsList` updated to expect the 4th built-in plugin

🤖 Generated with [Claude Code](https://claude.com/claude-code)