### PR TITLE
fix(transport,router): self-review cleanups for #76 follow-ups

### DIFF
--- a/pkg/router/retry_budget.go
+++ b/pkg/router/retry_budget.go
@@ -202,7 +202,13 @@ func classifyRetryOutcome(errs []ShardError, attempts, shardCount int64) string 
 		if strings.Contains(e.Error, "retry budget exhausted") {
 			return RetryOutcomeBudgetExhausted
 		}
+		// Accept both the British spelling the router writes for its
+		// synthetic scatter-side timeout *and* the American spelling
+		// Go's stdlib ctx.Err() emits — the latter is what surfaces
+		// when a per-shard retryRemoteCall returns ctx.Err() directly
+		// rather than the router's outer-select message.
 		if strings.Contains(e.Error, "context cancelled") ||
+			strings.Contains(e.Error, "context canceled") ||
 			strings.Contains(e.Error, "context deadline exceeded") ||
 			strings.Contains(e.Error, "scatter-gather timed out") {
 			return RetryOutcomeDeadlineExceeded

--- a/pkg/router/retry_budget_test.go
+++ b/pkg/router/retry_budget_test.go
@@ -218,3 +218,38 @@ func TestRouter_ScatterRetryBudget_DeadlineBeatsBudget(t *testing.T) {
 type allToOnePlacement struct{ node string }
 
 func (p *allToOnePlacement) PrimaryForShard(_ int) string { return p.node }
+
+// TestClassifyRetryOutcome_AcceptsStdlibContextSpelling guards against
+// the British/American spelling mismatch between scatter-loop's
+// synthetic "context cancelled" message and Go's stdlib
+// context.Canceled.Error() "context canceled". A per-shard retry that
+// returns ctx.Err() bubbles up with the stdlib spelling; the
+// classifier must recognise it as a deadline outcome.
+func TestClassifyRetryOutcome_AcceptsStdlibContextSpelling(t *testing.T) {
+	cases := []struct {
+		name string
+		errs []ShardError
+		want string
+	}{
+		{"stdlib canceled", []ShardError{{Error: "context canceled"}}, RetryOutcomeDeadlineExceeded},
+		{"stdlib deadline", []ShardError{{Error: "context deadline exceeded"}}, RetryOutcomeDeadlineExceeded},
+		{"router cancelled (British)", []ShardError{{Error: "context cancelled"}}, RetryOutcomeDeadlineExceeded},
+		{"scatter timeout", []ShardError{{Error: "scatter-gather timed out"}}, RetryOutcomeDeadlineExceeded},
+		{"budget exhausted", []ShardError{{Error: "retry budget exhausted after 3 attempts"}}, RetryOutcomeBudgetExhausted},
+		{"no retry needed", nil, ""},
+		{"success after retry", nil, RetryOutcomeSuccessAfterRetry},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			attempts := int64(0)
+			shardCount := int64(4)
+			if tc.want == RetryOutcomeSuccessAfterRetry {
+				attempts = shardCount + 1
+			}
+			got := classifyRetryOutcome(tc.errs, attempts, shardCount)
+			if got != tc.want {
+				t.Errorf("classifyRetryOutcome = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/transport/mtls_test.go
+++ b/pkg/transport/mtls_test.go
@@ -110,7 +110,7 @@ func writeMTLSPEM(t *testing.T, path, blockType string, data []byte) {
 // difference is the certs are generated in-process per test.
 func TestMTLS_HappyPath(t *testing.T) {
 	dir := t.TempDir()
-	caCertPath, caKeyPath, caCert, caKey := generateCA(t, dir, "cluster-ca")
+	caCertPath, _, caCert, caKey := generateCA(t, dir, "cluster-ca")
 	srvCertPath, srvKeyPath := generateLeaf(t, dir, "server", caCert, caKey)
 	cliCertPath, cliKeyPath := generateLeaf(t, dir, "client", caCert, caKey)
 
@@ -146,7 +146,6 @@ func TestMTLS_HappyPath(t *testing.T) {
 	pool.SetTLS(cliTLS)
 	pool.SetPeer("server", srv.Addr().String())
 
-	_ = caKeyPath // referenced only via the CA above
 	resp, err := pool.QueryRemoteTCP("server", 0, "MATCH (n) RETURN n")
 	if err != nil {
 		t.Fatalf("mTLS happy-path RPC failed: %v", err)

--- a/pkg/transport/pool.go
+++ b/pkg/transport/pool.go
@@ -218,11 +218,11 @@ func (p *TCPPool) QueryRemoteTCPCtx(ctx context.Context, nodeID string, shardID 
 	ce.conn.SetWriteDeadline(wireDeadline)
 	if err := WriteFrame(ce.writer, MsgQuery, req); err != nil {
 		p.evict(nodeID, ce)
-		return nil, fmt.Errorf("write to %s: %w", nodeID, err)
+		return nil, fmt.Errorf("write to %s [request_id=%d]: %w", nodeID, req.RequestID, err)
 	}
 	if err := ce.writer.Flush(); err != nil {
 		p.evict(nodeID, ce)
-		return nil, fmt.Errorf("flush to %s: %w", nodeID, err)
+		return nil, fmt.Errorf("flush to %s [request_id=%d]: %w", nodeID, req.RequestID, err)
 	}
 
 	// Read response.
@@ -230,12 +230,12 @@ func (p *TCPPool) QueryRemoteTCPCtx(ctx context.Context, nodeID string, shardID 
 	msgType, payload, err := ReadFrame(ce.reader)
 	if err != nil {
 		p.evict(nodeID, ce)
-		return nil, fmt.Errorf("read from %s: %w", nodeID, err)
+		return nil, fmt.Errorf("read from %s [request_id=%d]: %w", nodeID, req.RequestID, err)
 	}
 
 	var resp QueryResponse
 	if err := Decode(payload, &resp); err != nil {
-		return nil, fmt.Errorf("decode from %s: %w", nodeID, err)
+		return nil, fmt.Errorf("decode from %s [request_id=%d]: %w", nodeID, req.RequestID, err)
 	}
 
 	if msgType == MsgError || resp.Error != "" {


### PR DESCRIPTION
## Summary

Three small bugs caught in post-merge self-review of the #94–#98 stack:

1. **`pool.go`** — transport-layer errors (write/flush/read/decode) now stamp the per-RPC `request_id` (#86). Only the shard-error path had it before, which was the opposite of where operators most need it.
2. **`retry_budget.go`** — `classifyRetryOutcome` now accepts both British \"context cancelled\" (router's synthetic) and American \"context canceled\" (stdlib `ctx.Err()`). Without this, a per-shard ctx cancel skipped the `deadline_exceeded` metric. New table-driven test `TestClassifyRetryOutcome_AcceptsStdlibContextSpelling` guards.
3. **`mtls_test.go`** — replace `_ = caKeyPath` with `_` at call site.

## Test plan

- [x] `go test -race ./...`
- [x] `go test ./pkg/router/ -run ClassifyRetryOutcome -v` (7 sub-cases)
- [x] `golangci-lint run ./...`


💘 Generated with Crush