### PR TITLE
fix(config): honor empty LOVELINESS_BOLT_ADDR as "disable bolt"

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -196,7 +196,13 @@ func FromEnv() Config {
 	if v := os.Getenv("LOVELINESS_BACKUP_DIR"); v != "" {
 		c.BackupDir = v
 	}
-	if v := os.Getenv("LOVELINESS_BOLT_ADDR"); v != "" {
+	// Bolt address has bespoke handling: an explicit empty value
+	// (LOVELINESS_BOLT_ADDR=) is the documented way to *disable* the
+	// Bolt listener — useful in tests that don't want to fight the
+	// fixed :7687 port. The other env vars treat unset and empty
+	// the same way, but Bolt's default of ":7687" makes that
+	// behaviour user-hostile here.
+	if v, ok := os.LookupEnv("LOVELINESS_BOLT_ADDR"); ok {
 		c.BoltAddr = v
 	}
 	if v := os.Getenv("LOVELINESS_AUTH_TOKEN"); v != "" {


### PR DESCRIPTION
## Summary

Both `test/restore` and `test/mcp` integration tests set `LOVELINESS_BOLT_ADDR=` (empty) to disable the Bolt listener. The previous `os.Getenv`-with-empty-skip pattern silently ignored the empty value, leaving the default `:7687` in place. On any host with another bolt listener on 7687 the tests fail with \"bind: address already in use\".

Switch to `os.LookupEnv` so explicit empty disables Bolt; unset still falls through to the `:7687` default.

Surfaced during e2e verification of the #76 follow-up cluster.

## Test plan

- [x] Integration suite (`go test -tags=integration ./test/...`) passes with another bolt listener bound to 7687.
- [x] Default still `:7687` when env var unset.


💘 Generated with Crush