### PR TITLE
spike(transport): cross-node transport gaps (#76)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -253,3 +253,26 @@ Loveliness passes all Cypher through to LadybugDB — the router only classifies
 | **Writes** | `CREATE`, `MERGE`, `SET`, `DELETE`, `DETACH DELETE`, `REMOVE` | Shard key required; routes to owning shard |
 | **Schema DDL** | `CREATE NODE TABLE`, `CREATE REL TABLE`, `DROP TABLE`, `ALTER` | Broadcast to all shards |
 | **Bulk** | `COPY FROM` | Via `/bulk/nodes` or `/bulk/edges` endpoints |
+
+## Cross-node transport gaps
+
+The current TCP+msgpack transport is "good loopback" but has ten known gaps before it's a production-grade cross-node transport. The full analysis lives in [`spike/cross-node-transport/FINDINGS.md`](../spike/cross-node-transport/FINDINGS.md); a prior-art survey of four distributed graph and SQL systems is in [`SURVEY.md`](../spike/cross-node-transport/SURVEY.md).
+
+Categorisation, recorded so we don't re-discover the same gaps next time someone polishes the router:
+
+| # | Gap | Category | Follow-up | Rationale |
+|---|---|---|---|---|
+| 1 | `TCPServer.handleConn` waits on idle deadline at shutdown | must-fix-pre-prod | [#83](https://github.com/dreamware-nz/loveliness/issues/83) | A rolling restart of an N-node cluster takes ≥ N minutes of wallclock; mechanical fix (`SetReadDeadline(now)` when `stopCh` fires). |
+| 2 | TCPPool size vs scatter cap uncoordinated | should-fix-soon | [#88](https://github.com/dreamware-nz/loveliness/issues/88) | Not a correctness bug; a throughput bug under fan-out. Parked behind the v2-frame decision (#89) because streaming changes whether multiplexing or pool growth is the right answer. |
+| 3 | No deadline propagation to remote shard | must-fix-pre-prod | [#84](https://github.com/dreamware-nz/loveliness/issues/84) | A slow shard keeps running after the caller times out — wastes CPU and (for writes) can race late completions. Survey is unanimous on propagating deadlines on the wire. |
+| 4 | No whole-query retry budget | must-fix-pre-prod | [#85](https://github.com/dreamware-nz/loveliness/issues/85) | Per-shard retries × shard count is multiplicative; a 32-shard query with 2 retries each is 96 RPCs. Co-designed with #84 — retries after the deadline must not happen. |
+| 5 | No streaming / chunked responses | frame-v2 dependent | [#89](https://github.com/dreamware-nz/loveliness/issues/89) | Universal in prior art. Cannot be retrofitted onto the v1 single-envelope reader without flag day; bundled with item 6 in a v2-frame design issue. |
+| 6 | No cancel / partial-result signalling | frame-v2 dependent | [#89](https://github.com/dreamware-nz/loveliness/issues/89) | Same shape as item 5. Requires a server-side control opcode v1 never reserved. Ships with item 5 in the v2 frame. |
+| 7 | No per-RPC correlation ID | should-fix-soon | [#86](https://github.com/dreamware-nz/loveliness/issues/86) | The only v1-additive change in the list: a `request_id` field that old peers ignore. ~50 lines for a large debugging win. |
+| 8 | mTLS not exercised in tests | won't-fix-in-transport | [#90](https://github.com/dreamware-nz/loveliness/issues/90) | Real gap, but it's a CI/test/docs gap — not a transport design gap. Filed as a `testing`-labelled follow-up. |
+| 9 | No admission control / QoS | won't-fix-in-transport | [#91](https://github.com/dreamware-nz/loveliness/issues/91) | Belongs at the router/policy layer, not the transport. Filed as a roadmap issue for the router. |
+| 10 | Pool eviction is reactive only | should-fix-soon | [#87](https://github.com/dreamware-nz/loveliness/issues/87) | `MsgPing/MsgPong` exists in the wire format but no keepalive loop uses it. Single-file work; catches half-dead connections. |
+
+**Frame-format decision:** item 7 ships as a v1-additive field. Items 5 and 6 require a v2 frame and ship together; the v2 frame is its own design issue with rolling-upgrade negotiation as a section. The v1 frame is otherwise stable.
+
+When a must-fix lands, edit the relevant row to read `done in #N` rather than recreating decision records elsewhere.

--- a/spike/cross-node-transport/FINDINGS.md
+++ b/spike/cross-node-transport/FINDINGS.md
@@ -1,0 +1,111 @@
+# Spike Findings — cross-node transport gaps (#76)
+
+**Verdict:** the polish series got us to "good loopback"; three gaps stop us shipping to anything multi-host (deadlines, retry amplification, teardown leak), three more are cheap wins worth doing soon, and a v2 frame is unavoidable once we want streaming or cancel. Drop in the recommendations below and we have a credible cross-node transport without leaving the TCP+msgpack architecture.
+
+## Inputs
+
+- Issue: [#76](https://github.com/dreamware-nz/loveliness/issues/76)
+- Polish series that surfaced these gaps: PRs #61, #65, #68, #73, #75
+- Survey of prior art: [SURVEY.md](./SURVEY.md) (Neo4j Fabric, DGraph, MemGraph, CockroachDB)
+- Code under discussion: `pkg/transport/tcp.go`, `pkg/transport/pool.go`, `pkg/router/`
+
+## Categorisation
+
+| # | Gap | Category | Follow-up |
+|---|---|---|---|
+| 1 | `TCPServer.handleConn` blocks teardown on 60s idle | **must-fix-pre-prod** | new issue (S) |
+| 2 | TCPPool sizing vs scatter cap uncoordinated | **should-fix-soon** | new issue (M) |
+| 3 | No deadline propagation into remote shard | **must-fix-pre-prod** | new issue (M) |
+| 4 | No retry budget for the whole query | **must-fix-pre-prod** | new issue (M) |
+| 5 | No streaming / chunked responses | **frame-v2 dependent — defer** | bundled into v2 frame issue |
+| 6 | No cancel / partial-result signalling | **frame-v2 dependent — defer** | bundled into v2 frame issue |
+| 7 | No per-RPC correlation ID | **should-fix-soon** | new issue (S) — see frame-v1-additive note |
+| 8 | mTLS not exercised in tests | **won't-fix-here** (test/docs gap) | new issue (S), `testing` label |
+| 9 | No admission control / QoS | **won't-fix-here** (policy layer, not transport) | new roadmap issue |
+| 10 | Pool eviction is reactive only | **should-fix-soon** | new issue (S) |
+
+Counts: 3 must-fix, 3 should-fix, 2 frame-v2 dependent, 2 won't-fix-here.
+
+## Rationale per item
+
+### 1. Teardown blocked on idle deadline — must-fix
+The 60s read deadline means a clean `Stop()` waits up to 60s per connection. The bench saw 120s wallclock. In production this means a rolling restart of a 16-node cluster takes 16 minutes of wallclock at minimum and surfaces as alert noise that's purely a transport bug. Prior-art consensus is unanimous: gracefully close active sessions on shutdown, do not wait on idle deadlines. Fix is mechanical (`SetReadDeadline(now)` on every live conn when `stopCh` fires), test is deterministic. Single-PR-size.
+
+### 2. Pool vs scatter mismatch — should-fix
+At 16 shards on one peer with 4 pool slots, scatter serialises 4-at-a-time over TCP. Not a correctness bug; a throughput bug under fan-out. Fix has at least three flavours — adaptive pool growth, per-peer scatter cap, or multiplexing on a single connection — and the right answer probably depends on what we decide for items 5 and 7 (streaming/correlation make multiplexing more attractive). Schedule **after** the frame-v2 decision so we don't reimplement multiplexing on top of v2 streaming.
+
+### 3. Deadline propagation — must-fix
+`router.timeout` only gates the caller. A slow shard keeps burning CPU and (worse, for writes) keeps making mutations after the caller has timed out. This is the single biggest hidden-cost gap on the list. Survey is unanimous: deadline on the wire, server-side honors it. We **must** do this; frame already has room (the `MsgQuery` envelope can carry a `deadline_ns` field without rev'ing the frame major).
+
+### 4. Whole-query retry budget — must-fix
+Per-shard retries × shard count is multiplicative. A 32-shard query with 2 retries each is 96 RPCs for one user query — that's a self-DOS waiting for a bad day. CockroachDB's AC is the gold-standard reference; we can ship a coarser version (`max_attempts_per_query`, `max_retry_wallclock`) without the full AC framework. Co-design with item 3: retries that fire after the propagated deadline must not be attempted.
+
+### 5. Streaming responses — frame-v2 dependent
+Universal in prior art (Bolt `PULL`, gRPC server-streaming, DistSQL flows). Our `MsgResult` is single-shot. Adding streaming **requires** mid-stream framing (chunk + final-chunk markers, or end-of-stream signal). That's a v2 frame whether we want to admit it or not — msgpack tolerance for unknown fields is not enough because the wire-level reader expects one envelope per RPC. **Bundle with item 6**: streaming without cancel is half-built.
+
+### 6. Cancel / partial signalling — frame-v2 dependent
+Same shape. Server needs to recognise an in-band control frame ("client cancelled") or we leak compute on every router timeout. v2 frame is the natural place to add this — once we have streaming, the protocol already has a notion of mid-RPC server state, and adding a `MsgCancel` opcode is a small extension. Pinning this to v2 keeps the v1 frame stable until we commit to the migration.
+
+### 7. Per-RPC correlation ID — should-fix
+This is the **only** v1-additive change in the list. A `request_id` (uint64) field added to `MsgQuery`/`MsgResult`/`MsgError` is backwards-compatible: old peers that don't read the field still work; the field is just unused on legacy ends. Big debugging win for ~50 lines of code. Should not wait for v2.
+
+### 8. mTLS test gap — won't-fix-here (this layer)
+mTLS code paths exist (`SetTLS` on both client and pool). The gap is `:test:`-shaped: no integration test asserts "bad cert is rejected", and no doc covers cert rotation. This is real, but it doesn't change transport design; it's a CI/test work item with the `testing` label. Ship the follow-up as a small test-and-docs PR, don't bundle it with the design-shaped items.
+
+### 9. Admission control / QoS — won't-fix-here (this layer)
+Two priority classes + per-class rate limits is a router/policy concern, not a transport concern. The transport's job is to deliver bytes; the router decides which queries get bytes. CockroachDB is the only system in the survey with a real AC framework, and theirs lives in the SQL layer above the transport. File as a roadmap issue scoped at the router; revisit after items 3 and 4 land (since they shape what the policy layer sees).
+
+### 10. Proactive heartbeat — should-fix
+`MsgPing/MsgPong` already exists in the wire format. A keepalive loop in the pool that sends a `MsgPing` per idle connection every N seconds, and evicts the conn on no `MsgPong` within timeout, is single-file work. Catches half-dead TCP connections (FIN dropped, NAT timeout) that today linger until the next real RPC fails.
+
+## Frame-format decision
+
+**Recommend: v1-additive for #7 now, v2 frame for #5 + #6 together when scheduled.**
+
+The v1 frame is otherwise stable; we shouldn't churn it just because we want better debugging logs. Item #7 fits the additive model perfectly — old peers ignore the field, new peers benefit immediately, no migration story needed.
+
+Items #5 and #6 force a v2 frame because:
+- Streaming changes the reader contract: instead of "one envelope, then ready for next request", the reader has to handle "chunk frames followed by a final marker". You cannot retrofit this onto a single-envelope reader without flag day.
+- Cancel needs a server-side control opcode the v1 frame never reserved opcodes for.
+- A v2 frame buys us room for other things we don't know we need yet (cancel reasons, partial-result indicators, server-side ack-of-cancel).
+
+Migration shape (sketch, lands with the v2 frame issue):
+- Handshake byte advertises supported frame versions. Peers negotiate down to the highest common version.
+- v1 stays in tree until rolling-upgrade is confirmed working in a real deployment; remove it in the release after.
+- The v1 connection path stays the default until v2 is feature-complete + benched.
+
+Track the v2 frame as its own issue (will be filed alongside items 5 + 6 — see below). Cancellation needs the v2 frame, so its issue depends on the frame issue.
+
+## Co-design constraints
+
+- **Item 4 depends on item 3.** Whole-query retry budgets are meaningful only if remote work has actually stopped — otherwise the retry is racing the abandoned attempt's late completion. Both issues should explicitly call out the dependency.
+- **Item 2 depends on the v2 frame outcome.** If we go to streaming, multiplexing on one connection is much more useful than growing the pool. Park #2 until the v2 frame issue lands a decision.
+- **Items 5 and 6 must ship together.** Streaming without cancel leaks compute; cancel without streaming is awkward to express. One v2-frame issue covers both; do not split.
+
+## Open questions / parked
+
+- **Wire-format version negotiation byte:** do we add it now (as a v1 cleanup) or as part of the v2 frame issue? Recommend the latter — adding negotiation to v1 in isolation just adds a no-op handshake.
+- **Mixed-version cluster rolling upgrade:** the v2 frame issue must answer this. Sketch above is one paragraph; the issue gets a section.
+- **Out-of-tree consumers of the wire frame:** nothing currently outside `pkg/transport/` reaches into the frame. If we ever add a non-Go client, that's a much larger conversation that this spike doesn't touch.
+
+## Named follow-ups (filed against this spike)
+
+1. [#83](https://github.com/dreamware-nz/loveliness/issues/83) `fix(transport): unblock TCPServer teardown on stop` — must-fix, S, no wire change.
+2. [#88](https://github.com/dreamware-nz/loveliness/issues/88) `feat(transport): adaptive TCP pool sizing or per-peer scatter cap` — should-fix, M, parked behind v2 frame (#89).
+3. [#84](https://github.com/dreamware-nz/loveliness/issues/84) `feat(transport): deadline propagation to remote shard` — must-fix, M, v1-additive (`deadline_ns` field).
+4. [#85](https://github.com/dreamware-nz/loveliness/issues/85) `feat(router): whole-query retry budget` — must-fix, M, co-designed with #84.
+5. [#89](https://github.com/dreamware-nz/loveliness/issues/89) `spec: v2 wire frame (streaming + cancel)` — frame-v2 design issue, L; bundles items 5 + 6 (streaming + cancel) implementation work.
+6. [#86](https://github.com/dreamware-nz/loveliness/issues/86) `feat(transport): per-RPC correlation ID (v1-additive)` — should-fix, S, no v2 dependency.
+7. [#87](https://github.com/dreamware-nz/loveliness/issues/87) `feat(transport): proactive ping/pong keepalive` — should-fix, S, no wire change.
+8. [#90](https://github.com/dreamware-nz/loveliness/issues/90) `test(transport): mTLS rejection + cert-rotation smoke tests` — testing, S.
+9. [#91](https://github.com/dreamware-nz/loveliness/issues/91) `roadmap(router): admission control / QoS` — won't-fix-in-transport-layer; router-layer roadmap discussion.
+
+## Out of scope (recorded for the record)
+
+- Implementing any of items 1–10 directly in this PR. Each gets its own issue and PR.
+- Replacing the transport with gRPC, HTTP/2, or QUIC. That's the question for [#64](https://github.com/dreamware-nz/loveliness/issues/64) (transport architecture review), not this spike.
+- Frame-format change for #7 alone. Additive only; no negotiation byte, no version bump.
+
+## Re-read in 6 months
+
+This file plus `docs/architecture.md`'s "Cross-node transport gaps" section is the source of truth. When you ship a must-fix, edit the architecture.md table cell to read "done in #N" rather than recreating decision records elsewhere.

--- a/spike/cross-node-transport/SURVEY.md
+++ b/spike/cross-node-transport/SURVEY.md
@@ -1,0 +1,43 @@
+# Cross-node transport — prior-art survey
+
+One-sentence cells per item × system. Docs-only sources (linked at the bottom); no source-reading. Bias is toward what each system **does today** in user-facing docs, not what its design papers aspire to.
+
+## Systems
+
+- **Neo4j Fabric** — Neo4j's federated query layer; uses the Bolt protocol over TCP to talk to remote DBMSes inside one Fabric query plan.
+- **DGraph** — distributed graph DB; scatter-gather to Alpha nodes over gRPC.
+- **MemGraph** — Bolt-protocol graph DB; high-availability via Raft replication and Bolt routing.
+- **CockroachDB** — distributed SQL; KV and DistSQL flows over gRPC with explicit deadline + retry + admission-control machinery.
+
+## 4 × 10 matrix
+
+| # | Gap | Neo4j Fabric | DGraph | MemGraph | CockroachDB |
+|---|---|---|---|---|---|
+| 1 | Teardown unblocks in-flight reads | Bolt server closes active sessions on shutdown via `dbms.shutdown_transaction_end_timeout` rather than waiting on a per-conn read deadline. | gRPC server's `GracefulStop` cancels in-flight RPCs via context, then `Stop` force-closes; no per-conn idle wait. | Documented `--bolt-session-inactivity-timeout` is independent of shutdown path; HA replicas drain before exit. | gRPC `GracefulStop` plus per-server shutdown hooks; `server.shutdown.drain_wait` and `.query_wait` give operators explicit control. |
+| 2 | Pool sizing vs scatter cap | Driver-side: `dbms.connector.bolt.thread_pool_max_size` + per-driver `maxConnectionPoolSize`; users tune both. | HTTP/2 multiplexing through gRPC means a single connection carries many concurrent streams, so pool size is decoupled from fan-out. | Bolt routing connections sized per replica; client-side pool config (`MEMGRAPH_BOLT_NUM_CONNECTIONS`). | Per-node RPC connection class plus HTTP/2 multiplexing; pool size isn't the scatter bound. |
+| 3 | Deadline propagation to remote | Fabric forwards transaction timeout to remote DBMSes via Bolt `tx_timeout` metadata. | gRPC `context.Deadline` propagates through call metadata to Alpha-server handlers. | Bolt `tx_timeout` honored end-to-end on the replica that owns the read. | SQL `statement_timeout` propagates into KV layer via `roachpb.Header.Timestamp` and per-request context deadlines. |
+| 4 | Whole-query retry budget | No explicit budget; driver-level retry helpers (e.g. `Session.executeRead`) are per-tx with attempt count + backoff. | gRPC retry policy is per-call; no documented scatter-level budget. | Bolt driver retries are per-tx; HA routing retries on a different replica without a global cap. | DistSQL caps per-flow retries; admission control + queue-depth budgets the host, not the query, but `kv.transaction.max_refresh_spans_bytes` and friends bound retry amplification. |
+| 5 | Streaming / chunked responses | Bolt is record-streaming by design — `PULL n` pulls in chunks; no buffered "all rows then send". | gRPC server-streaming RPCs are first-class; `Query` returns a stream of result chunks. | Bolt streaming as in Neo4j (same protocol family). | DistSQL flows stream rows between nodes over gRPC streaming RPCs. |
+| 6 | Cancel / partial-result signalling | Bolt `RESET` cancels the current statement on the open connection; `<INTERRUPT>` aborts. | gRPC client `context.Cancel()` propagates to server via `ctx.Done()`; server cleans up its flow. | Bolt `RESET` as in Neo4j. | gRPC cancellation tears down DistSQL flow; `pg_cancel_backend()` for SQL-layer cancel. |
+| 7 | Per-RPC correlation ID | Bolt connection ID + transaction ID written to query logs; correlation across logs is documented. | OpenTelemetry trace + span IDs propagated through gRPC metadata. | Bolt session ID logged on every statement; mirrors Neo4j. | TraceID propagated via gRPC metadata; surfaces in `EXPLAIN ANALYZE (DEBUG)` and statement bundles. |
+| 8 | mTLS exercised / cert rotation | Java SSLContext on both ends; Neo4j Ops Manual documents rolling cert rotation with reload-without-restart. | TLS docs cover client-cert auth; rotation requires Alpha restart per docs (no live-reload). | mTLS supported; cert rotation requires reload per docs. | First-class: `cockroach cert create-node`, online rotation via `SIGHUP` reloads cert dir. |
+| 9 | Admission control / QoS | Procedure-level `dbms.transaction.timeout` + a per-database transaction concurrency limit; no priority classes. | Per-Alpha rate limit (`--limit`) and pending-transaction caps; no explicit priority classes. | No documented admission framework; rely on Bolt session caps. | Explicit AC framework: priority classes (`background`/`normal`/`high`), elastic queues per resource (CPU, IO, KV), tunable via cluster settings. |
+| 10 | Proactive heartbeat / health-check | Bolt `NOOP` chunks used as keepalive; driver `connectionLivenessCheckTimeout` polls idle conns. | HTTP/2 PING frames; gRPC client keepalive (`grpc.keepalive_time_ms`). | Bolt NOOP keepalive; HA layer adds Raft heartbeats. | gRPC keepalive + cluster gossip for node liveness; failed nodes marked draining within a few heartbeats. |
+
+## Sources
+
+- Neo4j: <https://neo4j.com/docs/operations-manual/current/fabric/>, <https://neo4j.com/docs/bolt/current/>
+- DGraph: <https://dgraph.io/docs/deploy/>, <https://dgraph.io/docs/clients/>
+- MemGraph: <https://memgraph.com/docs/clustering/high-availability>, <https://memgraph.com/docs/getting-started/connect-to-memgraph/drivers>
+- CockroachDB: <https://www.cockroachlabs.com/docs/stable/architecture/distribution-layer.html>, <https://www.cockroachlabs.com/docs/stable/admission-control.html>, <https://www.cockroachlabs.com/docs/stable/cockroach-cert.html>
+
+## What the consensus says
+
+- **Streaming is universal.** Every system in the survey streams results by default. We are the outlier on item 5.
+- **Deadline propagation is universal.** Every system carries a deadline on the wire and respects it server-side. We are the outlier on item 3.
+- **Cancel is universal.** Bolt has `RESET`; gRPC has context cancellation. We are the outlier on item 6.
+- **Retry budgets are not universal.** Only CockroachDB documents a budget-shaped story; others retry per-call with no global cap. Our gap on item 4 is real but the prior art is thinner.
+- **Correlation IDs are universal.** Trace IDs (gRPC) or session/tx IDs (Bolt) — every system surfaces them in logs.
+- **mTLS rotation varies.** Neo4j + CockroachDB do live reload; DGraph + MemGraph require restart. Item 8 is "good enough to ship" in the survey set, not "best in class".
+- **Admission control is rare.** Only CockroachDB has a real framework; the others rely on session/connection caps. Item 9 is genuinely a frontier item.
+- **Heartbeats are universal.** Every system has either Bolt NOOP or gRPC keepalive. Our `MsgPing/MsgPong` exists but isn't wired into a loop — easy delta.


### PR DESCRIPTION
## Summary

Closes #76. Spike output, docs-only — no transport code changes here. Lands two artifacts under `spike/cross-node-transport/` plus a new "Cross-node transport gaps" section in `docs/architecture.md`.

- [SURVEY.md](https://github.com/dreamware-nz/loveliness/blob/spike/cross-node-transport-gaps/spike/cross-node-transport/SURVEY.md): docs-only prior-art survey across Neo4j Fabric, DGraph, MemGraph, CockroachDB. 4x10 matrix, one sentence per cell.
- [FINDINGS.md](https://github.com/dreamware-nz/loveliness/blob/spike/cross-node-transport-gaps/spike/cross-node-transport/FINDINGS.md): categorisation, per-item rationale, frame-format decision, co-design constraints, named follow-up issues.
- `docs/architecture.md`: a 10-row categorisation table with links to the filed follow-ups.

## Verdict (from FINDINGS)

Three must-fix-pre-prod, three should-fix-soon, two frame-v2 dependent, two won't-fix-in-transport-layer.

## Frame-format decision

- **v1-additive now** for the per-RPC correlation ID (item 7) — old peers ignore unknown msgpack fields, no migration story.
- **v2 frame** for streaming + cancel (items 5 + 6) shipped together — they need mid-RPC framing and a server-side control opcode that v1 didn't reserve. The v2 frame issue carries the rolling-upgrade negotiation design.
- The v1 frame is otherwise stable; we don't churn it for debugging-only wins.

## Follow-ups filed

| # | Issue | Category |
|---|---|---|
| 1 | #83 fix(transport): unblock TCPServer teardown on stop | must-fix |
| 2 | #88 feat(transport): adaptive TCP pool sizing or per-peer scatter cap | should-fix (parked) |
| 3 | #84 feat(transport): deadline propagation to remote shard | must-fix |
| 4 | #85 feat(router): whole-query retry budget | must-fix |
| 5+6 | #89 spec: v2 wire frame (streaming + cancel) | frame-v2 |
| 7 | #86 feat(transport): per-RPC correlation ID (v1-additive) | should-fix |
| 8 | #90 test(transport): mTLS rejection + cert-rotation smoke tests | testing |
| 9 | #91 roadmap(router): admission control / QoS | won't-fix-in-transport |
| 10 | #87 feat(transport): proactive ping/pong keepalive | should-fix |

## Co-design constraints (recorded in FINDINGS)

- #85 (retry budget) depends on #84 (deadline propagation): a retry that fires after the propagated deadline amplifies wasted work.
- #88 (pool sizing) parks behind #89 (v2 frame): if we go to streaming, multiplexing beats pool growth.
- #89 bundles items 5 + 6: streaming without cancel leaks compute; cancel without streaming is awkward.

## Test plan

- [ ] Reviewer reads SURVEY.md — verifies the four prior-art systems are accurate at a one-sentence level (or files corrections).
- [ ] Reviewer reads FINDINGS.md — challenges the categorisation if any of the must-fix items don't belong as must-fix (or vice versa).
- [ ] Reviewer reads docs/architecture.md "Cross-node transport gaps" section — confirms it's the right shape to live alongside the transport docs.
- [ ] Reviewer skims the 9 follow-up issues — flags any that are mis-scoped or missing.

No code paths exercised by this PR; CI signal is docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
