### PR TITLE
fix(transport): unblock TCPServer teardown on stop (#83)

### DIFF
--- a/pkg/transport/tcp.go
+++ b/pkg/transport/tcp.go
@@ -162,6 +162,18 @@ func (s *TCPServer) handleConn(conn net.Conn) {
 		}
 
 		_ = conn.SetReadDeadline(time.Now().Add(60 * time.Second))
+		// Re-check stopCh AFTER setting the deadline. Without this, a
+		// concurrent Stop() that pokes the deadline to now between the
+		// previous select and this SetReadDeadline would have its poke
+		// overridden by the 60s future we just set, and ReadFrame would
+		// then block for 60s. Closing this race requires either Close()-on-Stop
+		// (loses graceful response semantics) or this re-check.
+		select {
+		case <-s.stopCh:
+			return
+		default:
+		}
+
 		msgType, payload, err := ReadFrame(reader)
 		if err != nil {
 			if ne, ok := err.(net.Error); ok && ne.Timeout() {

--- a/pkg/transport/tcp.go
+++ b/pkg/transport/tcp.go
@@ -24,6 +24,10 @@ type TCPServer struct {
 	tlsConfig *tls.Config
 	wg        sync.WaitGroup
 	stopCh    chan struct{}
+
+	mu      sync.Mutex
+	conns   map[net.Conn]struct{}
+	stopped bool
 }
 
 // NewTCPServer creates a TCP transport server.
@@ -31,6 +35,7 @@ func NewTCPServer(shards ShardQuerier) *TCPServer {
 	return &TCPServer{
 		shards: shards,
 		stopCh: make(chan struct{}),
+		conns:  make(map[net.Conn]struct{}),
 	}
 }
 
@@ -67,13 +72,53 @@ func (s *TCPServer) Addr() net.Addr {
 	return s.listener.Addr()
 }
 
-// Stop shuts down the TCP server gracefully.
+// Stop shuts down the TCP server gracefully. All live connections have their
+// read deadlines pulled to now so in-flight handlers wake immediately rather
+// than waiting up to 60s for the idle-read deadline to fire.
 func (s *TCPServer) Stop() {
+	s.mu.Lock()
+	if s.stopped {
+		s.mu.Unlock()
+		s.wg.Wait()
+		return
+	}
+	s.stopped = true
 	close(s.stopCh)
+	live := make([]net.Conn, 0, len(s.conns))
+	for c := range s.conns {
+		live = append(live, c)
+	}
+	s.mu.Unlock()
+
 	if s.listener != nil {
 		s.listener.Close()
 	}
+	now := time.Now()
+	for _, c := range live {
+		// Ignore errors: conn may already be closed, which is fine.
+		_ = c.SetReadDeadline(now)
+	}
 	s.wg.Wait()
+}
+
+// registerConn adds a connection to the live set. Returns false if the server
+// has already stopped, in which case the caller must close the conn and exit.
+func (s *TCPServer) registerConn(c net.Conn) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.stopped {
+		return false
+	}
+	s.conns[c] = struct{}{}
+	return true
+}
+
+// deregisterConn removes a connection from the live set. Safe to call multiple
+// times.
+func (s *TCPServer) deregisterConn(c net.Conn) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.conns, c)
 }
 
 func (s *TCPServer) acceptLoop() {
@@ -89,6 +134,13 @@ func (s *TCPServer) acceptLoop() {
 				continue
 			}
 		}
+		// Register before spawning the handler so a concurrent Stop() that
+		// races accept either tracks this conn (and pokes it) or sees stopped
+		// and we close immediately.
+		if !s.registerConn(conn) {
+			conn.Close()
+			continue
+		}
 		s.wg.Add(1)
 		go s.handleConn(conn)
 	}
@@ -97,6 +149,7 @@ func (s *TCPServer) acceptLoop() {
 func (s *TCPServer) handleConn(conn net.Conn) {
 	defer s.wg.Done()
 	defer conn.Close()
+	defer s.deregisterConn(conn)
 
 	reader := bufio.NewReaderSize(conn, 64*1024)
 	writer := bufio.NewWriterSize(conn, 64*1024)
@@ -112,7 +165,10 @@ func (s *TCPServer) handleConn(conn net.Conn) {
 		msgType, payload, err := ReadFrame(reader)
 		if err != nil {
 			if ne, ok := err.(net.Error); ok && ne.Timeout() {
-				continue // idle timeout, keep connection alive
+				// Idle timeout — keep the connection alive, unless Stop() has
+				// pulled the deadline to now, in which case the next loop
+				// iteration sees stopCh closed and exits.
+				continue
 			}
 			return // connection closed or broken
 		}

--- a/pkg/transport/tcp_test.go
+++ b/pkg/transport/tcp_test.go
@@ -3,6 +3,7 @@ package transport
 import (
 	"bytes"
 	"fmt"
+	"net"
 	"sync"
 	"testing"
 	"time"
@@ -233,5 +234,116 @@ func TestPingPong(t *testing.T) {
 	}
 	if msgType != MsgPing {
 		t.Errorf("expected MsgPing, got %d", msgType)
+	}
+}
+
+// TestTCPServerStop_FastTeardown_IdleConn covers the #83 fix: an idle client
+// connection must not pin Stop() to the 60s read deadline. Before the fix this
+// test would block ~60s; after the fix it returns within 1s.
+func TestTCPServerStop_FastTeardown_IdleConn(t *testing.T) {
+	srv, addr := setupTCPServer(t)
+
+	// Open a client connection but send nothing, so the server's handleConn
+	// is parked in ReadFrame against the 60s idle deadline.
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	// Give the server a moment to register the conn.
+	time.Sleep(50 * time.Millisecond)
+
+	start := time.Now()
+	done := make(chan struct{})
+	go func() {
+		srv.Stop()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		elapsed := time.Since(start)
+		if elapsed > time.Second {
+			t.Errorf("Stop() took %v, expected < 1s (idle-conn teardown)", elapsed)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Stop() did not return within 5s — teardown is blocked")
+	}
+}
+
+// TestTCPServerStop_FastTeardown_PartialFrame covers the in-flight read case:
+// a client that sent a header but no body parks the server inside ReadFrame
+// reading the payload. Stop() must still wake it within 1s.
+func TestTCPServerStop_FastTeardown_PartialFrame(t *testing.T) {
+	srv, addr := setupTCPServer(t)
+
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	// Send a frame header claiming a 1024-byte payload but never deliver the
+	// body. ReadFrame on the server side will block reading the payload.
+	// Frame format: [length u32 BE][msgType u8][payload...].
+	header := []byte{0x00, 0x00, 0x04, 0x00, byte(MsgQuery)}
+	if _, err := conn.Write(header); err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(50 * time.Millisecond)
+
+	start := time.Now()
+	done := make(chan struct{})
+	go func() {
+		srv.Stop()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		elapsed := time.Since(start)
+		if elapsed > time.Second {
+			t.Errorf("Stop() took %v, expected < 1s (partial-frame teardown)", elapsed)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Stop() did not return within 5s — teardown is blocked on partial read")
+	}
+}
+
+// TestTCPServerStop_Idempotent verifies Stop() can be called multiple times
+// without panicking on close-of-closed-channel or double-deregister.
+func TestTCPServerStop_Idempotent(t *testing.T) {
+	srv, _ := setupTCPServer(t)
+	srv.Stop()
+	srv.Stop() // must not panic
+}
+
+// TestTCPServerStop_AcceptRaceWithStop covers the race where a connection is
+// accepted as Stop() is firing. The conn must either be tracked (and woken)
+// or rejected immediately, never leaked.
+func TestTCPServerStop_AcceptRaceWithStop(t *testing.T) {
+	srv, addr := setupTCPServer(t)
+
+	// Fire a burst of dials concurrent with Stop(). At least some should land
+	// before/during the Stop().
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			c, err := net.Dial("tcp", addr)
+			if err == nil {
+				defer c.Close()
+			}
+		}()
+	}
+
+	start := time.Now()
+	srv.Stop()
+	wg.Wait()
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Errorf("Stop() under accept race took %v, expected < 2s", elapsed)
 	}
 }

--- a/pkg/transport/tcp_test.go
+++ b/pkg/transport/tcp_test.go
@@ -347,3 +347,46 @@ func TestTCPServerStop_AcceptRaceWithStop(t *testing.T) {
 		t.Errorf("Stop() under accept race took %v, expected < 2s", elapsed)
 	}
 }
+
+// TestTCPServerStop_StressTeardownRace stresses the preemption race between
+// the handler's stopCh-check and SetReadDeadline(60s). With GOMAXPROCS > 1
+// the scheduler can in principle preempt between those two lines, allowing
+// Stop()'s SetReadDeadline(now) to be overridden by the handler's 60s deadline.
+// The second stopCh-check after SetReadDeadline closes this race; without it,
+// over enough iterations this test would eventually see a multi-second Stop().
+//
+// We can't deterministically trigger the race, so we iterate. Each iteration
+// must individually complete its Stop() in < 1s.
+func TestTCPServerStop_StressTeardownRace(t *testing.T) {
+	if testing.Short() {
+		t.Skip("stress test skipped in -short mode")
+	}
+	const iterations = 20
+	for i := 0; i < iterations; i++ {
+		srv, addr := setupTCPServer(t)
+
+		// Two idle client conns increase the chance the scheduler is busy
+		// when Stop() fires, raising the odds of catching the race.
+		conns := make([]net.Conn, 4)
+		for j := range conns {
+			c, err := net.Dial("tcp", addr)
+			if err != nil {
+				t.Fatalf("iter %d: dial: %v", i, err)
+			}
+			conns[j] = c
+		}
+		time.Sleep(10 * time.Millisecond)
+
+		start := time.Now()
+		srv.Stop()
+		elapsed := time.Since(start)
+
+		for _, c := range conns {
+			c.Close()
+		}
+
+		if elapsed > time.Second {
+			t.Fatalf("iter %d: Stop() took %v, expected < 1s — race may not be plugged", i, elapsed)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Closes #83 (first of the #76 must-fix triad).

Tracks live connections in `TCPServer` and, on `Stop()`, pulls their read deadlines to now so in-flight handler goroutines wake immediately instead of waiting up to 60s for the idle-read deadline to fire. The #75 cross-node bench observed a 120s teardown pause for this reason; in production a rolling restart of an N-node cluster took ≥ N minutes of pseudo-hang.

### What changed

- `TCPServer` now keeps `conns map[net.Conn]struct{}` guarded by `s.mu`.
- `registerConn` / `deregisterConn` bracket `handleConn`'s lifecycle.
- `Stop()` snapshots the live-conn set under the lock, closes the listener, then `SetReadDeadline(now)` on every tracked conn. The handler's existing `select { case <-s.stopCh: return }` at the top of its loop then runs on the next wakeup.
- `Stop()` is idempotent via a `stopped` flag — no close-of-closed-channel panic.
- `registerConn` returns false if `Stop()` has fired; the acceptLoop closes the late-arriving conn rather than leaking it.

### Tests

Four new tests in `pkg/transport/tcp_test.go`, all run in well under 1s with the fix:

| Test | Asserts |
|---|---|
| `TestTCPServerStop_FastTeardown_IdleConn` | Idle client connected, `Stop()` returns < 1s |
| `TestTCPServerStop_FastTeardown_PartialFrame` | Client sent header, no body, `Stop()` still < 1s |
| `TestTCPServerStop_Idempotent` | `Stop()` callable twice without panic |
| `TestTCPServerStop_AcceptRaceWithStop` | Burst dials racing `Stop()` never leak |

Verified pre-fix: with `tcp.go` reverted, `TestTCPServerStop_FastTeardown_IdleConn` fails after the 5s test timeout (`Stop() did not return within 5s — teardown is blocked`). With the fix it passes in 50ms.

### Wire / API change

None. Server-internal only. No protocol behaviour change.

## Test plan

- [x] `go test ./pkg/transport/ -timeout 30s` — all green, 0.4s
- [x] `go test ./... -timeout 120s` — full project green
- [x] `go vet ./...` — clean
- [x] Pre-fix regression check: confirmed new test fails without `tcp.go` changes

## Related

- Parent spike: #76
- Findings: [`spike/cross-node-transport/FINDINGS.md`](https://github.com/dreamware-nz/loveliness/blob/main/spike/cross-node-transport/FINDINGS.md) item 1
- Surfaced by: #75 cross-node bench

🤖 Generated with [Claude Code](https://claude.com/claude-code)