### PR TITLE
feat(transport): proactive ping/pong keepalive (#87)

### DIFF
--- a/cmd/loveliness/main.go
+++ b/cmd/loveliness/main.go
@@ -362,6 +362,7 @@ func main() {
 	srv.SetAuth(tokenAuth)
 	srv.SetIngestQueue(ingestQueue)
 	srv.SetDatabaseRouter(dbRouter)
+	srv.SetTransportMetricsProvider(transportClientMetricsAdapter{c: transportClient})
 	httpServer := &http.Server{
 		Addr:         cfg.BindAddr,
 		Handler:      srv.Handler(),
@@ -694,3 +695,17 @@ func discoverPrimaryKey(s *shard.Shard, tableName string) string {
 	}
 	return ""
 }
+
+// transportClientMetricsAdapter bridges transport.Client.KeepaliveSnapshot
+// (which returns transport.KeepaliveSnapshot) to the api.KeepaliveSnapshot
+// shape the API package consumes. Kept tiny and inline so pkg/api stays
+// free of any transport-package import (#87).
+type transportClientMetricsAdapter struct {
+	c *transport.Client
+}
+
+func (a transportClientMetricsAdapter) KeepaliveSnapshot() api.KeepaliveSnapshot {
+	s := a.c.KeepaliveSnapshot()
+	return api.KeepaliveSnapshot{OK: s.OK, Miss: s.Miss, Error: s.Error}
+}
+

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -271,7 +271,7 @@ Categorisation, recorded so we don't re-discover the same gaps next time someone
 | 7 | No per-RPC correlation ID | should-fix-soon | in flight [#86](https://github.com/dreamware-nz/loveliness/issues/86) | The only v1-additive change in the list: a `request_id` field that old peers ignore. ~50 lines for a large debugging win. |
 | 8 | mTLS not exercised in tests | won't-fix-in-transport | [#90](https://github.com/dreamware-nz/loveliness/issues/90) | Real gap, but it's a CI/test/docs gap — not a transport design gap. Filed as a `testing`-labelled follow-up. |
 | 9 | No admission control / QoS | won't-fix-in-transport | [#91](https://github.com/dreamware-nz/loveliness/issues/91) | Belongs at the router/policy layer, not the transport. Filed as a roadmap issue for the router. |
-| 10 | Pool eviction is reactive only | should-fix-soon | [#87](https://github.com/dreamware-nz/loveliness/issues/87) | `MsgPing/MsgPong` exists in the wire format but no keepalive loop uses it. Single-file work; catches half-dead connections. |
+| 10 | Pool eviction is reactive only | should-fix-soon | in flight [#87](https://github.com/dreamware-nz/loveliness/issues/87) | `MsgPing/MsgPong` exists in the wire format but no keepalive loop uses it. Single-file work; catches half-dead connections. |
 
 **Frame-format decision:** item 7 ships as a v1-additive field. Items 5 and 6 require a v2 frame and ship together; the v2 frame is its own design issue with rolling-upgrade negotiation as a section. The v1 frame is otherwise stable.
 

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -74,6 +74,34 @@ type Server struct {
 	// against a Cypher Result when the client hits POST /db/{name}/query
 	// with an analytics[] selector. Plugins register at boot.
 	analytics *analytics.Registry
+
+	// transportMetrics is the optional source of cross-node
+	// transport observability — currently the keepalive counters
+	// from pkg/transport.TCPPool (#87). Wired via
+	// SetTransportMetricsProvider so the API package does not have
+	// to import pkg/transport directly.
+	transportMetrics TransportMetricsProvider
+}
+
+// TransportMetricsProvider is the interface the API server uses to
+// surface cross-node transport counters in /metrics. The transport
+// package's Client satisfies it; tests can pass any stub.
+type TransportMetricsProvider interface {
+	KeepaliveSnapshot() KeepaliveSnapshot
+}
+
+// KeepaliveSnapshot mirrors pkg/transport.KeepaliveSnapshot. Kept
+// here to keep pkg/api free of a transport import dependency cycle.
+type KeepaliveSnapshot struct {
+	OK    uint64
+	Miss  uint64
+	Error uint64
+}
+
+// SetTransportMetricsProvider wires the keepalive counter source for
+// /metrics. cmd/loveliness calls this with the transport.Client.
+func (s *Server) SetTransportMetricsProvider(p TransportMetricsProvider) {
+	s.transportMetrics = p
 }
 
 // NewServer creates a new API server.

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -101,6 +101,10 @@ func writeMetrics(w io.Writer, s *Server) {
 		writeRouterMetrics(w, s.router.Metrics().Snapshot())
 	}
 
+	if s.transportMetrics != nil {
+		writeTransportMetrics(w, s.transportMetrics.KeepaliveSnapshot())
+	}
+
 	if s.dr == nil || s.dr.WAL == nil {
 		return
 	}
@@ -178,6 +182,25 @@ func writeRouterMetrics(w io.Writer, snap router.RouterMetricsSnapshot) {
 			fprintf(w, "loveliness_router_retries_total{outcome=%q} %d\n", s.Outcome, s.Count)
 		}
 	}
+}
+
+// writeTransportMetrics emits the keepalive counters owned by the
+// TCP transport pool (#87):
+//
+//	loveliness_transport_keepalive_total{outcome="ok"}     counter
+//	loveliness_transport_keepalive_total{outcome="miss"}   counter
+//	loveliness_transport_keepalive_total{outcome="error"}  counter
+//
+// All three outcomes are always emitted (even at zero) so a scrape
+// at a fresh node still produces the series — the keepalive worker
+// is always running once a transport client exists, and a zero
+// reading is itself informative ("no half-dead conns this scrape").
+func writeTransportMetrics(w io.Writer, snap KeepaliveSnapshot) {
+	emitHelp(w, "loveliness_transport_keepalive_total",
+		"Cumulative proactive ping/pong outcomes on pooled TCP conns. 'ok' = pong received in time, 'miss' = pong timed out (conn evicted), 'error' = transport error during ping (conn evicted).", "counter")
+	fprintf(w, "loveliness_transport_keepalive_total{outcome=\"ok\"} %d\n", snap.OK)
+	fprintf(w, "loveliness_transport_keepalive_total{outcome=\"miss\"} %d\n", snap.Miss)
+	fprintf(w, "loveliness_transport_keepalive_total{outcome=\"error\"} %d\n", snap.Error)
 }
 
 // writeQueryHistogramMetrics emits loveliness_query_duration_seconds in

--- a/pkg/router/retry_test.go
+++ b/pkg/router/retry_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -16,16 +17,34 @@ import (
 // flakyRemote is a RemoteQuerier that fails the first n calls with a
 // supplied error, then succeeds on every subsequent call. Used to
 // exercise the retry loop without needing a real network failure.
+//
+// When failuresPerShard > 0, the shared `failures` counter is
+// ignored and instead each shard ID gets its own independent
+// failure budget of failuresPerShard attempts. This is what the
+// end-to-end test needs to avoid a goroutine-scheduling-dependent
+// distribution of the shared failure pool across shards (see
+// TestRouter_RemoteRetry_EndToEnd — without per-shard tracking,
+// one unlucky shard can absorb all failures and break the test).
 type flakyRemote struct {
-	failures int32 // remaining failures to inject (atomic)
-	err      error
-	calls    int32
-	resp     *shard.QueryResponse
+	failures         int32 // remaining failures to inject (atomic) — shared mode
+	failuresPerShard int32 // when >0, per-shard mode (ignores `failures`)
+	perShardCalls    sync.Map
+	err              error
+	calls            int32
+	resp             *shard.QueryResponse
 }
 
-func (f *flakyRemote) QueryRemoteShard(_ string, _ int, _ string) (*shard.QueryResponse, error) {
+func (f *flakyRemote) QueryRemoteShard(_ string, shardID int, _ string) (*shard.QueryResponse, error) {
 	atomic.AddInt32(&f.calls, 1)
-	if atomic.AddInt32(&f.failures, -1) >= 0 {
+	if f.failuresPerShard > 0 {
+		// Per-shard counter: load-or-init a *int32 for this shardID,
+		// then increment. Fail while the count is <= failuresPerShard.
+		v, _ := f.perShardCalls.LoadOrStore(shardID, new(int32))
+		count := atomic.AddInt32(v.(*int32), 1)
+		if count <= f.failuresPerShard {
+			return nil, f.err
+		}
+	} else if atomic.AddInt32(&f.failures, -1) >= 0 {
 		return nil, f.err
 	}
 	if f.resp == nil {
@@ -161,7 +180,7 @@ func TestRouter_RemoteRetry_EndToEnd(t *testing.T) {
 	const shardCount = 4
 	r := NewRouter(make([]*shard.Shard, shardCount), 2*time.Second)
 
-	fr := &flakyRemote{failures: int32(shardCount), err: io.ErrUnexpectedEOF}
+	fr := &flakyRemote{failuresPerShard: 1, err: io.ErrUnexpectedEOF}
 	r.SetRemoteTransport("local", fr, allRemotePlacement{})
 	r.SetRemoteRetryBackoff(time.Microsecond) // race-free fast retries
 

--- a/pkg/transport/client.go
+++ b/pkg/transport/client.go
@@ -95,6 +95,19 @@ func (c *Client) SetTLS(cfg *tls.Config) {
 	c.tcpPool.SetTLS(cfg)
 }
 
+// SetKeepalive configures the proactive ping/pong cadence on the
+// underlying TCP pool (#87). Pass interval <= 0 to keep the worker
+// dormant; the default interval set in NewTCPPool is 15s.
+func (c *Client) SetKeepalive(interval, pongWait time.Duration) {
+	c.tcpPool.SetKeepalive(interval, pongWait)
+}
+
+// KeepaliveSnapshot returns the closed-set counters that feed the
+// loveliness_transport_keepalive_total{outcome} metric.
+func (c *Client) KeepaliveSnapshot() KeepaliveSnapshot {
+	return c.tcpPool.KeepaliveSnapshot()
+}
+
 // SetPeerTCP registers a peer's TCP transport address for msgpack comms.
 func (c *Client) SetPeerTCP(nodeID, tcpAddr string) {
 	c.tcpPool.SetPeer(nodeID, tcpAddr)

--- a/pkg/transport/keepalive_test.go
+++ b/pkg/transport/keepalive_test.go
@@ -1,0 +1,164 @@
+package transport
+
+import (
+	"net"
+	"testing"
+	"time"
+)
+
+// TestKeepalive_PingsIdleConn proves a freshly-pooled conn with no
+// RPC traffic gets a proactive ping after the keepalive interval and
+// the OK counter ticks up.
+func TestKeepalive_PingsIdleConn(t *testing.T) {
+	srv, addr := setupTCPServer(t)
+	defer srv.Stop()
+
+	pool := NewTCPPool(2, 2*time.Second)
+	defer pool.Close()
+	// Very fast keepalive so the test stays under a second.
+	pool.SetKeepalive(20*time.Millisecond, 200*time.Millisecond)
+	pool.SetPeer("node-tcp", addr)
+
+	// Run one real RPC to seed a conn.
+	if _, err := pool.QueryRemoteTCP("node-tcp", 0, "MATCH (n) RETURN n"); err != nil {
+		t.Fatalf("seed rpc: %v", err)
+	}
+
+	// Wait long enough for at least two keepalive ticks beyond the
+	// interval — the conn is idle the whole time.
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if pool.KeepaliveSnapshot().OK > 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	snap := pool.KeepaliveSnapshot()
+	if snap.OK == 0 {
+		t.Errorf("expected at least one ok keepalive, got %+v", snap)
+	}
+	if snap.Miss > 0 || snap.Error > 0 {
+		t.Errorf("expected no misses or errors on healthy conn, got %+v", snap)
+	}
+}
+
+// silentListener accepts TCP conns but never reads or writes,
+// simulating a half-dead peer (FIN dropped, peer kernel panic, NAT
+// timeout). The keepalive worker should send a MsgPing and time out
+// waiting for the pong, count one "miss", and evict the conn.
+type silentListener struct {
+	ln net.Listener
+}
+
+func newSilentListener(t *testing.T) *silentListener {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	sl := &silentListener{ln: ln}
+	go sl.acceptLoop()
+	return sl
+}
+
+func (s *silentListener) acceptLoop() {
+	for {
+		conn, err := s.ln.Accept()
+		if err != nil {
+			return
+		}
+		// Hold the conn open but never read / never write: any
+		// frame the peer sends sits unread in the kernel buffer
+		// until our SetReadDeadline fires on the client.
+		_ = conn
+	}
+}
+
+func (s *silentListener) Addr() string { return s.ln.Addr().String() }
+func (s *silentListener) Close()       { s.ln.Close() }
+
+// TestKeepalive_EvictsHalfDeadConn proves the worker actually evicts
+// a conn whose pong never comes back, and that the miss counter
+// reflects the outcome.
+func TestKeepalive_EvictsHalfDeadConn(t *testing.T) {
+	sl := newSilentListener(t)
+	defer sl.Close()
+
+	pool := NewTCPPool(2, 2*time.Second)
+	defer pool.Close()
+	pool.SetKeepalive(20*time.Millisecond, 50*time.Millisecond)
+	pool.SetPeer("silent", sl.Addr())
+
+	// Force a conn into the pool — dial directly because the
+	// silent peer never responds to a real RPC either.
+	ce, err := pool.getConn("silent")
+	if err != nil {
+		t.Fatalf("getConn: %v", err)
+	}
+	// Pretend the conn has been idle for ages so the keepalive
+	// worker pings it on the next tick. (touch was called at dial
+	// time; rewind it.)
+	ce.lastActivityNanos.Store(time.Now().Add(-time.Second).UnixNano())
+
+	// Wait until both the miss counter ticks AND the conn drops out
+	// of the pool. pingOne increments the counter just before calling
+	// evict, so polling on the counter alone is racy under -race.
+	deadline := time.Now().Add(1 * time.Second)
+	for time.Now().Before(deadline) {
+		pool.mu.RLock()
+		remaining := len(pool.conns["silent"])
+		pool.mu.RUnlock()
+		if pool.KeepaliveSnapshot().Miss > 0 && remaining == 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	snap := pool.KeepaliveSnapshot()
+	if snap.Miss == 0 {
+		t.Errorf("expected at least one miss keepalive, got %+v", snap)
+	}
+	// Conn should be evicted from the pool.
+	pool.mu.RLock()
+	remaining := len(pool.conns["silent"])
+	pool.mu.RUnlock()
+	if remaining != 0 {
+		t.Errorf("expected conn evicted after miss, %d remain", remaining)
+	}
+}
+
+// TestKeepalive_SkipsBusyConn proves a conn with an in-flight RPC
+// (mu held) is not pinged — its in-flight RPC is its own liveness
+// signal, so layering a ping on top would just serialise behind the
+// RPC and pointlessly delay both.
+func TestKeepalive_SkipsBusyConn(t *testing.T) {
+	srv, addr := setupTCPServer(t)
+	defer srv.Stop()
+
+	pool := NewTCPPool(2, 2*time.Second)
+	defer pool.Close()
+	pool.SetKeepalive(10*time.Millisecond, 50*time.Millisecond)
+	pool.SetPeer("node-tcp", addr)
+
+	// Seed a conn.
+	if _, err := pool.QueryRemoteTCP("node-tcp", 0, "MATCH (n) RETURN n"); err != nil {
+		t.Fatalf("seed rpc: %v", err)
+	}
+
+	// Hold the conn's mutex to simulate an in-flight RPC, and
+	// force it to look idle. The keepalive worker should TryLock,
+	// fail, and skip the conn entirely.
+	pool.mu.RLock()
+	ce := pool.conns["node-tcp"][0]
+	pool.mu.RUnlock()
+	ce.lastActivityNanos.Store(time.Now().Add(-time.Second).UnixNano())
+	ce.mu.Lock()
+	defer ce.mu.Unlock()
+
+	startSnap := pool.KeepaliveSnapshot()
+	time.Sleep(200 * time.Millisecond)
+	endSnap := pool.KeepaliveSnapshot()
+
+	if endSnap.OK > startSnap.OK || endSnap.Miss > startSnap.Miss || endSnap.Error > startSnap.Error {
+		t.Errorf("busy conn was pinged: start=%+v end=%+v", startSnap, endSnap)
+	}
+}

--- a/pkg/transport/pool.go
+++ b/pkg/transport/pool.go
@@ -18,6 +18,31 @@ type connEntry struct {
 	reader *bufio.Reader
 	writer *bufio.Writer
 	mu     sync.Mutex // serializes request/response on this connection
+
+	// lastActivityNanos is the Unix-nanos timestamp of the most
+	// recent successful frame read/write on this conn. Read in the
+	// keepalive worker (#87) to decide whether to send a proactive
+	// MsgPing; written under conn.mu by every RPC path that
+	// touches the wire. Stored as an atomic so the worker can
+	// snapshot without locking the RPC path.
+	lastActivityNanos atomic.Int64
+}
+
+// touch stamps the conn's last-activity timestamp. Called from any
+// path that successfully exchanges bytes with the peer.
+func (c *connEntry) touch() {
+	c.lastActivityNanos.Store(time.Now().UnixNano())
+}
+
+// idleSince reports how long the conn has been idle. Negative means
+// "active right now"; callers should treat zero / negative as
+// "not idle long enough to ping".
+func (c *connEntry) idleSince(now time.Time) time.Duration {
+	last := c.lastActivityNanos.Load()
+	if last == 0 {
+		return 0
+	}
+	return now.Sub(time.Unix(0, last))
 }
 
 // TCPPool manages persistent TCP connections to peer nodes.
@@ -36,19 +61,86 @@ type TCPPool struct {
 	// pair is implicitly unique because each peer has its own pool).
 	// Atomic 64-bit counter wraps at 2^64; effectively infinite.
 	requestSeq atomic.Uint64
+
+	// Keepalive (#87): proactively ping idle conns so half-dead TCP
+	// connections (FIN dropped, NAT timeout, peer kernel panic) are
+	// evicted before a real RPC lands on them. Wire format already
+	// has MsgPing/MsgPong; this just sequences them.
+	//
+	// The two duration fields are atomic.Int64 (nanoseconds) so the
+	// keepalive worker can read them on every tick without locking
+	// while SetKeepalive can swap them from any goroutine. A plain
+	// time.Duration field would race under -race.
+	keepaliveIntervalNs atomic.Int64
+	keepalivePongWaitNs atomic.Int64
+	keepaliveStop       chan struct{}
+	keepaliveDone       chan struct{}
+	keepaliveCounts     keepaliveCounters
+}
+
+// keepaliveCounters tracks the closed set of per-ping outcomes used
+// for the loveliness_transport_keepalive_total{outcome} metric:
+//
+//	ok    — peer replied with MsgPong before keepalivePongWait.
+//	miss  — pong did not arrive in time; conn was evicted.
+//	error — write or read failed at the network layer.
+//
+// All three are atomic so the worker can update them without taking
+// any pool lock. Snapshot returns a stable copy.
+type keepaliveCounters struct {
+	ok    atomic.Uint64
+	miss  atomic.Uint64
+	error atomic.Uint64
+}
+
+// KeepaliveSnapshot is the deterministic view consumed by the
+// metrics writer in pkg/api.
+type KeepaliveSnapshot struct {
+	OK    uint64
+	Miss  uint64
+	Error uint64
+}
+
+// KeepaliveSnapshot returns the current keepalive outcome counts.
+func (p *TCPPool) KeepaliveSnapshot() KeepaliveSnapshot {
+	return KeepaliveSnapshot{
+		OK:    p.keepaliveCounts.ok.Load(),
+		Miss:  p.keepaliveCounts.miss.Load(),
+		Error: p.keepaliveCounts.error.Load(),
+	}
 }
 
 // NewTCPPool creates a connection pool.
+//
+// Keepalive (#87) is enabled by default at a 15s interval with a 5s
+// pong timeout — modest enough that healthy LAN RTT is well under
+// the bound, aggressive enough that a half-dead conn is evicted
+// within ~20s of going bad. SetKeepalive overrides.
 func NewTCPPool(poolSize int, timeout time.Duration) *TCPPool {
 	if poolSize < 1 {
 		poolSize = 4
 	}
-	return &TCPPool{
-		peers:    make(map[string]string),
-		conns:    make(map[string][]*connEntry),
-		poolSize: poolSize,
-		timeout:  timeout,
+	p := &TCPPool{
+		peers:         make(map[string]string),
+		conns:         make(map[string][]*connEntry),
+		poolSize:      poolSize,
+		timeout:       timeout,
+		keepaliveStop: make(chan struct{}),
+		keepaliveDone: make(chan struct{}),
 	}
+	p.keepaliveIntervalNs.Store(int64(15 * time.Second))
+	p.keepalivePongWaitNs.Store(int64(5 * time.Second))
+	go p.keepaliveLoop()
+	return p
+}
+
+// SetKeepalive tunes the proactive ping cadence and pong timeout.
+// interval <= 0 disables keepalive (the worker keeps running but
+// performs no pings until interval is set non-zero again). Stored
+// atomically so it can be called from any goroutine.
+func (p *TCPPool) SetKeepalive(interval, pongWait time.Duration) {
+	p.keepaliveIntervalNs.Store(int64(interval))
+	p.keepalivePongWaitNs.Store(int64(pongWait))
 }
 
 // SetTLS configures mTLS for outbound connections.
@@ -157,6 +249,7 @@ func (p *TCPPool) QueryRemoteTCPCtx(ctx context.Context, nodeID string, shardID 
 		"node", nodeID, "shard", shardID, "request_id", req.RequestID,
 		"echoed_id", resp.RequestID, "rows", len(resp.Rows))
 
+	ce.touch()
 	return &resp, nil
 }
 
@@ -218,11 +311,14 @@ func (p *TCPPool) dial(addr string) (*connEntry, error) {
 		tc.SetKeepAlive(true)
 		tc.SetKeepAlivePeriod(30 * time.Second)
 	}
-	return &connEntry{
+	ce := &connEntry{
 		conn:   conn,
 		reader: bufio.NewReaderSize(conn, 64*1024),
 		writer: bufio.NewWriterSize(conn, 64*1024),
-	}, nil
+	}
+	ce.touch() // a fresh conn is "active now" so it's not pinged
+	// instantly on the next keepalive tick.
+	return ce, nil
 }
 
 func (p *TCPPool) evict(nodeID string, bad *connEntry) {
@@ -240,6 +336,18 @@ func (p *TCPPool) evict(nodeID string, bad *connEntry) {
 
 // Close shuts down all pooled connections.
 func (p *TCPPool) Close() {
+	// Signal the keepalive worker to stop and wait for it before
+	// closing conns — otherwise the worker can be mid-ping when
+	// connections disappear underneath it.
+	if p.keepaliveStop != nil {
+		// Guard against double-close from repeated Close() calls.
+		select {
+		case <-p.keepaliveStop:
+		default:
+			close(p.keepaliveStop)
+		}
+		<-p.keepaliveDone
+	}
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	for nodeID, conns := range p.conns {
@@ -248,4 +356,127 @@ func (p *TCPPool) Close() {
 		}
 		delete(p.conns, nodeID)
 	}
+}
+
+// keepaliveLoop is the per-pool worker that proactively pings idle
+// connections (#87). Runs until Close signals via keepaliveStop. The
+// goal is to catch half-dead TCP connections (peer kernel panic, FIN
+// dropped, NAT/firewall timeout) before a user RPC lands on one.
+//
+// Per-tick behaviour: for every connection idle longer than
+// keepaliveInterval, attempt to take its mu (skip if busy — an
+// in-flight RPC is its own liveness signal), send a MsgPing, and
+// read a MsgPong within keepalivePongWait. Miss or transport error
+// → evict via the existing eviction path so the next RPC dials a
+// fresh conn.
+func (p *TCPPool) keepaliveLoop() {
+	defer close(p.keepaliveDone)
+	// Re-read the interval every iteration via the atomic so a
+	// SetKeepalive update takes effect on the very next tick rather
+	// than waiting for an initial ticker period to elapse. Replaces
+	// time.NewTicker for the same reason; time.After per iteration
+	// is fine at the 1Hz-to-1mHz cadences keepalive runs at.
+	//
+	// When interval <= 0 (keepalive disabled) the worker still loops
+	// on a 1s wakeup so it remains responsive to keepaliveStop and
+	// can pick up a later SetKeepalive without restarting.
+	for {
+		interval := time.Duration(p.keepaliveIntervalNs.Load())
+		if interval <= 0 {
+			select {
+			case <-p.keepaliveStop:
+				return
+			case <-time.After(time.Second):
+			}
+			continue
+		}
+		select {
+		case <-p.keepaliveStop:
+			return
+		case <-time.After(interval):
+			p.tickKeepalive(time.Now())
+		}
+	}
+}
+
+// tickKeepalive walks every pooled connection and pings the idle
+// ones. Extracted from keepaliveLoop so tests can drive a single
+// tick deterministically without relying on real wallclock.
+func (p *TCPPool) tickKeepalive(now time.Time) {
+	// Snapshot the conn map under the read lock so the ping work
+	// happens outside the pool lock; eviction reacquires the lock
+	// inside p.evict.
+	type pair struct {
+		nodeID string
+		ce     *connEntry
+	}
+	interval := time.Duration(p.keepaliveIntervalNs.Load())
+	if interval <= 0 {
+		return
+	}
+	var idle []pair
+	p.mu.RLock()
+	for nodeID, conns := range p.conns {
+		for _, ce := range conns {
+			if ce.idleSince(now) >= interval {
+				idle = append(idle, pair{nodeID, ce})
+			}
+		}
+	}
+	p.mu.RUnlock()
+
+	for _, pr := range idle {
+		p.pingOne(pr.nodeID, pr.ce)
+	}
+}
+
+// pingOne sends a MsgPing on ce and waits for MsgPong. Skips the
+// conn if it's busy (TryLock fails) — an in-flight RPC is its own
+// liveness signal, so pinging on top of it would serialise behind
+// the RPC and pointlessly delay both. On failure the conn is
+// evicted via the same path used by RPC-side failures.
+func (p *TCPPool) pingOne(nodeID string, ce *connEntry) {
+	if !ce.mu.TryLock() {
+		return // busy — not idle in any practical sense
+	}
+	defer ce.mu.Unlock()
+
+	deadline := time.Now().Add(time.Duration(p.keepalivePongWaitNs.Load()))
+	_ = ce.conn.SetWriteDeadline(deadline)
+	if err := WriteFrame(ce.writer, MsgPing, nil); err != nil {
+		p.keepaliveCounts.error.Add(1)
+		slog.Debug("keepalive write failed", "node", nodeID, "err", err)
+		p.evict(nodeID, ce)
+		return
+	}
+	if err := ce.writer.Flush(); err != nil {
+		p.keepaliveCounts.error.Add(1)
+		slog.Debug("keepalive flush failed", "node", nodeID, "err", err)
+		p.evict(nodeID, ce)
+		return
+	}
+	_ = ce.conn.SetReadDeadline(deadline)
+	msgType, _, err := ReadFrame(ce.reader)
+	if err != nil {
+		// Timeout on the pong is the canonical "half-dead conn"
+		// signal — count separately from raw transport errors so
+		// operators can tell apart "peer is gone" from "peer is
+		// slow to respond". net.Error.Timeout() differentiates.
+		if ne, ok := err.(net.Error); ok && ne.Timeout() {
+			p.keepaliveCounts.miss.Add(1)
+		} else {
+			p.keepaliveCounts.error.Add(1)
+		}
+		slog.Debug("keepalive read failed", "node", nodeID, "err", err)
+		p.evict(nodeID, ce)
+		return
+	}
+	if msgType != MsgPong {
+		p.keepaliveCounts.error.Add(1)
+		slog.Debug("keepalive unexpected msg type", "node", nodeID, "type", msgType)
+		p.evict(nodeID, ce)
+		return
+	}
+	p.keepaliveCounts.ok.Add(1)
+	ce.touch()
 }


### PR DESCRIPTION
## Summary

- Per-pool keepalive worker pings idle TCP conns at 15s/5s defaults; busy conns skipped (RPC is liveness).
- Failed ping evicts via existing path; `loveliness_transport_keepalive_total{outcome}` metric on /metrics with `{ok, miss, error}`.
- Small `TransportMetricsProvider` hook on `pkg/api.Server` keeps the API package free of a transport import.
- Stacked on #96 → #95 → #94.

Closes #87.

## Test plan

- [x] `go test ./pkg/transport/... -run Keepalive -v` (3 tests: idle ping, half-dead eviction, busy skip)
- [x] `go test ./...`
- [x] `go vet ./...`


💘 Generated with Crush